### PR TITLE
support updating tags on DB cluster param groups

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-05-10T13:35:23Z"
+  build_date: "2022-05-10T15:08:44Z"
   build_hash: c6efa6ac643edb21219e0763541b2558718b5fe6
   go_version: go1.18.1
   version: v0.18.4-10-gc6efa6a
@@ -7,7 +7,7 @@ api_directory_checksum: e7bbd21f4f975f9cf1e1e804ebd450e8e310023d
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: abea9fcd7e75ec05fc8004dc944a49528ff3652f
+  file_checksum: ad1e93741dacbcf19188d95771c12957936a5e1d
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -112,6 +112,16 @@ resources:
         DeleteDBClusterParameterGroup:
           input_fields:
             DBClusterParameterGroupName: Name
+    update_operation:
+      # We need a custom update implementation until the issue behind
+      # https://github.com/aws-controllers-k8s/community/issues/869 is
+      # resolved.
+      custom_method_name: customUpdate
+    hooks:
+      sdk_read_many_post_set_output:
+        template_path: hooks/db_cluster_parameter_group/sdk_read_many_post_set_output.go.tpl
+      delta_pre_compare:
+        template_path: hooks/db_cluster_parameter_group/delta_pre_compare.go.tpl
     fields:
       Name:
         is_primary_key: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -112,6 +112,16 @@ resources:
         DeleteDBClusterParameterGroup:
           input_fields:
             DBClusterParameterGroupName: Name
+    update_operation:
+      # We need a custom update implementation until the issue behind
+      # https://github.com/aws-controllers-k8s/community/issues/869 is
+      # resolved.
+      custom_method_name: customUpdate
+    hooks:
+      sdk_read_many_post_set_output:
+        template_path: hooks/db_cluster_parameter_group/sdk_read_many_post_set_output.go.tpl
+      delta_pre_compare:
+        template_path: hooks/db_cluster_parameter_group/delta_pre_compare.go.tpl
     fields:
       Name:
         is_primary_key: true

--- a/pkg/resource/db_cluster_parameter_group/delta.go
+++ b/pkg/resource/db_cluster_parameter_group/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.Description, b.ko.Spec.Description) {
 		delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)

