### PR TITLE
support tags in DBCluster resources

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-05-09T20:24:56Z"
+  build_date: "2022-05-10T13:35:23Z"
   build_hash: c6efa6ac643edb21219e0763541b2558718b5fe6
   go_version: go1.18.1
   version: v0.18.4-10-gc6efa6a
@@ -7,7 +7,7 @@ api_directory_checksum: e7bbd21f4f975f9cf1e1e804ebd450e8e310023d
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: aca88fe4f1fa7b88393cb547b5352b26455f5d20
+  file_checksum: abea9fcd7e75ec05fc8004dc944a49528ff3652f
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -67,6 +67,8 @@ resources:
       # resolved.
       custom_method_name: customUpdate
     hooks:
+      delta_pre_compare:
+        template_path: hooks/db_cluster/delta_pre_compare.go.tpl
       sdk_create_post_set_output:
         template_path: hooks/db_cluster/sdk_create_post_set_output.go.tpl
       sdk_read_many_post_set_output:

--- a/generator.yaml
+++ b/generator.yaml
@@ -67,6 +67,8 @@ resources:
       # resolved.
       custom_method_name: customUpdate
     hooks:
+      delta_pre_compare:
+        template_path: hooks/db_cluster/delta_pre_compare.go.tpl
       sdk_create_post_set_output:
         template_path: hooks/db_cluster/sdk_create_post_set_output.go.tpl
       sdk_read_many_post_set_output:

--- a/pkg/resource/db_cluster/custom_update.go
+++ b/pkg/resource/db_cluster/custom_update.go
@@ -75,6 +75,11 @@ func (rm *resourceManager) customUpdate(
 	if err != nil {
 		return nil, err
 	}
+	if delta.DifferentAt("Spec.Tags") {
+		if err = rm.syncTags(ctx, desired, latest); err != nil {
+			return nil, err
+		}
+	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
 	ko := desired.ko.DeepCopy()

--- a/pkg/resource/db_cluster/delta.go
+++ b/pkg/resource/db_cluster/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	compareTags(delta, a, b)
 
 	if !ackcompare.SliceStringPEqual(a.ko.Spec.AvailabilityZones, b.ko.Spec.AvailabilityZones) {
 		delta.Add("Spec.AvailabilityZones", a.ko.Spec.AvailabilityZones, b.ko.Spec.AvailabilityZones)

--- a/pkg/resource/db_cluster/hooks.go
+++ b/pkg/resource/db_cluster/hooks.go
@@ -14,10 +14,15 @@
 package db_cluster
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
+	svcapitypes "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	svcsdk "github.com/aws/aws-sdk-go/service/rds"
 )
 
 // NOTE(jaypipes): The below list is derived from looking at the RDS control
@@ -144,4 +149,172 @@ func clusterDeleting(r *resource) bool {
 	}
 	dbcs := *r.ko.Status.Status
 	return dbcs == StatusDeleting
+}
+
+// syncTags keeps the resource's tags in sync
+//
+// NOTE(jaypipes): RDS' Tagging APIs differ from other AWS APIs in the
+// following ways:
+//
+// 1. The names of the tagging API operations are different. Other APIs use the
+//    Tagris `ListTagsForResource`, `TagResource` and `UntagResource` API
+//    calls. RDS uses `ListTagsForResource`, `AddTagsToResource` and
+//    `RemoveTagsFromResource`.
+//
+// 2. Even though the name of the `ListTagsForResource` API call is the same,
+//    the structure of the input and the output are different from other APIs.
+//    For the input, instead of a `ResourceArn` field, RDS names the field
+//    `ResourceName`, but actually expects an ARN, not the cluster
+//    name.  This is the same for the `AddTagsToResource` and
+//    `RemoveTagsFromResource` input shapes. For the output shape, the field is
+//    called `TagList` instead of `Tags` but is otherwise the same struct with
+//    a `Key` and `Value` member field.
+func (rm *resourceManager) syncTags(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.syncTags")
+	defer func() { exit(err) }()
+
+	arn := (*string)(latest.ko.Status.ACKResourceMetadata.ARN)
+
+	toAdd, toDelete := computeTagsDelta(
+		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+	)
+
+	if len(toDelete) > 0 {
+		rlog.Debug("removing tags from cluster", "tags", toDelete)
+		_, err = rm.sdkapi.RemoveTagsFromResourceWithContext(
+			ctx,
+			&svcsdk.RemoveTagsFromResourceInput{
+				ResourceName: arn,
+				TagKeys:      toDelete,
+			},
+		)
+		rm.metrics.RecordAPICall("UPDATE", "RemoveTagsFromResource", err)
+		if err != nil {
+			return err
+		}
+	}
+
+	// NOTE(jaypipes): According to the RDS API documentation, adding a tag
+	// with a new value overwrites any existing tag with the same key. So, we
+	// don't need to do anything to "update" a Tag. Simply including it in the
+	// AddTagsToResource call is enough.
+	if len(toAdd) > 0 {
+		rlog.Debug("adding tags to cluster", "tags", toAdd)
+		_, err = rm.sdkapi.AddTagsToResourceWithContext(
+			ctx,
+			&svcsdk.AddTagsToResourceInput{
+				ResourceName: arn,
+				Tags:         sdkTagsFromResourceTags(toAdd),
+			},
+		)
+		rm.metrics.RecordAPICall("UPDATE", "AddTagsToResource", err)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// getTags retrieves the resource's associated tags
+func (rm *resourceManager) getTags(
+	ctx context.Context,
+	resourceARN string,
+) ([]*svcapitypes.Tag, error) {
+	resp, err := rm.sdkapi.ListTagsForResourceWithContext(
+		ctx,
+		&svcsdk.ListTagsForResourceInput{
+			ResourceName: &resourceARN,
+		},
+	)
+	rm.metrics.RecordAPICall("GET", "ListTagsForResource", err)
+	if err != nil {
+		return nil, err
+	}
+	tags := make([]*svcapitypes.Tag, 0, len(resp.TagList))
+	for _, tag := range resp.TagList {
+		tags = append(tags, &svcapitypes.Tag{
+			Key:   tag.Key,
+			Value: tag.Value,
+		})
+	}
+	return tags, nil
+}
+
+// compareTags adds a difference to the delta if the supplied resources have
+// different tag collections
+func compareTags(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	} else if len(a.ko.Spec.Tags) > 0 {
+		if !equalTags(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+		}
+	}
+}
+
+// equalTags returns true if two Tag arrays are equal regardless of the order
+// of their elements.
+func equalTags(
+	a []*svcapitypes.Tag,
+	b []*svcapitypes.Tag,
+) bool {
+	added, removed := computeTagsDelta(a, b)
+	return len(added) == 0 && len(removed) == 0
+}
+
+// computeTagsDelta compares two Tag arrays and returns the tags to add and the
+// tag keys to delete
+func computeTagsDelta(
+	desired []*svcapitypes.Tag,
+	latest []*svcapitypes.Tag,
+) (added []*svcapitypes.Tag, removed []*string) {
+	toDelete := []*string{}
+	toAdd := []*svcapitypes.Tag{}
+
+	desiredTags := map[string]string{}
+	for _, tag := range desired {
+		desiredTags[*tag.Key] = *tag.Value
+	}
+
+	for _, tag := range desired {
+		toAdd = append(toAdd, tag)
+	}
+	for _, tag := range latest {
+		_, ok := desiredTags[*tag.Key]
+		if !ok {
+			toDelete = append(toDelete, tag.Key)
+		}
+	}
+	return toAdd, toDelete
+}
+
+// sdkTagsFromResourceTags transforms a *svcapitypes.Tag array to a *svcsdk.Tag
+// array.
+func sdkTagsFromResourceTags(
+	rTags []*svcapitypes.Tag,
+) []*svcsdk.Tag {
+	tags := make([]*svcsdk.Tag, len(rTags))
+	for i := range rTags {
+		tags[i] = &svcsdk.Tag{
+			Key:   rTags[i].Key,
+			Value: rTags[i].Value,
+		}
+	}
+	return tags
+}
+
+func equalStrings(a, b *string) bool {
+	if a == nil {
+		return b == nil || *b == ""
+	}
+	return (*a == "" && b == nil) || *a == *b
 }

--- a/pkg/resource/db_cluster/sdk.go
+++ b/pkg/resource/db_cluster/sdk.go
@@ -536,6 +536,14 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	if ko.Status.ACKResourceMetadata != nil && ko.Status.ACKResourceMetadata.ARN != nil {
+		resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
+		tags, err := rm.getTags(ctx, *resourceARN)
+		if err != nil {
+			return nil, err
+		}
+		ko.Spec.Tags = tags
+	}
 	if !clusterAvailable(&resource{ko}) {
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.

--- a/templates/hooks/db_cluster/delta_pre_compare.go.tpl
+++ b/templates/hooks/db_cluster/delta_pre_compare.go.tpl
@@ -1,0 +1,1 @@
+    compareTags(delta, a, b)

--- a/templates/hooks/db_cluster/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/db_cluster/sdk_read_many_post_set_output.go.tpl
@@ -1,3 +1,11 @@
+	if ko.Status.ACKResourceMetadata != nil && ko.Status.ACKResourceMetadata.ARN != nil {
+        resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
+        tags, err := rm.getTags(ctx, *resourceARN)
+        if err != nil {
+            return nil, err
+        }
+        ko.Spec.Tags = tags
+	}
 	if !clusterAvailable(&resource{ko}) {
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.

--- a/test/e2e/db_cluster.py
+++ b/test/e2e/db_cluster.py
@@ -122,3 +122,18 @@ def get(db_cluster_id):
         return resp['DBClusters'][0]
     except c.exceptions.DBClusterNotFoundFault:
         return None
+
+
+def get_tags(db_cluster_arn):
+    """Returns a dict containing the DB cluster's tag records from the RDS API.
+
+    If no such DB cluster exists, returns None.
+    """
+    c = boto3.client('rds')
+    try:
+        resp = c.list_tags_for_resource(
+            ResourceName=db_cluster_arn,
+        )
+        return resp['TagList']
+    except c.exceptions.DBClusterNotFoundFault:
+        return None

--- a/test/e2e/resources/db_cluster_mysql_serverless.yaml
+++ b/test/e2e/resources/db_cluster_mysql_serverless.yaml
@@ -13,3 +13,6 @@ spec:
     namespace: $MASTER_USER_PASS_SECRET_NAMESPACE
     name: $MASTER_USER_PASS_SECRET_NAME
     key: $MASTER_USER_PASS_SECRET_KEY
+  tags:
+    - key: environment
+      value: dev


### PR DESCRIPTION
Adds support for reading and updating tags for DBCluster resources.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
