### PR TITLE
Remove DBClusterNotFoundFault as a terminal condition for GlobalCluster.

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2021-10-18T13:05:50Z"
+  build_date: "2021-10-21T19:35:08Z"
   build_hash: 21ee1672e2c1556fd5784a22bc48aa619975cc6f
-  go_version: go1.17
+  go_version: go1.17.1
   version: v0.15.1
-api_directory_checksum: 00e04ca66417394b3744716ee1c047dff5326ecf
+api_directory_checksum: cd0469d4474d82dbcf9badb97a43cac68ba07044
 api_version: v1alpha1
 aws_sdk_go_version: v1.37.10
 generator_config_info:
-  file_checksum: d683ba821488baaa11becafe3049ba9259d2d829
+  file_checksum: e99b7e3e4ce6b046e2aabcc164c99bc920272c4d
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -151,7 +151,6 @@ resources:
   GlobalCluster:
     exceptions:
       terminal_codes:
-        - DBClusterNotFoundFault
         - GlobalClusterAlreadyExistsFault
         - GlobalClusterQuotaExceededFault
         - InvalidDBClusterStateFault

--- a/generator.yaml
+++ b/generator.yaml
@@ -151,7 +151,6 @@ resources:
   GlobalCluster:
     exceptions:
       terminal_codes:
-        - DBClusterNotFoundFault
         - GlobalClusterAlreadyExistsFault
         - GlobalClusterQuotaExceededFault
         - InvalidDBClusterStateFault

--- a/pkg/resource/global_cluster/sdk.go
+++ b/pkg/resource/global_cluster/sdk.go
@@ -637,8 +637,7 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 		return false
 	}
 	switch awsErr.Code() {
-	case "DBClusterNotFoundFault",
-		"GlobalClusterAlreadyExistsFault",
+	case "GlobalClusterAlreadyExistsFault",
 		"GlobalClusterQuotaExceededFault",
 		"InvalidDBClusterStateFault":
 		return true


### PR DESCRIPTION
Issue #, if available: aws-controllers-k8s/community#1027

Description of changes:
Remove `DBClusterNotFoundFault` as a terminal condition for `GlobalCluster`.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
