### PR TITLE
refactor DB instance e2e tests

### DIFF
--- a/test/e2e/tests/test_db_cluster.py
+++ b/test/e2e/tests/test_db_cluster.py
@@ -46,7 +46,7 @@ class TestDBCluster:
     MUP_SEC_KEY = "master_user_password"
     MUP_SEC_VAL = "secretpass123456"
 
-    def test_create_delete_mysql_serverless(
+    def test_crud_mysql_serverless(
             self,
             k8s_secret,
     ):
@@ -121,7 +121,6 @@ class TestDBCluster:
         assert latest is not None
         assert latest['CopyTagsToSnapshot'] == True
 
-        # Delete the k8s resource on teardown of the module
         k8s.delete_custom_resource(ref)
 
         time.sleep(DELETE_WAIT_AFTER_SECONDS)


### PR DESCRIPTION
Pulls out the waiter and getter functions for DB instance resources into
a test/e2e/db_instance.py file, modeled after the same set of functions
for the DB cluster resource.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
