### PR TITLE
fix: setTerminalCondition setting Synced condition

### DIFF
--- a/pkg/resource/db_instance/conditions.go
+++ b/pkg/resource/db_instance/conditions.go
@@ -87,7 +87,7 @@ func setTerminalCondition(
 	message *string,
 	reason *string,
 ) {
-	c := getSyncedCondition(r)
+	c := getTerminalCondition(r)
 	if c == nil {
 		c = &ackv1alpha1.Condition{
 			Type: ackv1alpha1.ConditionTypeTerminal,


### PR DESCRIPTION
Fixes the custom setTerminalCondition() function in
pkg/resource/db_instance/conditions.go to fetch the terminal condition
and not the resource synced condition.

Issue aws-controllers-k8s/community#827

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
