### PR TITLE
support updating tags for DB Parameter Groups

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-04-22T16:22:06Z"
-  build_hash: 302c31fcf0cb7eacf535af8a65569882b3ee0d7c
-  go_version: go1.17.5
-  version: v0.18.4-3-g302c31f
+  build_date: "2022-05-09T20:24:56Z"
+  build_hash: c6efa6ac643edb21219e0763541b2558718b5fe6
+  go_version: go1.18.1
+  version: v0.18.4-10-gc6efa6a
 api_directory_checksum: e7bbd21f4f975f9cf1e1e804ebd450e8e310023d
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 9526e946bbd1d8b3b4c76b010966f6c0158a6941
+  file_checksum: aca88fe4f1fa7b88393cb547b5352b26455f5d20
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -187,6 +187,16 @@ resources:
         DeleteDBParameterGroup:
           input_fields:
             DBParameterGroupName: Name
+    update_operation:
+      # We need a custom update implementation until the issue behind
+      # https://github.com/aws-controllers-k8s/community/issues/869 is
+      # resolved.
+      custom_method_name: customUpdate
+    hooks:
+      sdk_read_many_post_set_output:
+        template_path: hooks/db_parameter_group/sdk_read_many_post_set_output.go.tpl
+      delta_pre_compare:
+        template_path: hooks/db_parameter_group/delta_pre_compare.go.tpl
     fields:
       Name:
         is_primary_key: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -187,6 +187,16 @@ resources:
         DeleteDBParameterGroup:
           input_fields:
             DBParameterGroupName: Name
+    update_operation:
+      # We need a custom update implementation until the issue behind
+      # https://github.com/aws-controllers-k8s/community/issues/869 is
+      # resolved.
+      custom_method_name: customUpdate
+    hooks:
+      sdk_read_many_post_set_output:
+        template_path: hooks/db_parameter_group/sdk_read_many_post_set_output.go.tpl
+      delta_pre_compare:
+        template_path: hooks/db_parameter_group/delta_pre_compare.go.tpl
     fields:
       Name:
         is_primary_key: true

--- a/pkg/resource/db_parameter_group/delta.go
+++ b/pkg/resource/db_parameter_group/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.Description, b.ko.Spec.Description) {
 		delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)