--- a/pkg/resource/db_cluster_parameter_group/hooks.go
+++ b/pkg/resource/db_cluster_parameter_group/hooks.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package db_parameter_group
+package db_cluster_parameter_group
 
 import (
 	"context"
@@ -81,7 +81,7 @@ func (rm *resourceManager) syncTags(
 	)
 
 	if len(toDelete) > 0 {
-		rlog.Debug("removing tags from parameter group", "tags", toDelete)
+		rlog.Debug("removing tags from cluster parameter group", "tags", toDelete)
 		_, err = rm.sdkapi.RemoveTagsFromResourceWithContext(
 			ctx,
 			&svcsdk.RemoveTagsFromResourceInput{
@@ -100,7 +100,7 @@ func (rm *resourceManager) syncTags(
 	// don't need to do anything to "update" a Tag. Simply including it in the
 	// AddTagsToResource call is enough.
 	if len(toAdd) > 0 {
-		rlog.Debug("adding tags to parameter group", "tags", toAdd)
+		rlog.Debug("adding tags to cluster parameter group", "tags", toAdd)
 		_, err = rm.sdkapi.AddTagsToResourceWithContext(
 			ctx,
 			&svcsdk.AddTagsToResourceInput{

--- a/pkg/resource/db_cluster_parameter_group/sdk.go
+++ b/pkg/resource/db_cluster_parameter_group/sdk.go
@@ -107,6 +107,15 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	if ko.Status.ACKResourceMetadata != nil && ko.Status.ACKResourceMetadata.ARN != nil {
+		resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
+		tags, err := rm.getTags(ctx, *resourceARN)
+		if err != nil {
+			return nil, err
+		}
+		ko.Spec.Tags = tags
+	}
+
 	return &resource{ko}, nil
 }
 
@@ -229,87 +238,8 @@ func (rm *resourceManager) sdkUpdate(
 	desired *resource,
 	latest *resource,
 	delta *ackcompare.Delta,
-) (updated *resource, err error) {
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.sdkUpdate")
-	defer exit(err)
-	input, err := rm.newUpdateRequestPayload(ctx, desired)
-	if err != nil {
-		return nil, err
-	}
-
-	var resp *svcsdk.DBClusterParameterGroupNameMessage
-	_ = resp
-	resp, err = rm.sdkapi.ModifyDBClusterParameterGroupWithContext(ctx, input)
-	rm.metrics.RecordAPICall("UPDATE", "ModifyDBClusterParameterGroup", err)
-	if err != nil {
-		return nil, err
-	}
-	// Merge in the information we read from the API call above to the copy of
-	// the original Kubernetes object we passed to the function
-	ko := desired.ko.DeepCopy()
-
-	rm.setStatusDefaults(ko)
-	return &resource{ko}, nil
-}
-
-// newUpdateRequestPayload returns an SDK-specific struct for the HTTP request
-// payload of the Update API call for the resource
-func (rm *resourceManager) newUpdateRequestPayload(
-	ctx context.Context,
-	r *resource,
-) (*svcsdk.ModifyDBClusterParameterGroupInput, error) {
-	res := &svcsdk.ModifyDBClusterParameterGroupInput{}
-
-	if r.ko.Spec.Parameters != nil {
-		f1 := []*svcsdk.Parameter{}
-		for _, f1iter := range r.ko.Spec.Parameters {
-			f1elem := &svcsdk.Parameter{}
-			if f1iter.AllowedValues != nil {
-				f1elem.SetAllowedValues(*f1iter.AllowedValues)
-			}
-			if f1iter.ApplyMethod != nil {
-				f1elem.SetApplyMethod(*f1iter.ApplyMethod)
-			}
-			if f1iter.ApplyType != nil {
-				f1elem.SetApplyType(*f1iter.ApplyType)
-			}
-			if f1iter.DataType != nil {
-				f1elem.SetDataType(*f1iter.DataType)
-			}
-			if f1iter.Description != nil {
-				f1elem.SetDescription(*f1iter.Description)
-			}
-			if f1iter.IsModifiable != nil {
-				f1elem.SetIsModifiable(*f1iter.IsModifiable)
-			}
-			if f1iter.MinimumEngineVersion != nil {
-				f1elem.SetMinimumEngineVersion(*f1iter.MinimumEngineVersion)
-			}
-			if f1iter.ParameterName != nil {
-				f1elem.SetParameterName(*f1iter.ParameterName)
-			}
-			if f1iter.ParameterValue != nil {
-				f1elem.SetParameterValue(*f1iter.ParameterValue)
-			}
-			if f1iter.Source != nil {
-				f1elem.SetSource(*f1iter.Source)
-			}
-			if f1iter.SupportedEngineModes != nil {
-				f1elemf10 := []*string{}
-				for _, f1elemf10iter := range f1iter.SupportedEngineModes {
-					var f1elemf10elem string
-					f1elemf10elem = *f1elemf10iter
-					f1elemf10 = append(f1elemf10, &f1elemf10elem)
-				}
-				f1elem.SetSupportedEngineModes(f1elemf10)
-			}
-			f1 = append(f1, f1elem)
-		}
-		res.SetParameters(f1)
-	}
-
-	return res, nil
+) (*resource, error) {
+	return rm.customUpdate(ctx, desired, latest, delta)
 }
 
 // sdkDelete deletes the supplied resource in the backend AWS service API

--- a/templates/hooks/db_cluster_parameter_group/delta_pre_compare.go.tpl
+++ b/templates/hooks/db_cluster_parameter_group/delta_pre_compare.go.tpl
@@ -1,0 +1,1 @@
+    compareTags(delta, a, b)

--- a/templates/hooks/db_cluster_parameter_group/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/db_cluster_parameter_group/sdk_read_many_post_set_output.go.tpl
@@ -1,0 +1,8 @@
+	if ko.Status.ACKResourceMetadata != nil && ko.Status.ACKResourceMetadata.ARN != nil {
+        resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
+        tags, err := rm.getTags(ctx, *resourceARN)
+        if err != nil {
+            return nil, err
+        }
+        ko.Spec.Tags = tags
+	}

--- a/test/e2e/db_cluster_parameter_group.py
+++ b/test/e2e/db_cluster_parameter_group.py
@@ -1,0 +1,51 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Utilities for working with DB cluster parameter group resources"""
+
+import boto3
+
+
+def get(db_cluster_parameter_group_name):
+    """Returns a dict containing the DB cluster parameter group record from the
+    RDS API.
+
+    If no such DB cluster parameter group exists, returns None.
+    """
+    c = boto3.client('rds')
+    try:
+        resp = c.describe_db_cluster_parameter_groups(
+            DBClusterParameterGroupName=db_cluster_parameter_group_name,
+        )
+        assert len(resp['DBClusterParameterGroups']) == 1
+        return resp['DBClusterParameterGroups'][0]
+    # NOTE(jaypipes): RDS DescribeDBClusterParameterGroups returns
+    # DBParameterGroupNotFoundFault, *not* DBClusterParameterGroupNotFound.
+    except c.exceptions.DBParameterGroupNotFoundFault:
+        return None
+
+
+def get_tags(db_cluster_parameter_group_arn):
+    """Returns a dict containing the DB cluster parameter group's tag records
+    from the RDS API.
+
+    If no such DB cluster parameter group exists, returns None.
+    """
+    c = boto3.client('rds')
+    try:
+        resp = c.list_tags_for_resource(
+            ResourceName=db_cluster_parameter_group_arn,
+        )
+        return resp['TagList']
+    except c.exceptions.DBParameterGroupNotFoundFault:
+        return None

--- a/test/e2e/db_parameter_group.py
+++ b/test/e2e/db_parameter_group.py
@@ -13,12 +13,7 @@
 
 """Utilities for working with DB parameter group resources"""
 
-import datetime
-import time
-import typing
-
 import boto3
-import pytest
 
 
 def get(db_parameter_group_name):

--- a/test/e2e/resources/db_cluster_parameter_group_aurora_mysql5.7.yaml
+++ b/test/e2e/resources/db_cluster_parameter_group_aurora_mysql5.7.yaml
@@ -6,3 +6,6 @@ spec:
   name: $DB_CLUSTER_PARAMETER_GROUP_NAME
   description: $DB_CLUSTER_PARAMETER_GROUP_DESC
   family: "aurora-mysql5.7"
+  tags:
+    - key: environment
+      value: dev

--- a/test/e2e/tests/test_db_cluster_parameter_group.py
+++ b/test/e2e/tests/test_db_cluster_parameter_group.py
@@ -14,11 +14,8 @@
 """Integration tests for the RDS API DBClusterParameterGroup resource
 """
 
-import boto3
-import datetime
 import logging
 import time
-from typing import Dict
 
 import pytest
 
@@ -26,21 +23,21 @@ from acktest.k8s import resource as k8s
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_rds_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
 from e2e.bootstrap_resources import get_bootstrap_resources
+from e2e import condition
+from e2e import db_cluster_parameter_group
 
 RESOURCE_PLURAL = 'dbclusterparametergroups'
 
 DELETE_WAIT_AFTER_SECONDS = 10
-
-
-@pytest.fixture(scope="module")
-def rds_client():
-    return boto3.client('rds')
+# NOTE(jaypipes): According to the RDS API documentation, updating tags can
+# take several minutes before the new tag values are available due to caching.
+MODIFY_WAIT_AFTER_SECONDS = 180
 
 
 @service_marker
 @pytest.mark.canary
 class TestDBClusterParameterGroup:
-    def test_create_delete_aurora_mysql5_7(self, rds_client):
+    def test_create_delete_aurora_mysql5_7(self):
         resource_name = "aurora-mysql-5-7"
         resource_desc = "Parameters for Aurora MySQL 5.7-compatible"
 
@@ -66,11 +63,39 @@ class TestDBClusterParameterGroup:
         assert k8s.get_resource_exists(ref)
 
         # Let's check that the DB cluster parameter group appears in RDS
-        aws_res = rds_client.describe_db_cluster_parameter_groups(
-            DBClusterParameterGroupName=resource_name,
-        )
-        assert aws_res is not None
-        assert len(aws_res['DBClusterParameterGroups']) == 1
+        latest = db_cluster_parameter_group.get(resource_name)
+        assert latest is not None
+        assert latest['Description'] == resource_desc
+
+        arn = latest['DBClusterParameterGroupArn']
+        expect_tags = [
+            {"Key": "environment", "Value": "dev"}
+        ]
+        latest_tags = db_cluster_parameter_group.get_tags(arn)
+        assert expect_tags == latest_tags
+
+        # OK, now let's update the tag set and check that the tags are
+        # updated accordingly.
+        new_tags = [
+            {
+                "key": "environment",
+                "value": "prod",
+            }
+        ]
+        updates = {
+            "spec": {"tags": new_tags},
+        }
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+
+        latest_tags = db_cluster_parameter_group.get_tags(arn)
+        after_update_expected_tags = [
+            {
+                "Key": "environment",
+                "Value": "prod",
+            }
+        ]
+        assert latest_tags == after_update_expected_tags
 
         # Delete the k8s resource on teardown of the module
         k8s.delete_custom_resource(ref)
@@ -78,12 +103,5 @@ class TestDBClusterParameterGroup:
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
 
         # DB cluster parameter group should no longer appear in RDS
-        try:
-            aws_res = rds_client.describe_db_cluster_parameter_groups(
-                DBClusterParameterGroupName=resource_name,
-            )
-            assert False
-        # NOTE(jaypipes): RDS DescribeDBClusterParameterGroups returns
-        # DBParameterGroupNotFoundFault, *not* DBClusterParameterGroupNotFound.
-        except rds_client.exceptions.DBParameterGroupNotFoundFault:
-            pass
+        latest = db_cluster_parameter_group.get(resource_name)
+        assert latest is None

--- a/test/e2e/tests/test_db_parameter_group.py
+++ b/test/e2e/tests/test_db_parameter_group.py
@@ -14,11 +14,8 @@
 """Integration tests for the RDS API DBParameterGroup resource
 """
 
-import boto3
-import datetime
 import logging
 import time
-from typing import Dict
 
 import pytest
 
@@ -37,15 +34,10 @@ DELETE_WAIT_AFTER_SECONDS = 10
 MODIFY_WAIT_AFTER_SECONDS = 180
 
 
-@pytest.fixture(scope="module")
-def rds_client():
-    return boto3.client('rds')
-
-
 @service_marker
 @pytest.mark.canary
 class TestDBParameterGroup:
-    def test_create_delete_postgres13_standard(self, rds_client):
+    def test_create_delete_postgres13_standard(self):
         resource_name = "pg13-standard"
         resource_desc = "Parameters for PostgreSQL 13"
 
@@ -112,8 +104,5 @@ class TestDBParameterGroup:
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
 
         # DB parameter group should no longer appear in RDS
-        try:
-            aws_res = rds_client.describe_db_parameter_groups(DBParameterGroupName=resource_name)
-            assert False
-        except rds_client.exceptions.DBParameterGroupNotFoundFault:
-            pass
+        latest = db_parameter_group.get(resource_name)
+        assert latest is None


### PR DESCRIPTION
Adds support for updating and retrieving tags for DB cluster parameter
groups.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

Issue aws-controllers-k8s/community#1276

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
