### PR TITLE
Ensure Synced Condition on DB instance/cluster

### DIFF
--- a/generator.yaml
+++ b/generator.yaml
@@ -144,6 +144,8 @@ resources:
         - DBSubnetGroupNotFoundFault
         - DBParameterGroupNotFound
     fields:
+      AvailabilityZone:
+        late_initialize: {}
       DBInstanceIdentifier:
         is_primary_key: true
       MasterUserPassword:

--- a/pkg/resource/db_cluster/sdk.go
+++ b/pkg/resource/db_cluster/sdk.go
@@ -529,7 +529,8 @@ func (rm *resourceManager) sdkFind(
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.
 		setSyncedCondition(&resource{ko}, corev1.ConditionFalse, nil, nil)
-		return &resource{ko}, nil
+	} else {
+		setSyncedCondition(&resource{ko}, corev1.ConditionTrue, nil, nil)
 	}
 
 	return &resource{ko}, nil

--- a/pkg/resource/db_instance/manager.go
+++ b/pkg/resource/db_instance/manager.go
@@ -40,7 +40,7 @@ import (
 // +kubebuilder:rbac:groups=rds.services.k8s.aws,resources=dbinstances,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rds.services.k8s.aws,resources=dbinstances/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{}
+var lateInitializeFieldNames = []string{"AvailabilityZone"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -238,7 +238,12 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	observed acktypes.AWSResource,
 	latest acktypes.AWSResource,
 ) acktypes.AWSResource {
-	return latest
+	observedKo := rm.concreteResource(observed).ko.DeepCopy()
+	latestKo := rm.concreteResource(latest).ko.DeepCopy()
+	if observedKo.Spec.AvailabilityZone != nil && latestKo.Spec.AvailabilityZone == nil {
+		latestKo.Spec.AvailabilityZone = observedKo.Spec.AvailabilityZone
+	}
+	return &resource{latestKo}
 }
 
 // newResourceManager returns a new struct implementing

--- a/templates/hooks/db_cluster/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/db_cluster/sdk_read_many_post_set_output.go.tpl
@@ -2,6 +2,7 @@
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.
 		setSyncedCondition(&resource{ko}, corev1.ConditionFalse, nil, nil)
-		return &resource{ko}, nil
+	} else {
+		setSyncedCondition(&resource{ko}, corev1.ConditionTrue, nil, nil)
 	}
 

--- a/templates/hooks/db_instance/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/db_instance/sdk_read_many_post_set_output.go.tpl
@@ -2,5 +2,7 @@
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.
 		setSyncedCondition(&resource{ko}, corev1.ConditionFalse, nil, nil)
-		return &resource{ko}, nil
-	}
+	} else {
+		setSyncedCondition(&resource{ko}, corev1.ConditionTrue, nil, nil)
+    }
+

--- a/templates/hooks/db_instance/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/db_instance/sdk_update_pre_build_request.go.tpl
@@ -14,3 +14,8 @@
 		setSyncedCondition(desired, corev1.ConditionTrue, nil, nil)
 		return desired, nil
 	}
+	if !instanceAvailable(latest) {
+		msg := "DB instance cannot be modifed while in '" + *latest.ko.Status.DBInstanceStatus + "' status"
+		setSyncedCondition(desired, corev1.ConditionFalse, &msg, nil)
+		return desired, requeueWaitUntilCanModify(latest)
+	}

