### PR TITLE
update to ACK runtime 0.6.0

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,9 +1,9 @@
 ack_generate_info:
-  build_date: "2021-07-05T16:07:02Z"
-  build_hash: 6017295ba34a54966646eac360c7d808ed4b6bf1
+  build_date: "2021-07-19T15:18:11Z"
+  build_hash: c77aa9c75d944952dee198029ba9822691cd82b0
   go_version: go1.15.5 linux/amd64
-  version: v0.4.0
-api_directory_checksum: 2159e3b5ae30722e85747b7b3c146a4e5daefb78
+  version: v0.6.0
+api_directory_checksum: c2500a34cb9377122cf5382a6456812006d8261b
 api_version: v1alpha1
 aws_sdk_go_version: ""
 generator_config_info:
@@ -11,4 +11,4 @@ generator_config_info:
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-07-05 16:07:08.348205607 +0000 UTC
+  timestamp: 2021-07-19 15:18:16.161125161 +0000 UTC

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/rds-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.4.0
+	github.com/aws-controllers-k8s/runtime v0.6.0
 	github.com/aws/aws-sdk-go v1.37.4
 	github.com/go-logr/logr v0.1.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws-controllers-k8s/runtime v0.4.0 h1:qsCp1OKXoSMtjS+6zlH65PN3/UkVJNbI/ybwYjPmhrY=
 github.com/aws-controllers-k8s/runtime v0.4.0/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
+github.com/aws-controllers-k8s/runtime v0.6.0 h1:Up9pn9FfItYiItiSdT+FOfHQNKO8oSb5GU8pKH9JF8E=
+github.com/aws-controllers-k8s/runtime v0.6.0/go.mod h1:xA2F18PJerBHaqrS4de1lpP7skeSMeStkmh+3x5sWvw=
 github.com/aws/aws-sdk-go v1.37.4 h1:tWxrpMK/oRSXVnjUzhGeCWLR00fW0WF4V4sycYPPrJ8=
 github.com/aws/aws-sdk-go v1.37.4/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/resource/db_cluster/manager.go