--- a/pkg/resource/db_parameter_group/hooks.go
+++ b/pkg/resource/db_parameter_group/hooks.go
@@ -1,0 +1,216 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package db_parameter_group
+
+import (
+	"context"
+
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+
+	svcapitypes "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
+	svcsdk "github.com/aws/aws-sdk-go/service/rds"
+)
+
+// customUpdate is required to fix
+// https://github.com/aws-controllers-k8s/community/issues/869.
+//
+// We will need to update parameters in a parameter group using custom logic.
+// Until then, however, let's support updating tags for the parameter group.
+func (rm *resourceManager) customUpdate(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	delta *ackcompare.Delta,
+) (updated *resource, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.customUpdate")
+	defer func() {
+		exit(err)
+	}()
+	if delta.DifferentAt("Spec.Tags") {
+		if err = rm.syncTags(ctx, desired, latest); err != nil {
+			return nil, err
+		}
+	}
+	return desired, nil
+}
+
+// syncTags keeps the resource's tags in sync
+//
+// NOTE(jaypipes): RDS' Tagging APIs differ from other AWS APIs in the
+// following ways:
+//
+// 1. The names of the tagging API operations are different. Other APIs use the
+//    Tagris `ListTagsForResource`, `TagResource` and `UntagResource` API
+//    calls. RDS uses `ListTagsForResource`, `AddTagsToResource` and
+//    `RemoveTagsFromResource`.
+//
+// 2. Even though the name of the `ListTagsForResource` API call is the same,
+//    the structure of the input and the output are different from other APIs.
+//    For the input, instead of a `ResourceArn` field, RDS names the field
+//    `ResourceName`, but actually expects an ARN, not the parameter group
+//    name.  This is the same for the `AddTagsToResource` and
+//    `RemoveTagsFromResource` input shapes. For the output shape, the field is
+//    called `TagList` instead of `Tags` but is otherwise the same struct with
+//    a `Key` and `Value` member field.
+func (rm *resourceManager) syncTags(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.syncTags")
+	defer func() { exit(err) }()
+
+	arn := (*string)(latest.ko.Status.ACKResourceMetadata.ARN)
+
+	toAdd, toDelete := computeTagsDelta(
+		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+	)
+
+	if len(toDelete) > 0 {
+		rlog.Debug("removing tags from parameter group", "tags", toDelete)
+		_, err = rm.sdkapi.RemoveTagsFromResourceWithContext(
+			ctx,
+			&svcsdk.RemoveTagsFromResourceInput{
+				ResourceName: arn,
+				TagKeys:      toDelete,
+			},
+		)
+		rm.metrics.RecordAPICall("UPDATE", "RemoveTagsFromResource", err)
+		if err != nil {
+			return err
+		}
+	}
+
+	// NOTE(jaypipes): According to the RDS API documentation, adding a tag
+	// with a new value overwrites any existing tag with the same key. So, we
+	// don't need to do anything to "update" a Tag. Simply including it in the
+	// AddTagsToResource call is enough.
+	if len(toAdd) > 0 {
+		rlog.Debug("adding tags to parameter group", "tags", toAdd)
+		_, err = rm.sdkapi.AddTagsToResourceWithContext(
+			ctx,
+			&svcsdk.AddTagsToResourceInput{
+				ResourceName: arn,
+				Tags:         sdkTagsFromResourceTags(toAdd),
+			},
+		)
+		rm.metrics.RecordAPICall("UPDATE", "AddTagsToResource", err)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// getTags retrieves the resource's associated tags
+func (rm *resourceManager) getTags(
+	ctx context.Context,
+	resourceARN string,
+) ([]*svcapitypes.Tag, error) {
+	resp, err := rm.sdkapi.ListTagsForResourceWithContext(
+		ctx,
+		&svcsdk.ListTagsForResourceInput{
+			ResourceName: &resourceARN,
+		},
+	)
+	rm.metrics.RecordAPICall("GET", "ListTagsForResource", err)
+	if err != nil {
+		return nil, err
+	}
+	tags := make([]*svcapitypes.Tag, 0, len(resp.TagList))
+	for _, tag := range resp.TagList {
+		tags = append(tags, &svcapitypes.Tag{
+			Key:   tag.Key,
+			Value: tag.Value,
+		})
+	}
+	return tags, nil
+}
+
+// compareTags adds a difference to the delta if the supplied resources have
+// different tag collections
+func compareTags(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	} else if len(a.ko.Spec.Tags) > 0 {
+		if !equalTags(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+		}
+	}
+}
+
+// equalTags returns true if two Tag arrays are equal regardless of the order
+// of their elements.
+func equalTags(
+	a []*svcapitypes.Tag,
+	b []*svcapitypes.Tag,
+) bool {
+	added, removed := computeTagsDelta(a, b)
+	return len(added) == 0 && len(removed) == 0
+}
+
+// computeTagsDelta compares two Tag arrays and returns the tags to add and the
+// tag keys to delete
+func computeTagsDelta(
+	desired []*svcapitypes.Tag,
+	latest []*svcapitypes.Tag,
+) (added []*svcapitypes.Tag, removed []*string) {
+	toDelete := []*string{}
+	toAdd := []*svcapitypes.Tag{}
+
+	desiredTags := map[string]string{}
+	for _, tag := range desired {
+		desiredTags[*tag.Key] = *tag.Value
+	}
+
+	for _, tag := range desired {
+		toAdd = append(toAdd, tag)
+	}
+	for _, tag := range latest {
+		_, ok := desiredTags[*tag.Key]
+		if !ok {
+			toDelete = append(toDelete, tag.Key)
+		}
+	}
+	return toAdd, toDelete
+}
+
+// sdkTagsFromResourceTags transforms a *svcapitypes.Tag array to a *svcsdk.Tag
+// array.
+func sdkTagsFromResourceTags(
+	rTags []*svcapitypes.Tag,
+) []*svcsdk.Tag {
+	tags := make([]*svcsdk.Tag, len(rTags))
+	for i := range rTags {
+		tags[i] = &svcsdk.Tag{
+			Key:   rTags[i].Key,
+			Value: rTags[i].Value,
+		}
+	}
+	return tags
+}
+
+func equalStrings(a, b *string) bool {
+	if a == nil {
+		return b == nil || *b == ""
+	}
+	return (*a == "" && b == nil) || *a == *b
+}

--- a/templates/hooks/db_parameter_group/delta_pre_compare.go.tpl
+++ b/templates/hooks/db_parameter_group/delta_pre_compare.go.tpl
@@ -1,0 +1,1 @@
+    compareTags(delta, a, b)

--- a/templates/hooks/db_parameter_group/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/db_parameter_group/sdk_read_many_post_set_output.go.tpl
@@ -1,0 +1,8 @@
+	if ko.Status.ACKResourceMetadata != nil && ko.Status.ACKResourceMetadata.ARN != nil {
+        resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
+        tags, err := rm.getTags(ctx, *resourceARN)
+        if err != nil {
+            return nil, err
+        }
+        ko.Spec.Tags = tags
+	}

--- a/test/e2e/db_parameter_group.py
+++ b/test/e2e/db_parameter_group.py
@@ -1,0 +1,54 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Utilities for working with DB parameter group resources"""
+
+import datetime
+import time
+import typing
+
+import boto3
+import pytest
+
+
+def get(db_parameter_group_name):
+    """Returns a dict containing the DB parameter group record from the RDS
+    API.
+
+    If no such DB parameter group exists, returns None.
+    """
+    c = boto3.client('rds')
+    try:
+        resp = c.describe_db_parameter_groups(
+            DBParameterGroupName=db_parameter_group_name,
+        )
+        assert len(resp['DBParameterGroups']) == 1
+        return resp['DBParameterGroups'][0]
+    except c.exceptions.DBParameterGroupNotFoundFault:
+        return None
+
+
+def get_tags(db_parameter_group_arn):
+    """Returns a dict containing the DB parameter group's tag records from the
+    RDS API.
+
+    If no such DB parameter group exists, returns None.
+    """
+    c = boto3.client('rds')
+    try:
+        resp = c.list_tags_for_resource(
+            ResourceName=db_parameter_group_arn,
+        )
+        return resp['TagList']
+    except c.exceptions.DBParameterGroupNotFoundFault:
+        return None

--- a/test/e2e/resources/db_parameter_group_postgres13_standard.yaml
+++ b/test/e2e/resources/db_parameter_group_postgres13_standard.yaml
@@ -6,3 +6,6 @@ spec:
   name: $DB_PARAMETER_GROUP_NAME
   description: $DB_PARAMETER_GROUP_DESC
   family: postgres13
+  tags:
+    - key: environment
+      value: dev


### PR DESCRIPTION
Adds custom update code to the DBParameterGroup resource manager for
syncing tags. Removes the non-working existing update code in favor of a
`customUpdate` method that only syncs tags.

Issue aws-controllers-k8s/community#1276

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