--- a/test/e2e/condition.py
+++ b/test/e2e/condition.py
@@ -1,0 +1,145 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Utility functions to help processing Kubernetes resource conditions"""
+
+# TODO(jaypipes): Move these functions to acktest library. The reason these are
+# here is because the existing k8s.assert_condition_state_message doesn't
+# actually assert anything. It returns true or false and logs messages.
+
+import pytest
+
+from acktest.k8s import resource as k8s
+
+CONDITION_TYPE_ADOPTED = "ACK.Adopted"
+CONDITION_TYPE_RESOURCE_SYNCED = "ACK.ResourceSynced"
+CONDITION_TYPE_TERMINAL = "ACK.Terminal"
+CONDITION_TYPE_RECOVERABLE = "ACK.Recoverable"
+CONDITION_TYPE_ADVISORY = "ACK.Advisory"
+CONDITION_TYPE_LATE_INITIALIZED = "ACK.LateInitialized"
+
+
+def assert_type_status(
+    ref: k8s.CustomResourceReference,
+    cond_type_match: str = CONDITION_TYPE_RESOURCE_SYNCED,
+    cond_status_match: bool = True,
+):
+    """Asserts that the supplied resource has a condition of type
+    ACK.ResourceSynced and that the Status of this condition is True.
+
+    Usage:
+        from acktest.k8s import resource as k8s
+
+        from e2e import condition
+
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            db_cluster_id, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        k8s.wait_resource_consumed_by_controller(ref)
+        condition.assert_type_status(
+            ref,
+            condition.CONDITION_TYPE_RESOURCE_SYNCED,
+            False)
+
+    Raises:
+        pytest.fail when condition of the specified type is not found or is not
+        in the supplied status.
+    """
+    cond = k8s.get_resource_condition(ref, cond_type_match)
+    if cond is None:
+        msg = (f"Failed to find {cond_type_match} condition in "
+               f"resource {ref}")
+        pytest.fail(msg)
+
+    cond_status = cond.get('status', None)
+    if str(cond_status) != str(cond_status_match):
+        msg = (f"Expected {cond_type_match} condition to "
+               f"have status {cond_status_match} but found {cond_status}")
+        pytest.fail(msg)
+
+
+def assert_synced_status(
+    ref: k8s.CustomResourceReference,
+    cond_status_match: bool,
+):
+    """Asserts that the supplied resource has a condition of type
+    ACK.ResourceSynced and that the Status of this condition is True.
+
+    Usage:
+        from acktest.k8s import resource as k8s
+
+        from e2e import condition
+
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            db_cluster_id, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        k8s.wait_resource_consumed_by_controller(ref)
+        condition.assert_synced_status(ref, False)
+
+    Raises:
+        pytest.fail when ACK.ResourceSynced condition is not found or is not in
+        a True status.
+    """
+    assert_type_status(ref, CONDITION_TYPE_RESOURCE_SYNCED, cond_status_match)
+
+
+def assert_synced(ref: k8s.CustomResourceReference):
+    """Asserts that the supplied resource has a condition of type
+    ACK.ResourceSynced and that the Status of this condition is True.
+
+    Usage:
+        from acktest.k8s import resource as k8s
+
+        from e2e import condition
+
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            db_cluster_id, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        k8s.wait_resource_consumed_by_controller(ref)
+        condition.assert_synced(ref)
+
+    Raises:
+        pytest.fail when ACK.ResourceSynced condition is not found or is not in
+        a True status.
+    """
+    return assert_synced_status(ref, True)
+
+
+def assert_not_synced(ref: k8s.CustomResourceReference):
+    """Asserts that the supplied resource has a condition of type
+    ACK.ResourceSynced and that the Status of this condition is False.
+
+    Usage:
+        from acktest.k8s import resource as k8s
+
+        from e2e import condition
+
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            db_cluster_id, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        k8s.wait_resource_consumed_by_controller(ref)
+        condition.assert_not_synced(ref)
+
+    Raises:
+        pytest.fail when ACK.ResourceSynced condition is not found or is not in
+        a False status.
+    """
+    return assert_synced_status(ref, False)


### PR DESCRIPTION
Adds tests that the ACK.ResourceSynced Condition is present on resources
of kind DBCluster and DBInstance and that the status of those conditions
are either False or True depending on the expected state transition of
the DB instance or cluster.

This involved creating some helper functions in test/e2e/condition.py
that assert that a Condition of a specific type and status is present in
a resource's Status.Conditions collection.

In grep'ing through logs for the rds-controller, I noticed that the
AvailabilityZone field for the DBInstance should be late-initialized and
so added that to the generator.yaml file.

Finally, found that ACK.ResourceSynced/True was not being set on
DBCluster and DBInstance resources when the status of the instance or
cluster made its way to 'available'. I added an else block to the
generic hook code templates to ensure that ACK.ResourceSynced condition
with a status of True is present when the resource's status transitions
to 'available'.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
