### PR TITLE
Update terminal exception code to not include recoverable states

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-01-31T20:38:22Z"
-  build_hash: 4ebcd703a95a2fbd71bd07130f92aa6813c1398b
-  go_version: go1.17.1
-  version: v0.16.3
+  build_date: "2022-02-02T19:12:40Z"
+  build_hash: 76bb8df5f54ad3791f93f4aa4d805f61fccb3591
+  go_version: go1.17.5
+  version: v0.16.4
 api_directory_checksum: cae902b75e1b0827659c4bfe7ef9f6bb98769f5c
 api_version: v1alpha1
 aws_sdk_go_version: v1.37.10
 generator_config_info:
-  file_checksum: e87619caa6304d2a07818296e3a6a5fd4da1e704
+  file_checksum: 9e97b1b3599949c830774210b9c24676b613b9d5
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -83,10 +83,7 @@ resources:
         - InvalidParameter
         - InvalidParameterValue
         - InvalidParameterCombination
-        - InvalidDBClusterStateFault
-        - InvalidDBInstanceStateFault
         - InvalidSubnet
-        - InvalidVPCNetworkStateFault
         - KMSKeyNotAccessibleFault
         - StorageQuotaExceeded
     fields:
@@ -129,7 +126,6 @@ resources:
         - InvalidParameter
         - InvalidParameterValue
         - InvalidParameterCombination
-        - InvalidDBInstanceState
         - DBSecurityGroupNotFound
         - DBSubnetGroupNotFoundFault
         - DBParameterGroupNotFound
@@ -158,7 +154,6 @@ resources:
       terminal_codes:
         - GlobalClusterAlreadyExistsFault
         - GlobalClusterQuotaExceededFault
-        - InvalidDBClusterStateFault
     fields:
       GlobalClusterIdentifier:
         is_primary_key: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -83,10 +83,7 @@ resources:
         - InvalidParameter
         - InvalidParameterValue
         - InvalidParameterCombination
-        - InvalidDBClusterStateFault
-        - InvalidDBInstanceStateFault
         - InvalidSubnet
-        - InvalidVPCNetworkStateFault
         - KMSKeyNotAccessibleFault
         - StorageQuotaExceeded
     fields:
@@ -129,7 +126,6 @@ resources:
         - InvalidParameter
         - InvalidParameterValue
         - InvalidParameterCombination
-        - InvalidDBInstanceState
         - DBSecurityGroupNotFound
         - DBSubnetGroupNotFoundFault
         - DBParameterGroupNotFound
@@ -158,7 +154,6 @@ resources:
       terminal_codes:
         - GlobalClusterAlreadyExistsFault
         - GlobalClusterQuotaExceededFault
-        - InvalidDBClusterStateFault
     fields:
       GlobalClusterIdentifier:
         is_primary_key: true

--- a/pkg/resource/db_cluster/sdk.go
+++ b/pkg/resource/db_cluster/sdk.go
@@ -1370,10 +1370,7 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 		"InvalidParameter",
 		"InvalidParameterValue",
 		"InvalidParameterCombination",
-		"InvalidDBClusterStateFault",
-		"InvalidDBInstanceStateFault",
 		"InvalidSubnet",
-		"InvalidVPCNetworkStateFault",
 		"KMSKeyNotAccessibleFault",
 		"StorageQuotaExceeded":
 		return true

--- a/pkg/resource/db_instance/sdk.go
+++ b/pkg/resource/db_instance/sdk.go
@@ -2503,7 +2503,6 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 	case "InvalidParameter",
 		"InvalidParameterValue",
 		"InvalidParameterCombination",
-		"InvalidDBInstanceState",
 		"DBSecurityGroupNotFound",
 		"DBSubnetGroupNotFoundFault",
 		"DBParameterGroupNotFound":

--- a/pkg/resource/global_cluster/sdk.go
+++ b/pkg/resource/global_cluster/sdk.go
@@ -640,8 +640,7 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 	}
 	switch awsErr.Code() {
 	case "GlobalClusterAlreadyExistsFault",
-		"GlobalClusterQuotaExceededFault",
-		"InvalidDBClusterStateFault":
+		"GlobalClusterQuotaExceededFault":
 		return true
 	default:
 		return false


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1151

Description of changes:
* Remove *InvalidDBClusterStateFault*, *InvalidDBInstanceStateFault*, *InvalidDBInstanceState* and *InvalidVPCNetworkStateFault* from Terminal Exception codes
    * All these errors are recoverable and putting them in terminal state code causes reconciliation to stop in valid cases like deleting DBCluster and DBInstances together. When DBInstances eventually get deleted, the DeleteDBCluster call stops returning InvalidDBClusterStateFault as per [troubleshoot guide](https://aws.amazon.com/premiumsupport/knowledge-center/rds-error-delete-aurora-cluster/)
* If there are specific cases where these errors will need to enforce Terminal State, custom hooks can be used in future.

-------

* For DBCluster operations, "InvalidDBClusterStateFault", "InvalidDBInstanceStateFault", "InvalidVPCNetworkStateFault" go away when DBInstance and DBSubnetGroup get into correct state.
* For DBInstance operations, "InvalidDBInstanceState" goes away when DBInstance moves into correct state
* For GlobalCluster, the "InvalidDBClusterStateFault" goes away when DBCluster moves into correct state.

----

* locally tested that e2e tests are passing

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