+++ b/pkg/resource/db_cluster/manager.go
@@ -142,11 +142,12 @@ func (rm *resourceManager) Update(
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
-// service API.
+// service API, returning an AWSResource representing the
+// resource being deleted (if delete is asynchronous and takes time)
 func (rm *resourceManager) Delete(
 	ctx context.Context,
 	res acktypes.AWSResource,
-) error {
+) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.

--- a/pkg/resource/db_cluster/sdk.go
+++ b/pkg/resource/db_cluster/sdk.go
@@ -1566,21 +1566,23 @@ func (rm *resourceManager) newUpdateRequestPayload(
 func (rm *resourceManager) sdkDelete(
 	ctx context.Context,
 	r *resource,
-) (err error) {
+) (latest *resource, err error) {
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("rm.sdkDelete")
 	defer exit(err)
 	if clusterDeleting(r) {
-		return requeueWaitWhileDeleting
+		return r, requeueWaitWhileDeleting
 	}
 
 	input, err := rm.newDeleteRequestPayload(r)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = rm.sdkapi.DeleteDBClusterWithContext(ctx, input)
+	var resp *svcsdk.DeleteDBClusterOutput
+	_ = resp
+	resp, err = rm.sdkapi.DeleteDBClusterWithContext(ctx, input)
 	rm.metrics.RecordAPICall("DELETE", "DeleteDBCluster", err)
-	return err
+	return nil, err
 }
 
 // newDeleteRequestPayload returns an SDK-specific struct for the HTTP request

--- a/pkg/resource/db_cluster_parameter_group/manager.go
+++ b/pkg/resource/db_cluster_parameter_group/manager.go
@@ -142,11 +142,12 @@ func (rm *resourceManager) Update(
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
-// service API.
+// service API, returning an AWSResource representing the
+// resource being deleted (if delete is asynchronous and takes time)
 func (rm *resourceManager) Delete(
 	ctx context.Context,
 	res acktypes.AWSResource,
-) error {
+) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.

--- a/pkg/resource/db_cluster_parameter_group/sdk.go
+++ b/pkg/resource/db_cluster_parameter_group/sdk.go
@@ -279,17 +279,19 @@ func (rm *resourceManager) newUpdateRequestPayload(
 func (rm *resourceManager) sdkDelete(
 	ctx context.Context,
 	r *resource,
-) (err error) {
+) (latest *resource, err error) {
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("rm.sdkDelete")
 	defer exit(err)
 	input, err := rm.newDeleteRequestPayload(r)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = rm.sdkapi.DeleteDBClusterParameterGroupWithContext(ctx, input)
+	var resp *svcsdk.DeleteDBClusterParameterGroupOutput
+	_ = resp
+	resp, err = rm.sdkapi.DeleteDBClusterParameterGroupWithContext(ctx, input)
 	rm.metrics.RecordAPICall("DELETE", "DeleteDBClusterParameterGroup", err)
-	return err
+	return nil, err
 }
 
 // newDeleteRequestPayload returns an SDK-specific struct for the HTTP request

--- a/pkg/resource/db_instance/manager.go
+++ b/pkg/resource/db_instance/manager.go
@@ -142,11 +142,12 @@ func (rm *resourceManager) Update(
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
-// service API.
+// service API, returning an AWSResource representing the
+// resource being deleted (if delete is asynchronous and takes time)
 func (rm *resourceManager) Delete(
 	ctx context.Context,
 	res acktypes.AWSResource,
-) error {
+) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.

--- a/pkg/resource/db_instance/sdk.go
+++ b/pkg/resource/db_instance/sdk.go
@@ -1924,21 +1924,23 @@ func (rm *resourceManager) newUpdateRequestPayload(
 func (rm *resourceManager) sdkDelete(
 	ctx context.Context,
 	r *resource,
-) (err error) {
+) (latest *resource, err error) {
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("rm.sdkDelete")
 	defer exit(err)
 	if instanceDeleting(r) {
-		return requeueWaitWhileDeleting
+		return r, requeueWaitWhileDeleting
 	}
 
 	input, err := rm.newDeleteRequestPayload(r)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = rm.sdkapi.DeleteDBInstanceWithContext(ctx, input)
+	var resp *svcsdk.DeleteDBInstanceOutput
+	_ = resp
+	resp, err = rm.sdkapi.DeleteDBInstanceWithContext(ctx, input)
 	rm.metrics.RecordAPICall("DELETE", "DeleteDBInstance", err)
-	return err
+	return nil, err
 }
 
 // newDeleteRequestPayload returns an SDK-specific struct for the HTTP request

--- a/pkg/resource/db_parameter_group/manager.go
+++ b/pkg/resource/db_parameter_group/manager.go
@@ -142,11 +142,12 @@ func (rm *resourceManager) Update(
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
-// service API.
+// service API, returning an AWSResource representing the
+// resource being deleted (if delete is asynchronous and takes time)
 func (rm *resourceManager) Delete(
 	ctx context.Context,
 	res acktypes.AWSResource,
-) error {
+) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.

--- a/pkg/resource/db_parameter_group/sdk.go
+++ b/pkg/resource/db_parameter_group/sdk.go
@@ -279,17 +279,19 @@ func (rm *resourceManager) newUpdateRequestPayload(
 func (rm *resourceManager) sdkDelete(
 	ctx context.Context,
 	r *resource,
-) (err error) {
+) (latest *resource, err error) {
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("rm.sdkDelete")
 	defer exit(err)
 	input, err := rm.newDeleteRequestPayload(r)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = rm.sdkapi.DeleteDBParameterGroupWithContext(ctx, input)
+	var resp *svcsdk.DeleteDBParameterGroupOutput
+	_ = resp
+	resp, err = rm.sdkapi.DeleteDBParameterGroupWithContext(ctx, input)
 	rm.metrics.RecordAPICall("DELETE", "DeleteDBParameterGroup", err)
-	return err
+	return nil, err
 }
 
 // newDeleteRequestPayload returns an SDK-specific struct for the HTTP request

--- a/pkg/resource/db_security_group/manager.go
+++ b/pkg/resource/db_security_group/manager.go
@@ -142,11 +142,12 @@ func (rm *resourceManager) Update(
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
-// service API.
+// service API, returning an AWSResource representing the
+// resource being deleted (if delete is asynchronous and takes time)
 func (rm *resourceManager) Delete(
 	ctx context.Context,
 	res acktypes.AWSResource,
-) error {
+) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.

--- a/pkg/resource/db_security_group/sdk.go
+++ b/pkg/resource/db_security_group/sdk.go
@@ -289,17 +289,19 @@ func (rm *resourceManager) sdkUpdate(
 func (rm *resourceManager) sdkDelete(
 	ctx context.Context,
 	r *resource,
-) (err error) {
+) (latest *resource, err error) {
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("rm.sdkDelete")
 	defer exit(err)
 	input, err := rm.newDeleteRequestPayload(r)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = rm.sdkapi.DeleteDBSecurityGroupWithContext(ctx, input)
+	var resp *svcsdk.DeleteDBSecurityGroupOutput
+	_ = resp
+	resp, err = rm.sdkapi.DeleteDBSecurityGroupWithContext(ctx, input)
 	rm.metrics.RecordAPICall("DELETE", "DeleteDBSecurityGroup", err)
-	return err
+	return nil, err
 }
 
 // newDeleteRequestPayload returns an SDK-specific struct for the HTTP request

--- a/pkg/resource/db_subnet_group/manager.go
+++ b/pkg/resource/db_subnet_group/manager.go
@@ -142,11 +142,12 @@ func (rm *resourceManager) Update(
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
-// service API.
+// service API, returning an AWSResource representing the
+// resource being deleted (if delete is asynchronous and takes time)
 func (rm *resourceManager) Delete(
 	ctx context.Context,
 	res acktypes.AWSResource,
-) error {
+) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.

--- a/pkg/resource/db_subnet_group/sdk.go
+++ b/pkg/resource/db_subnet_group/sdk.go
@@ -370,17 +370,19 @@ func (rm *resourceManager) newUpdateRequestPayload(
 func (rm *resourceManager) sdkDelete(
 	ctx context.Context,
 	r *resource,
-) (err error) {
+) (latest *resource, err error) {
 	rlog := ackrtlog.FromContext(ctx)
 	exit := rlog.Trace("rm.sdkDelete")
 	defer exit(err)
 	input, err := rm.newDeleteRequestPayload(r)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, err = rm.sdkapi.DeleteDBSubnetGroupWithContext(ctx, input)
+	var resp *svcsdk.DeleteDBSubnetGroupOutput
+	_ = resp
+	resp, err = rm.sdkapi.DeleteDBSubnetGroupWithContext(ctx, input)
 	rm.metrics.RecordAPICall("DELETE", "DeleteDBSubnetGroup", err)
-	return err
+	return nil, err
 }
 
 // newDeleteRequestPayload returns an SDK-specific struct for the HTTP request

--- a/templates/hooks/db_cluster/sdk_delete_pre_build_request.go.tpl
+++ b/templates/hooks/db_cluster/sdk_delete_pre_build_request.go.tpl
@@ -1,3 +1,3 @@
 	if clusterDeleting(r) {
-		return requeueWaitWhileDeleting
+		return r, requeueWaitWhileDeleting
 	}

--- a/templates/hooks/db_instance/sdk_delete_pre_build_request.go.tpl
+++ b/templates/hooks/db_instance/sdk_delete_pre_build_request.go.tpl
@@ -1,4 +1,3 @@
 	if instanceDeleting(r) {
-		return requeueWaitWhileDeleting
+		return r, requeueWaitWhileDeleting
 	}
-


### PR DESCRIPTION
Brings in ACK runtime 0.6.0 and makes the requisite changes to the
delete sdk hook templates to deal with the altered Delete method
signature.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
