### PR TITLE
always ApplyImmediately for DBCluster/Instance

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2021-07-19T15:18:11Z"
+  build_date: "2021-07-19T15:47:38Z"
   build_hash: c77aa9c75d944952dee198029ba9822691cd82b0
   go_version: go1.15.5 linux/amd64
   version: v0.6.0
@@ -7,8 +7,8 @@ api_directory_checksum: c2500a34cb9377122cf5382a6456812006d8261b
 api_version: v1alpha1
 aws_sdk_go_version: ""
 generator_config_info:
-  file_checksum: 39e5c7eb8d1a39ab0a1c27e9185f412972ce84be
+  file_checksum: bb80f830d61e1a1c6016fde6102463862f9dc8dd
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-07-19 15:18:16.161125161 +0000 UTC
+  timestamp: 2021-07-19 15:47:43.42123851 +0000 UTC

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -18,12 +18,40 @@ ignore:
     - OptionGroup
   field_paths:
 operations:
+  ModifyDBCluster:
+    override_values:
+      # The whole concept of a "maintenance window" isn't aligned with the
+      # declarative state model in Kubernetes. Users should build "maintenance
+      # window" functionality at a higher layer than the APIs that manage the
+      # lifecycle of individual resources like a DB cluster or DB instance. For
+      # example, users can build maintenance window functionality into their
+      # deployment pipeline solution or GitOps solution.
+      #
+      # We override the value of the ApplyImmediately field in the modify
+      # operations to "true" because we want changes that a Kubernetes user
+      # makes to a resource's Spec to be reconciled by the ACK service
+      # controller, not a different service.
+      ApplyImmediately: true
   DeleteDBCluster:
     override_values:
       # Clearly this is not ideal, but will suffice until we add custom hook
       # points to the build_request methods to enable a genmeration of the
       # final snapshot identifier to use.
       SkipFinalSnapshot: true
+  ModifyDBInstance:
+    override_values:
+      # The whole concept of a "maintenance window" isn't aligned with the
+      # declarative state model in Kubernetes. Users should build "maintenance
+      # window" functionality at a higher layer than the APIs that manage the
+      # lifecycle of individual resources like a DB cluster or DB instance. For
+      # example, users can build maintenance window functionality into their
+      # deployment pipeline solution or GitOps solution.
+      #
+      # We override the value of the ApplyImmediately field in the modify
+      # operations to "true" because we want changes that a Kubernetes user
+      # makes to a resource's Spec to be reconciled by the ACK service
+      # controller, not a different service.
+      ApplyImmediately: true
   DeleteDBInstance:
     override_values:
       # Clearly this is not ideal, but will suffice until we add custom hook

--- a/generator.yaml
+++ b/generator.yaml
@@ -18,12 +18,40 @@ ignore:
     - OptionGroup
   field_paths:
 operations:
+  ModifyDBCluster:
+    override_values:
+      # The whole concept of a "maintenance window" isn't aligned with the
+      # declarative state model in Kubernetes. Users should build "maintenance
+      # window" functionality at a higher layer than the APIs that manage the
+      # lifecycle of individual resources like a DB cluster or DB instance. For
+      # example, users can build maintenance window functionality into their
+      # deployment pipeline solution or GitOps solution.
+      #
+      # We override the value of the ApplyImmediately field in the modify
+      # operations to "true" because we want changes that a Kubernetes user
+      # makes to a resource's Spec to be reconciled by the ACK service
+      # controller, not a different service.
+      ApplyImmediately: true
   DeleteDBCluster:
     override_values:
       # Clearly this is not ideal, but will suffice until we add custom hook
       # points to the build_request methods to enable a genmeration of the
       # final snapshot identifier to use.
       SkipFinalSnapshot: true
+  ModifyDBInstance:
+    override_values:
+      # The whole concept of a "maintenance window" isn't aligned with the
+      # declarative state model in Kubernetes. Users should build "maintenance
+      # window" functionality at a higher layer than the APIs that manage the
+      # lifecycle of individual resources like a DB cluster or DB instance. For
+      # example, users can build maintenance window functionality into their
+      # deployment pipeline solution or GitOps solution.
+      #
+      # We override the value of the ApplyImmediately field in the modify
+      # operations to "true" because we want changes that a Kubernetes user
+      # makes to a resource's Spec to be reconciled by the ACK service
+      # controller, not a different service.
+      ApplyImmediately: true
   DeleteDBInstance:
     override_values:
       # Clearly this is not ideal, but will suffice until we add custom hook

--- a/pkg/resource/db_cluster/sdk.go
+++ b/pkg/resource/db_cluster/sdk.go
@@ -1473,6 +1473,7 @@ func (rm *resourceManager) newUpdateRequestPayload(
 ) (*svcsdk.ModifyDBClusterInput, error) {
 	res := &svcsdk.ModifyDBClusterInput{}
 
+	res.SetApplyImmediately(true)
 	if r.ko.Spec.BacktrackWindow != nil {
 		res.SetBacktrackWindow(*r.ko.Spec.BacktrackWindow)
 	}

--- a/pkg/resource/db_instance/sdk.go
+++ b/pkg/resource/db_instance/sdk.go
@@ -1788,6 +1788,7 @@ func (rm *resourceManager) newUpdateRequestPayload(
 	if r.ko.Spec.AllocatedStorage != nil {
 		res.SetAllocatedStorage(*r.ko.Spec.AllocatedStorage)
 	}
+	res.SetApplyImmediately(true)
 	if r.ko.Spec.AutoMinorVersionUpgrade != nil {
 		res.SetAutoMinorVersionUpgrade(*r.ko.Spec.AutoMinorVersionUpgrade)
 	}

--- a/test/e2e/resources/db_cluster_mysql_serverless.yaml
+++ b/test/e2e/resources/db_cluster_mysql_serverless.yaml
@@ -3,6 +3,7 @@ kind: DBCluster
 metadata:
   name: $DB_CLUSTER_ID
 spec:
+  copyTagsToSnapshot: $COPY_TAGS_TO_SNAPSHOT
   dbClusterIdentifier: $DB_CLUSTER_ID
   databaseName: $DB_NAME
   engine: aurora-mysql

--- a/test/e2e/resources/db_instance_postgres13_t3_micro.yaml
+++ b/test/e2e/resources/db_instance_postgres13_t3_micro.yaml
@@ -4,6 +4,7 @@ metadata:
   name: $DB_INSTANCE_ID
 spec:
   allocatedStorage: 20
+  copyTagsToSnapshot: $COPY_TAGS_TO_SNAPSHOT
   dbInstanceClass: db.t3.micro
   dbInstanceIdentifier: $DB_INSTANCE_ID
   engine: postgres


### PR DESCRIPTION
Sets the ApplyImmediately field in the ModifyDBInstance and
ModifyDBCluster API Input shapes to always be `true`, enabling immediate
modification of the DB cluster or instance.

Issue aws-controllers-k8s/community#865

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
