### PR TITLE
add KMSKeyRef inside DBCluster and DBInstance

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-04-15T17:51:27Z"
-  build_hash: 50c64871bcaf88b9ee200eb8d6b8245fa8f675eb
+  build_date: "2022-04-19T21:22:13Z"
+  build_hash: db274dc04c0ad2b6a7fc5a8c364909f3cd45ec6c
   go_version: go1.17.5
-  version: v0.18.4
-api_directory_checksum: c5762d0b5707ca20866f2f0e85bc23863733ca11
+  version: v0.18.4-3-gdb274dc
+api_directory_checksum: e7bbd21f4f975f9cf1e1e804ebd450e8e310023d
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 3afea95265e7836112e0b1e37166290f18511d09
+  file_checksum: 9526e946bbd1d8b3b4c76b010966f6c0158a6941
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/db_cluster.go
+++ b/apis/v1alpha1/db_cluster.go
@@ -232,7 +232,8 @@ type DBClusterSpec struct {
 	// Web Services Region, you must set KmsKeyId to a KMS key identifier that is
 	// valid in the destination Amazon Web Services Region. This KMS key is used
 	// to encrypt the read replica in that Amazon Web Services Region.
-	KMSKeyID *string `json:"kmsKeyID,omitempty"`
+	KMSKeyID  *string                                  `json:"kmsKeyID,omitempty"`
+	KMSKeyRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"kmsKeyRef,omitempty"`
 	// The password for the master database user. This password can contain any
 	// printable ASCII character except "/", """, or "@".
 	//

--- a/apis/v1alpha1/db_instance.go
+++ b/apis/v1alpha1/db_instance.go
@@ -540,7 +540,8 @@ type DBInstanceSpec struct {
 	// if you leave this parameter empty while enabling StorageEncrypted, the engine
 	// uses the default KMS key. However, RDS Custom for Oracle doesn't use the
 	// default key when this parameter is empty. You must explicitly specify a key.
-	KMSKeyID *string `json:"kmsKeyID,omitempty"`
+	KMSKeyID  *string                                  `json:"kmsKeyID,omitempty"`
+	KMSKeyRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"kmsKeyRef,omitempty"`
 	// License model information for this DB instance.
 	//
 	// Valid values: license-included | bring-your-own-license | general-public-license

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -92,6 +92,11 @@ resources:
         is_primary_key: true
       MasterUserPassword:
         is_secret: true
+      KmsKeyId:
+        references:
+          resource: Key
+          service_name: kms
+          path: Status.ACKResourceMetadata.ARN
   DBClusterParameterGroup:
     renames:
       operations:
@@ -156,6 +161,11 @@ resources:
             from: DBSecurityGroupName
       MasterUserPassword:
         is_secret: true
+      KmsKeyId:
+        references:
+          resource: Key
+          service_name: kms
+          path: Status.ACKResourceMetadata.ARN
   GlobalCluster:
     exceptions:
       terminal_codes:

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1074,6 +1074,11 @@ func (in *DBClusterSpec) DeepCopyInto(out *DBClusterSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.KMSKeyRef != nil {
+		in, out := &in.KMSKeyRef, &out.KMSKeyRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.MasterUserPassword != nil {
 		in, out := &in.MasterUserPassword, &out.MasterUserPassword
 		*out = new(corev1alpha1.SecretKeyReference)
@@ -2308,6 +2313,11 @@ func (in *DBInstanceSpec) DeepCopyInto(out *DBInstanceSpec) {
 		in, out := &in.KMSKeyID, &out.KMSKeyID
 		*out = new(string)
 		**out = **in
+	}
+	if in.KMSKeyRef != nil {
+		in, out := &in.KMSKeyRef, &out.KMSKeyRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.LicenseModel != nil {
 		in, out := &in.LicenseModel, &out.LicenseModel

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"os"
 
+	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
@@ -57,6 +58,7 @@ func init() {
 
 	_ = svctypes.AddToScheme(scheme)
 	_ = ackv1alpha1.AddToScheme(scheme)
+	_ = kmsapitypes.AddToScheme(scheme)
 }
 
 func main() {

--- a/config/crd/bases/rds.services.k8s.aws_dbclusters.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbclusters.yaml
@@ -218,6 +218,20 @@ spec:
                   destination Amazon Web Services Region. This KMS key is used to
                   encrypt the read replica in that Amazon Web Services Region."
                 type: string
+              kmsKeyRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               masterUserPassword:
                 description: "The password for the master database user. This password
                   can contain any printable ASCII character except \"/\", \"\"\",

--- a/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
@@ -358,6 +358,20 @@ spec:
                   key when this parameter is empty. You must explicitly specify a
                   key."
                 type: string
+              kmsKeyRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               licenseModel:
                 description: "License model information for this DB instance. \n Valid
                   values: license-included | bring-your-own-license | general-public-license

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -33,6 +33,20 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - kms.services.k8s.aws
+  resources:
+  - keys
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - kms.services.k8s.aws
+  resources:
+  - keys/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - rds.services.k8s.aws
   resources:
   - dbclusterparametergroups

--- a/generator.yaml
+++ b/generator.yaml
@@ -92,6 +92,11 @@ resources:
         is_primary_key: true
       MasterUserPassword:
         is_secret: true
+      KmsKeyId:
+        references:
+          resource: Key
+          service_name: kms
+          path: Status.ACKResourceMetadata.ARN
   DBClusterParameterGroup:
     renames:
       operations:
@@ -156,6 +161,11 @@ resources:
             from: DBSecurityGroupName
       MasterUserPassword:
         is_secret: true
+      KmsKeyId:
+        references:
+          resource: Key
+          service_name: kms
+          path: Status.ACKResourceMetadata.ARN
   GlobalCluster:
     exceptions:
       terminal_codes:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/aws-controllers-k8s/rds-controller
 go 1.17
 
 require (
+	github.com/aws-controllers-k8s/kms-controller v0.0.15
 	github.com/aws-controllers-k8s/runtime v0.18.4
 	github.com/aws/aws-sdk-go v1.42.0
 	github.com/go-logr/logr v1.2.0
@@ -42,7 +43,6 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.28.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
-	github.com/stretchr/objx v0.2.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.19.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/aws-controllers-k8s/kms-controller v0.0.15 h1:v9LLAE2Q517CvlP80EgXNq2juGCTLUfpn1OjBGY+n8Y=
+github.com/aws-controllers-k8s/kms-controller v0.0.15/go.mod h1:EbxvdZDS2n3JCMmhfjhavSutzt/9J0jXSvGj2bufS68=
 github.com/aws-controllers-k8s/runtime v0.18.4 h1:iwLYNwhbuiWZrHPoulGj75oT+alE91wCNkF1FUELiAw=
 github.com/aws-controllers-k8s/runtime v0.18.4/go.mod h1:oA8ML1/LL3chPn26P6SzBNu1CUI2nekB+PTqykNs0qU=
 github.com/aws/aws-sdk-go v1.42.0 h1:BMZws0t8NAhHFsfnT3B40IwD13jVDG5KerlRksctVIw=

--- a/helm/crds/rds.services.k8s.aws_dbclusters.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbclusters.yaml
@@ -218,6 +218,20 @@ spec:
                   destination Amazon Web Services Region. This KMS key is used to
                   encrypt the read replica in that Amazon Web Services Region."
                 type: string
+              kmsKeyRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               masterUserPassword:
                 description: "The password for the master database user. This password
                   can contain any printable ASCII character except \"/\", \"\"\",

--- a/helm/crds/rds.services.k8s.aws_dbinstances.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbinstances.yaml
@@ -358,6 +358,20 @@ spec:
                   key when this parameter is empty. You must explicitly specify a
                   key."
                 type: string
+              kmsKeyRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               licenseModel:
                 description: "License model information for this DB instance. \n Valid
                   values: license-included | bring-your-own-license | general-public-license

--- a/helm/templates/cluster-role-controller.yaml
+++ b/helm/templates/cluster-role-controller.yaml
@@ -39,6 +39,20 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - kms.services.k8s.aws
+  resources:
+  - keys
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - kms.services.k8s.aws
+  resources:
+  - keys/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - rds.services.k8s.aws
   resources:
   - dbclusterparametergroups

--- a/pkg/resource/db_cluster/delta.go
+++ b/pkg/resource/db_cluster/delta.go
@@ -187,6 +187,9 @@ func newResourceDelta(
 			delta.Add("Spec.KMSKeyID", a.ko.Spec.KMSKeyID, b.ko.Spec.KMSKeyID)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.KMSKeyRef, b.ko.Spec.KMSKeyRef) {
+		delta.Add("Spec.KMSKeyRef", a.ko.Spec.KMSKeyRef, b.ko.Spec.KMSKeyRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.MasterUserPassword, b.ko.Spec.MasterUserPassword) {
 		delta.Add("Spec.MasterUserPassword", a.ko.Spec.MasterUserPassword, b.ko.Spec.MasterUserPassword)
 	} else if a.ko.Spec.MasterUserPassword != nil && b.ko.Spec.MasterUserPassword != nil {

--- a/pkg/resource/db_cluster/references.go
+++ b/pkg/resource/db_cluster/references.go
@@ -17,12 +17,23 @@ package db_cluster
 
 import (
 	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
 )
+
+// +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
+// +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
 
 // ResolveReferences finds if there are any Reference field(s) present
 // inside AWSResource passed in the parameter and attempts to resolve
@@ -36,17 +47,87 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, error) {
-	return res, nil
+	namespace := res.MetaObject().GetNamespace()
+	ko := rm.concreteResource(res).ko.DeepCopy()
+	err := validateReferenceFields(ko)
+	if err == nil {
+		err = resolveReferenceForKMSKeyID(ctx, apiReader, namespace, ko)
+	}
+
+	if hasNonNilReferences(ko) {
+		return ackcondition.WithReferencesResolvedCondition(&resource{ko}, err)
+	}
+	return &resource{ko}, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.DBCluster) error {
+	if ko.Spec.KMSKeyRef != nil && ko.Spec.KMSKeyID != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("KMSKeyID", "KMSKeyRef")
+	}
 	return nil
 }
 
 // hasNonNilReferences returns true if resource contains a reference to another
 // resource
 func hasNonNilReferences(ko *svcapitypes.DBCluster) bool {
-	return false
+	return false || (ko.Spec.KMSKeyRef != nil)
+}
+
+// resolveReferenceForKMSKeyID reads the resource referenced
+// from KMSKeyRef field and sets the KMSKeyID
+// from referenced resource
+func resolveReferenceForKMSKeyID(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.DBCluster,
+) error {
+	if ko.Spec.KMSKeyRef != nil &&
+		ko.Spec.KMSKeyRef.From != nil {
+		arr := ko.Spec.KMSKeyRef.From
+		if arr == nil || arr.Name == nil || *arr.Name == "" {
+			return fmt.Errorf("provided resource reference is nil or empty")
+		}
+		namespacedName := types.NamespacedName{
+			Namespace: namespace,
+			Name:      *arr.Name,
+		}
+		obj := kmsapitypes.Key{}
+		err := apiReader.Get(ctx, namespacedName, &obj)
+		if err != nil {
+			return err
+		}
+		var refResourceSynced, refResourceTerminal bool
+		for _, cond := range obj.Status.Conditions {
+			if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceSynced = true
+			}
+			if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceTerminal = true
+			}
+		}
+		if refResourceTerminal {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Key",
+				namespace, *arr.Name)
+		}
+		if !refResourceSynced {
+			return ackerr.ResourceReferenceNotSyncedFor(
+				"Key",
+				namespace, *arr.Name)
+		}
+		if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+			return ackerr.ResourceReferenceMissingTargetFieldFor(
+				"Key",
+				namespace, *arr.Name,
+				"Status.ACKResourceMetadata.ARN")
+		}
+		referencedValue := string(*obj.Status.ACKResourceMetadata.ARN)
+		ko.Spec.KMSKeyID = &referencedValue
+	}
+	return nil
 }

--- a/pkg/resource/db_instance/delta.go
+++ b/pkg/resource/db_instance/delta.go
@@ -220,6 +220,9 @@ func newResourceDelta(
 			delta.Add("Spec.KMSKeyID", a.ko.Spec.KMSKeyID, b.ko.Spec.KMSKeyID)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.KMSKeyRef, b.ko.Spec.KMSKeyRef) {
+		delta.Add("Spec.KMSKeyRef", a.ko.Spec.KMSKeyRef, b.ko.Spec.KMSKeyRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.LicenseModel, b.ko.Spec.LicenseModel) {
 		delta.Add("Spec.LicenseModel", a.ko.Spec.LicenseModel, b.ko.Spec.LicenseModel)
 	} else if a.ko.Spec.LicenseModel != nil && b.ko.Spec.LicenseModel != nil {

--- a/pkg/resource/db_instance/references.go
+++ b/pkg/resource/db_instance/references.go
@@ -17,12 +17,23 @@ package db_instance
 
 import (
 	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
 )
+
+// +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
+// +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
 
 // ResolveReferences finds if there are any Reference field(s) present
 // inside AWSResource passed in the parameter and attempts to resolve
@@ -36,17 +47,87 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, error) {
-	return res, nil
+	namespace := res.MetaObject().GetNamespace()
+	ko := rm.concreteResource(res).ko.DeepCopy()
+	err := validateReferenceFields(ko)
+	if err == nil {
+		err = resolveReferenceForKMSKeyID(ctx, apiReader, namespace, ko)
+	}
+
+	if hasNonNilReferences(ko) {
+		return ackcondition.WithReferencesResolvedCondition(&resource{ko}, err)
+	}
+	return &resource{ko}, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.DBInstance) error {
+	if ko.Spec.KMSKeyRef != nil && ko.Spec.KMSKeyID != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("KMSKeyID", "KMSKeyRef")
+	}
 	return nil
 }
 
 // hasNonNilReferences returns true if resource contains a reference to another
 // resource
 func hasNonNilReferences(ko *svcapitypes.DBInstance) bool {
-	return false
+	return false || (ko.Spec.KMSKeyRef != nil)
+}
+
+// resolveReferenceForKMSKeyID reads the resource referenced
+// from KMSKeyRef field and sets the KMSKeyID
+// from referenced resource
+func resolveReferenceForKMSKeyID(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.DBInstance,
+) error {
+	if ko.Spec.KMSKeyRef != nil &&
+		ko.Spec.KMSKeyRef.From != nil {
+		arr := ko.Spec.KMSKeyRef.From
+		if arr == nil || arr.Name == nil || *arr.Name == "" {
+			return fmt.Errorf("provided resource reference is nil or empty")
+		}
+		namespacedName := types.NamespacedName{
+			Namespace: namespace,
+			Name:      *arr.Name,
+		}
+		obj := kmsapitypes.Key{}
+		err := apiReader.Get(ctx, namespacedName, &obj)
+		if err != nil {
+			return err
+		}
+		var refResourceSynced, refResourceTerminal bool
+		for _, cond := range obj.Status.Conditions {
+			if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceSynced = true
+			}
+			if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceTerminal = true
+			}
+		}
+		if refResourceTerminal {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Key",
+				namespace, *arr.Name)
+		}
+		if !refResourceSynced {
+			return ackerr.ResourceReferenceNotSyncedFor(
+				"Key",
+				namespace, *arr.Name)
+		}
+		if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+			return ackerr.ResourceReferenceMissingTargetFieldFor(
+				"Key",
+				namespace, *arr.Name,
+				"Status.ACKResourceMetadata.ARN")
+		}
+		referencedValue := string(*obj.Status.ACKResourceMetadata.ARN)
+		ko.Spec.KMSKeyID = &referencedValue
+	}
+	return nil
 }


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1258

Description of changes:
* Add reference for KMSKey inside DBCluster and DBInstance crds
* Currently there is no support to test cross-controller resource reference. Once https://github.com/aws-controllers-k8s/community/issues/1266 is resolved, I will add automated e2e tests
* I manually tested the referencing KMSKey inside DBInstance works as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
