### PR TITLE
requeue db cluster while not available

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,14 +1,14 @@
 ack_generate_info:
-  build_date: "2021-09-01T14:48:37Z"
+  build_date: "2021-09-01T17:48:47Z"
   build_hash: 6f22b7b568e25b4ee007bb1ab5f9338c16daf172
   go_version: go1.17 linux/amd64
   version: v0.13.0
-api_directory_checksum: 183f450ec5188cdb1cf76da50f21933f6b4cd7e3
+api_directory_checksum: 387f19255122f7e68716af4d6dbce0e7498cfe37
 api_version: v1alpha1
 aws_sdk_go_version: v1.37.10
 generator_config_info:
-  file_checksum: f62cefeb4c379bb1cc428d6685a4e5e4e182eb92
+  file_checksum: f5d26ad7ae3f2cdc82f2e08c45f5b0aefafb9fa4
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-09-01 14:48:42.205143913 +0000 UTC
+  timestamp: 2021-09-01 17:48:52.072416982 +0000 UTC

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -78,6 +78,10 @@ resources:
       # resolved.
       custom_method_name: customUpdate
     hooks:
+      sdk_create_post_set_output:
+        template_path: hooks/db_cluster/sdk_create_post_set_output.go.tpl
+      sdk_read_many_post_set_output:
+        template_path: hooks/db_cluster/sdk_read_many_post_set_output.go.tpl
       sdk_update_pre_build_request:
         template_path: hooks/db_cluster/sdk_update_pre_build_request.go.tpl
       sdk_delete_pre_build_request:

--- a/generator.yaml
+++ b/generator.yaml
@@ -78,6 +78,10 @@ resources:
       # resolved.
       custom_method_name: customUpdate
     hooks:
+      sdk_create_post_set_output:
+        template_path: hooks/db_cluster/sdk_create_post_set_output.go.tpl
+      sdk_read_many_post_set_output:
+        template_path: hooks/db_cluster/sdk_read_many_post_set_output.go.tpl
       sdk_update_pre_build_request:
         template_path: hooks/db_cluster/sdk_update_pre_build_request.go.tpl
       sdk_delete_pre_build_request:

--- a/pkg/resource/db_cluster/hooks.go
+++ b/pkg/resource/db_cluster/hooks.go
@@ -116,6 +116,16 @@ func clusterHasTerminalStatus(r *resource) bool {
 	return false
 }
 
+// clusterAvailable returns true if the supplied DB cluster is in an
+// available status
+func clusterAvailable(r *resource) bool {
+	if r.ko.Status.Status == nil {
+		return false
+	}
+	dbcs := *r.ko.Status.Status
+	return dbcs == StatusAvailable
+}
+
 // clusterCreating returns true if the supplied DB cluster is in the process
 // of being created
 func clusterCreating(r *resource) bool {

--- a/pkg/resource/db_cluster/sdk.go
+++ b/pkg/resource/db_cluster/sdk.go
@@ -523,6 +523,13 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	if !clusterAvailable(&resource{ko}) {
+		// Setting resource synced condition to false will trigger a requeue of
+		// the resource. No need to return a requeue error here.
+		setSyncedCondition(&resource{ko}, corev1.ConditionFalse, nil, nil)
+		return &resource{ko}, nil
+	}
+
 	return &resource{ko}, nil
 }
 
@@ -1015,6 +1022,16 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
+	// We expect the DB cluster to be in 'creating' status since we just
+	// issued the call to create it, but I suppose it doesn't hurt to check
+	// here.
+	if clusterCreating(&resource{ko}) {
+		// Setting resource synced condition to false will trigger a requeue of
+		// the resource. No need to return a requeue error here.
+		setSyncedCondition(&resource{ko}, corev1.ConditionFalse, nil, nil)
+		return &resource{ko}, nil
+	}
+
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/db_cluster/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/db_cluster/sdk_create_post_set_output.go.tpl
@@ -1,0 +1,9 @@
+	// We expect the DB cluster to be in 'creating' status since we just
+	// issued the call to create it, but I suppose it doesn't hurt to check
+	// here.
+	if clusterCreating(&resource{ko}) {
+		// Setting resource synced condition to false will trigger a requeue of
+		// the resource. No need to return a requeue error here.
+		setSyncedCondition(&resource{ko}, corev1.ConditionFalse, nil, nil)
+		return &resource{ko}, nil
+	}

--- a/templates/hooks/db_cluster/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/db_cluster/sdk_read_many_post_set_output.go.tpl
@@ -1,0 +1,7 @@
+	if !clusterAvailable(&resource{ko}) {
+		// Setting resource synced condition to false will trigger a requeue of
+		// the resource. No need to return a requeue error here.
+		setSyncedCondition(&resource{ko}, corev1.ConditionFalse, nil, nil)
+		return &resource{ko}, nil
+	}
+


### PR DESCRIPTION
After creating a new DBCluster resource, we were not setting
ConditionTypeResourceSynced on the resource nor were we asking to
requeue the resource after some time. This meant that the resource's
Status was not being updated on the Kubernetes side, even after the DB
instance's status transitioned to 'available' on the RDS side.

In this patch, we're adding two generic hook implementations for
sdk_read_many_post_set_output and sdk_create_post_set_output that will
create a ConditionTypeResourceSynced on the resource with a value of
ConditionFalse (because the resource isn't actually synced yet). This
causes the controller to queue the resource up for a new reconciliation
loop, during which the resource's Status will be updated to the latest
observed values.

Issue aws-controllers-k8s/community#923

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
