### PR TITLE
Bring in ACK runtime v0.15.2

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2021-10-21T19:35:08Z"
-  build_hash: 21ee1672e2c1556fd5784a22bc48aa619975cc6f
-  go_version: go1.17.1
-  version: v0.15.1
-api_directory_checksum: cd0469d4474d82dbcf9badb97a43cac68ba07044
+  build_date: "2021-11-18T15:25:36Z"
+  build_hash: 966e9a9ac6dfb4bbc2d3ded1972ce2b706391d44
+  go_version: go1.17
+  version: v0.15.2
+api_directory_checksum: cae902b75e1b0827659c4bfe7ef9f6bb98769f5c
 api_version: v1alpha1
 aws_sdk_go_version: v1.37.10
 generator_config_info:
-  file_checksum: e99b7e3e4ce6b046e2aabcc164c99bc920272c4d
+  file_checksum: a40f829b03389cf1b2a003ebe2a79b97bc9d3322
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/db_instance.go
+++ b/apis/v1alpha1/db_instance.go
@@ -276,7 +276,7 @@ type DBInstanceSpec struct {
 	// A list of DB security groups to associate with this DB instance.
 	//
 	// Default: The default DB security group for the database engine.
-	DBSecurityGroupNames []*string `json:"dbSecurityGroupNames,omitempty"`
+	DBSecurityGroups []*string `json:"dbSecurityGroups,omitempty"`
 	// A DB subnet group to associate with this DB instance.
 	//
 	// If there is no DB subnet group, then it is a non-VPC DB instance.

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -126,14 +126,6 @@ resources:
         template_path: hooks/db_instance/sdk_update_pre_build_request.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/db_instance/sdk_delete_pre_build_request.go.tpl
-    renames:
-      operations:
-        CreateDBInstance:
-          input_fields:
-            # The data type of the create input and create output shape of the
-            # DBSecurityGroups field is different which causes errors when
-            # compiling
-            DBSecurityGroups: DBSecurityGroupNames
     exceptions:
       terminal_codes:
         - InvalidParameter
@@ -144,8 +136,23 @@ resources:
         - DBSubnetGroupNotFoundFault
         - DBParameterGroupNotFound
     fields:
+      AvailabilityZone:
+        late_initialize: {}
       DBInstanceIdentifier:
         is_primary_key: true
+      # Because the Create input and Create/Update/ReadOne output shapes for
+      # the DBSecurityGroups field have different Go types, we are instructing
+      # the code generator to set the Spec.DBSecurityGroups field (which is a
+      # []string field) to the set of DBSecurityGroups..DBSecurityGroupName
+      # values in the ReadOne method's Output shape.
+      DBSecurityGroups:
+        set:
+          - method: Update
+            from: DBSecurityGroupName
+          - method: Create
+            from: DBSecurityGroupName
+          - method: ReadOne
+            from: DBSecurityGroupName
       MasterUserPassword:
         is_secret: true
   GlobalCluster:

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -2179,8 +2179,8 @@ func (in *DBInstanceSpec) DeepCopyInto(out *DBInstanceSpec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.DBSecurityGroupNames != nil {
-		in, out := &in.DBSecurityGroupNames, &out.DBSecurityGroupNames
+	if in.DBSecurityGroups != nil {
+		in, out := &in.DBSecurityGroups, &out.DBSecurityGroups
 		*out = make([]*string, len(*in))
 		for i := range *in {
 			if (*in)[i] != nil {

--- a/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
@@ -183,7 +183,7 @@ spec:
                   \n    * First character must be a letter \n    * Can't end with
                   a hyphen or contain two consecutive hyphens"
                 type: string
-              dbSecurityGroupNames:
+              dbSecurityGroups:
                 description: "A list of DB security groups to associate with this
                   DB instance. \n Default: The default DB security group for the database
                   engine."

--- a/generator.yaml
+++ b/generator.yaml
@@ -126,14 +126,6 @@ resources:
         template_path: hooks/db_instance/sdk_update_pre_build_request.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/db_instance/sdk_delete_pre_build_request.go.tpl
-    renames:
-      operations:
-        CreateDBInstance:
-          input_fields:
-            # The data type of the create input and create output shape of the
-            # DBSecurityGroups field is different which causes errors when
-            # compiling
-            DBSecurityGroups: DBSecurityGroupNames
     exceptions:
       terminal_codes:
         - InvalidParameter
@@ -148,6 +140,19 @@ resources:
         late_initialize: {}
       DBInstanceIdentifier:
         is_primary_key: true
+      # Because the Create input and Create/Update/ReadOne output shapes for
+      # the DBSecurityGroups field have different Go types, we are instructing
+      # the code generator to set the Spec.DBSecurityGroups field (which is a
+      # []string field) to the set of DBSecurityGroups..DBSecurityGroupName
+      # values in the ReadOne method's Output shape.
+      DBSecurityGroups:
+        set:
+          - method: Update
+            from: DBSecurityGroupName
+          - method: Create
+            from: DBSecurityGroupName
+          - method: ReadOne
+            from: DBSecurityGroupName
       MasterUserPassword:
         is_secret: true
   GlobalCluster:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/rds-controller
 go 1.14
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.15.1
+	github.com/aws-controllers-k8s/runtime v0.15.2
 	github.com/aws/aws-sdk-go v1.37.10
 	github.com/go-logr/logr v0.1.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.15.1 h1:3P+6MKWe8ITJynmoxmDnMPlkoI9nuVgn8XD9Pt/XHE8=
-github.com/aws-controllers-k8s/runtime v0.15.1/go.mod h1:W0Txdhb1Npx5kg72w2WFwIpGFvSsMxXlJzzNHAwCLeY=
+github.com/aws-controllers-k8s/runtime v0.15.2 h1:waRPQGw+b/9huNHcMG+LQoVW4VP2YIBqZNdB+JAh//E=
+github.com/aws-controllers-k8s/runtime v0.15.2/go.mod h1:W0Txdhb1Npx5kg72w2WFwIpGFvSsMxXlJzzNHAwCLeY=
 github.com/aws/aws-sdk-go v1.37.10 h1:LRwl+97B4D69Z7tz+eRUxJ1C7baBaIYhgrn5eLtua+Q=
 github.com/aws/aws-sdk-go v1.37.10/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/helm/crds/rds.services.k8s.aws_dbinstances.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbinstances.yaml
@@ -183,7 +183,7 @@ spec:
                   \n    * First character must be a letter \n    * Can't end with
                   a hyphen or contain two consecutive hyphens"
                 type: string
-              dbSecurityGroupNames:
+              dbSecurityGroups:
                 description: "A list of DB security groups to associate with this
                   DB instance. \n Default: The default DB security group for the database
                   engine."

--- a/pkg/resource/db_cluster/sdk.go
+++ b/pkg/resource/db_cluster/sdk.go
@@ -17,6 +17,7 @@ package db_cluster
 
 import (
 	"context"
+	"reflect"
 	"strings"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
@@ -42,6 +43,7 @@ var (
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
 	_ = &ackcondition.NotManagedMessage
+	_ = &reflect.Value{}
 )
 
 // sdkFind returns SDK-specific information about a supplied resource

--- a/pkg/resource/db_cluster_parameter_group/sdk.go
+++ b/pkg/resource/db_cluster_parameter_group/sdk.go
@@ -17,6 +17,7 @@ package db_cluster_parameter_group
 
 import (
 	"context"
+	"reflect"
 	"strings"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
@@ -42,6 +43,7 @@ var (
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
 	_ = &ackcondition.NotManagedMessage
+	_ = &reflect.Value{}
 )
 
 // sdkFind returns SDK-specific information about a supplied resource
@@ -113,7 +115,8 @@ func (rm *resourceManager) sdkFind(
 func (rm *resourceManager) requiredFieldsMissingFromReadManyInput(
 	r *resource,
 ) bool {
-	return false
+	return r.ko.Spec.Name == nil
+
 }
 
 // newListRequestPayload returns SDK-specific struct for the HTTP request

--- a/pkg/resource/db_instance/delta.go
+++ b/pkg/resource/db_instance/delta.go
@@ -118,8 +118,8 @@ func newResourceDelta(
 			delta.Add("Spec.DBParameterGroupName", a.ko.Spec.DBParameterGroupName, b.ko.Spec.DBParameterGroupName)
 		}
 	}
-	if !ackcompare.SliceStringPEqual(a.ko.Spec.DBSecurityGroupNames, b.ko.Spec.DBSecurityGroupNames) {
-		delta.Add("Spec.DBSecurityGroupNames", a.ko.Spec.DBSecurityGroupNames, b.ko.Spec.DBSecurityGroupNames)
+	if !ackcompare.SliceStringPEqual(a.ko.Spec.DBSecurityGroups, b.ko.Spec.DBSecurityGroups) {
+		delta.Add("Spec.DBSecurityGroups", a.ko.Spec.DBSecurityGroups, b.ko.Spec.DBSecurityGroups)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.DBSubnetGroupName, b.ko.Spec.DBSubnetGroupName) {
 		delta.Add("Spec.DBSubnetGroupName", a.ko.Spec.DBSubnetGroupName, b.ko.Spec.DBSubnetGroupName)

--- a/pkg/resource/db_instance/manager.go
+++ b/pkg/resource/db_instance/manager.go
@@ -229,6 +229,10 @@ func (rm *resourceManager) LateInitialize(
 func (rm *resourceManager) incompleteLateInitialization(
 	res acktypes.AWSResource,
 ) bool {
+	ko := rm.concreteResource(res).ko.DeepCopy()
+	if ko.Spec.AvailabilityZone == nil {
+		return true
+	}
 	return false
 }
 

--- a/pkg/resource/db_instance/sdk.go
+++ b/pkg/resource/db_instance/sdk.go
@@ -17,6 +17,7 @@ package db_instance
 
 import (
 	"context"
+	"reflect"
 	"strings"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
@@ -42,6 +43,7 @@ var (
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
 	_ = &ackcondition.NotManagedMessage
+	_ = &reflect.Value{}
 )
 
 // sdkFind returns SDK-specific information about a supplied resource
@@ -198,6 +200,17 @@ func (rm *resourceManager) sdkFind(
 			ko.Status.DBParameterGroups = f16
 		} else {
 			ko.Status.DBParameterGroups = nil
+		}
+		if elem.DBSecurityGroups != nil {
+			f17 := []*string{}
+			for _, f17iter := range elem.DBSecurityGroups {
+				var f17elem string
+				f17elem = *f17iter.DBSecurityGroupName
+				f17 = append(f17, &f17elem)
+			}
+			ko.Spec.DBSecurityGroups = f17
+		} else {
+			ko.Spec.DBSecurityGroups = nil
 		}
 		if elem.DBSubnetGroup != nil {
 			f18 := &svcapitypes.DBSubnetGroup_SDK{}
@@ -854,14 +867,13 @@ func (rm *resourceManager) sdkCreate(
 	if resp.DBInstance.DBSecurityGroups != nil {
 		f17 := []*string{}
 		for _, f17iter := range resp.DBInstance.DBSecurityGroups {
-			// TODO(rbranche): Updated this code here to fix compilation error until Issue #178 is resolved.
-			// var f17elem string
-			// f17 = append(f17, f17elem)
-			f17 = append(f17, f17iter.DBSecurityGroupName)
+			var f17elem string
+			f17elem = *f17iter.DBSecurityGroupName
+			f17 = append(f17, &f17elem)
 		}
-		ko.Spec.DBSecurityGroupNames = f17
+		ko.Spec.DBSecurityGroups = f17
 	} else {
-		ko.Spec.DBSecurityGroupNames = nil
+		ko.Spec.DBSecurityGroups = nil
 	}
 	if resp.DBInstance.DBSubnetGroup != nil {
 		f18 := &svcapitypes.DBSubnetGroup_SDK{}
@@ -1383,9 +1395,9 @@ func (rm *resourceManager) newCreateRequestPayload(
 	if r.ko.Spec.DBParameterGroupName != nil {
 		res.SetDBParameterGroupName(*r.ko.Spec.DBParameterGroupName)
 	}
-	if r.ko.Spec.DBSecurityGroupNames != nil {
+	if r.ko.Spec.DBSecurityGroups != nil {
 		f11 := []*string{}
-		for _, f11iter := range r.ko.Spec.DBSecurityGroupNames {
+		for _, f11iter := range r.ko.Spec.DBSecurityGroups {
 			var f11elem string
 			f11elem = *f11iter
 			f11 = append(f11, &f11elem)
@@ -1712,6 +1724,17 @@ func (rm *resourceManager) sdkUpdate(
 		ko.Status.DBParameterGroups = f16
 	} else {
 		ko.Status.DBParameterGroups = nil
+	}
+	if resp.DBInstance.DBSecurityGroups != nil {
+		f17 := []*string{}
+		for _, f17iter := range resp.DBInstance.DBSecurityGroups {
+			var f17elem string
+			f17elem = *f17iter.DBSecurityGroupName
+			f17 = append(f17, &f17elem)
+		}
+		ko.Spec.DBSecurityGroups = f17
+	} else {
+		ko.Spec.DBSecurityGroups = nil
 	}
 	if resp.DBInstance.DBSubnetGroup != nil {
 		f18 := &svcapitypes.DBSubnetGroup_SDK{}
@@ -2214,6 +2237,15 @@ func (rm *resourceManager) newUpdateRequestPayload(
 	}
 	if r.ko.Spec.DBParameterGroupName != nil {
 		res.SetDBParameterGroupName(*r.ko.Spec.DBParameterGroupName)
+	}
+	if r.ko.Spec.DBSecurityGroups != nil {
+		f13 := []*string{}
+		for _, f13iter := range r.ko.Spec.DBSecurityGroups {
+			var f13elem string
+			f13elem = *f13iter
+			f13 = append(f13, &f13elem)
+		}
+		res.SetDBSecurityGroups(f13)
 	}
 	if r.ko.Spec.DBSubnetGroupName != nil {
 		res.SetDBSubnetGroupName(*r.ko.Spec.DBSubnetGroupName)

--- a/pkg/resource/db_parameter_group/sdk.go
+++ b/pkg/resource/db_parameter_group/sdk.go
@@ -17,6 +17,7 @@ package db_parameter_group
 
 import (
 	"context"
+	"reflect"
 	"strings"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
@@ -42,6 +43,7 @@ var (
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
 	_ = &ackcondition.NotManagedMessage
+	_ = &reflect.Value{}
 )
 
 // sdkFind returns SDK-specific information about a supplied resource
@@ -113,7 +115,8 @@ func (rm *resourceManager) sdkFind(
 func (rm *resourceManager) requiredFieldsMissingFromReadManyInput(
 	r *resource,
 ) bool {
-	return false
+	return r.ko.Spec.Name == nil
+
 }
 
 // newListRequestPayload returns SDK-specific struct for the HTTP request

--- a/pkg/resource/db_security_group/sdk.go
+++ b/pkg/resource/db_security_group/sdk.go
@@ -17,6 +17,7 @@ package db_security_group
 
 import (
 	"context"
+	"reflect"
 	"strings"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
@@ -42,6 +43,7 @@ var (
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
 	_ = &ackcondition.NotManagedMessage
+	_ = &reflect.Value{}
 )
 
 // sdkFind returns SDK-specific information about a supplied resource
@@ -156,7 +158,8 @@ func (rm *resourceManager) sdkFind(
 func (rm *resourceManager) requiredFieldsMissingFromReadManyInput(
 	r *resource,
 ) bool {
-	return false
+	return r.ko.Spec.Name == nil
+
 }
 
 // newListRequestPayload returns SDK-specific struct for the HTTP request

--- a/pkg/resource/db_subnet_group/sdk.go
+++ b/pkg/resource/db_subnet_group/sdk.go
@@ -17,6 +17,7 @@ package db_subnet_group
 
 import (
 	"context"
+	"reflect"
 	"strings"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
@@ -42,6 +43,7 @@ var (
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
 	_ = &ackcondition.NotManagedMessage
+	_ = &reflect.Value{}
 )
 
 // sdkFind returns SDK-specific information about a supplied resource
@@ -148,7 +150,8 @@ func (rm *resourceManager) sdkFind(
 func (rm *resourceManager) requiredFieldsMissingFromReadManyInput(
 	r *resource,
 ) bool {
-	return false
+	return r.ko.Spec.Name == nil
+
 }
 
 // newListRequestPayload returns SDK-specific struct for the HTTP request

--- a/pkg/resource/global_cluster/sdk.go
+++ b/pkg/resource/global_cluster/sdk.go
@@ -17,6 +17,7 @@ package global_cluster
 
 import (
 	"context"
+	"reflect"
 	"strings"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
@@ -42,6 +43,7 @@ var (
 	_ = ackv1alpha1.AWSAccountID("")
 	_ = &ackerr.NotFound
 	_ = &ackcondition.NotManagedMessage
+	_ = &reflect.Value{}
 )
 
 // sdkFind returns SDK-specific information about a supplied resource


### PR DESCRIPTION
Regenerates the rds-controller with the latest v0.15.2 runtime.

**BREAKING CHANGES**:

The DBInstance's Spec.DBSecurityGroupNames field is now renamed to just
Spec.DBSecurityGroups. It continues to be a `[]*string` field but now
the rds-controller correctly handles comparisons for this fields value
with the returned latest observed state.

Includes changes to the generator.yaml file that instructs the
code-generator how to handle the DBSecurityGroups field on DBInstance.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
