### PR TITLE
Rename EnablePerformanceInsights to PerformanceInsightsEnabled for CreateDBInstance and ModifyDBInstance api

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-05-11T16:29:30Z"
-  build_hash: c6efa6ac643edb21219e0763541b2558718b5fe6
-  go_version: go1.18.1
-  version: v0.18.4-10-gc6efa6a
-api_directory_checksum: e7bbd21f4f975f9cf1e1e804ebd450e8e310023d
+  build_date: "2022-05-18T21:18:00Z"
+  build_hash: c651d2bb60694df1f7a5dad823258472a1a6fc8a
+  go_version: go1.18.2
+  version: v0.18.4-12-gc651d2b
+api_directory_checksum: 932f41dc8e3c84de66ba73cde9eecc2b94c847f3
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 977d8d553f526f7d5b76d8ea9d82e5798de16e39
+  file_checksum: 6f5ece4103c904b1e0417e817cdc437743a85fb3
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/db_instance.go
+++ b/apis/v1alpha1/db_instance.go
@@ -419,12 +419,6 @@ type DBInstanceSpec struct {
 	// (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html)
 	// in the Amazon RDS User Guide.
 	EnableIAMDatabaseAuthentication *bool `json:"enableIAMDatabaseAuthentication,omitempty"`
-	// A value that indicates whether to enable Performance Insights for the DB
-	// instance. For more information, see Using Amazon Performance Insights (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html)
-	// in the Amazon Relational Database Service User Guide.
-	//
-	// This setting doesn't apply to RDS Custom.
-	EnablePerformanceInsights *bool `json:"enablePerformanceInsights,omitempty"`
 	// The name of the database engine to be used for this instance.
 	//
 	// Not every database engine is available for every Amazon Web Services Region.
@@ -690,6 +684,12 @@ type DBInstanceSpec struct {
 	//
 	// This setting doesn't apply to RDS Custom.
 	OptionGroupName *string `json:"optionGroupName,omitempty"`
+	// A value that indicates whether to enable Performance Insights for the DB
+	// instance. For more information, see Using Amazon Performance Insights (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html)
+	// in the Amazon Relational Database Service User Guide.
+	//
+	// This setting doesn't apply to RDS Custom.
+	PerformanceInsightsEnabled *bool `json:"performanceInsightsEnabled,omitempty"`
 	// The Amazon Web Services KMS key identifier for encryption of Performance
 	// Insights data.
 	//
@@ -1029,10 +1029,6 @@ type DBInstanceStatus struct {
 	// by subelements.
 	// +kubebuilder:validation:Optional
 	PendingModifiedValues *PendingModifiedValues `json:"pendingModifiedValues,omitempty"`
-	// True if Performance Insights is enabled for the DB instance, and otherwise
-	// false.
-	// +kubebuilder:validation:Optional
-	PerformanceInsightsEnabled *bool `json:"performanceInsightsEnabled,omitempty"`
 	// Contains one or more identifiers of Aurora DB clusters to which the RDS DB
 	// instance is replicated as a read replica. For example, when you create an
 	// Aurora read replica of an RDS MySQL DB instance, the Aurora MySQL DB cluster

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -178,6 +178,14 @@ resources:
           resource: Key
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
+    renames:
+      operations:
+        CreateDBInstance:
+          input_fields:
+            EnablePerformanceInsights: PerformanceInsightsEnabled
+        ModifyDBInstance:
+          input_fields:
+            EnablePerformanceInsights: PerformanceInsightsEnabled
   GlobalCluster:
     exceptions:
       terminal_codes:

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -2289,11 +2289,6 @@ func (in *DBInstanceSpec) DeepCopyInto(out *DBInstanceSpec) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.EnablePerformanceInsights != nil {
-		in, out := &in.EnablePerformanceInsights, &out.EnablePerformanceInsights
-		*out = new(bool)
-		**out = **in
-	}
 	if in.Engine != nil {
 		in, out := &in.Engine, &out.Engine
 		*out = new(string)
@@ -2362,6 +2357,11 @@ func (in *DBInstanceSpec) DeepCopyInto(out *DBInstanceSpec) {
 	if in.OptionGroupName != nil {
 		in, out := &in.OptionGroupName, &out.OptionGroupName
 		*out = new(string)
+		**out = **in
+	}
+	if in.PerformanceInsightsEnabled != nil {
+		in, out := &in.PerformanceInsightsEnabled, &out.PerformanceInsightsEnabled
+		*out = new(bool)
 		**out = **in
 	}
 	if in.PerformanceInsightsKMSKeyID != nil {
@@ -2655,11 +2655,6 @@ func (in *DBInstanceStatus) DeepCopyInto(out *DBInstanceStatus) {
 		in, out := &in.PendingModifiedValues, &out.PendingModifiedValues
 		*out = new(PendingModifiedValues)
 		(*in).DeepCopyInto(*out)
-	}
-	if in.PerformanceInsightsEnabled != nil {
-		in, out := &in.PerformanceInsightsEnabled, &out.PerformanceInsightsEnabled
-		*out = new(bool)
-		**out = **in
 	}
 	if in.ReadReplicaDBClusterIdentifiers != nil {
 		in, out := &in.ReadReplicaDBClusterIdentifiers, &out.ReadReplicaDBClusterIdentifiers

--- a/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
@@ -284,13 +284,6 @@ spec:
                   for MySQL and PostgreSQL (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html)
                   in the Amazon RDS User Guide."
                 type: boolean
-              enablePerformanceInsights:
-                description: "A value that indicates whether to enable Performance
-                  Insights for the DB instance. For more information, see Using Amazon
-                  Performance Insights (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html)
-                  in the Amazon Relational Database Service User Guide. \n This setting
-                  doesn't apply to RDS Custom."
-                type: boolean
               engine:
                 description: "The name of the database engine to be used for this
                   instance. \n Not every database engine is available for every Amazon
@@ -468,6 +461,13 @@ spec:
                   from a DB instance after it is associated with a DB instance. \n
                   This setting doesn't apply to RDS Custom."
                 type: string
+              performanceInsightsEnabled:
+                description: "A value that indicates whether to enable Performance
+                  Insights for the DB instance. For more information, see Using Amazon
+                  Performance Insights (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html)
+                  in the Amazon Relational Database Service User Guide. \n This setting
+                  doesn't apply to RDS Custom."
+                type: boolean
               performanceInsightsKMSKeyID:
                 description: "The Amazon Web Services KMS key identifier for encryption
                   of Performance Insights data. \n The Amazon Web Services KMS key
@@ -1035,10 +1035,6 @@ spec:
                   storageType:
                     type: string
                 type: object
-              performanceInsightsEnabled:
-                description: True if Performance Insights is enabled for the DB instance,
-                  and otherwise false.
-                type: boolean
               readReplicaDBClusterIdentifiers:
                 description: "Contains one or more identifiers of Aurora DB clusters
                   to which the RDS DB instance is replicated as a read replica. For

--- a/generator.yaml
+++ b/generator.yaml
@@ -178,6 +178,14 @@ resources:
           resource: Key
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
+    renames:
+      operations:
+        CreateDBInstance:
+          input_fields:
+            EnablePerformanceInsights: PerformanceInsightsEnabled
+        ModifyDBInstance:
+          input_fields:
+            EnablePerformanceInsights: PerformanceInsightsEnabled
   GlobalCluster:
     exceptions:
       terminal_codes:

--- a/helm/crds/rds.services.k8s.aws_dbinstances.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbinstances.yaml
@@ -284,13 +284,6 @@ spec:
                   for MySQL and PostgreSQL (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html)
                   in the Amazon RDS User Guide."
                 type: boolean
-              enablePerformanceInsights:
-                description: "A value that indicates whether to enable Performance
-                  Insights for the DB instance. For more information, see Using Amazon
-                  Performance Insights (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html)
-                  in the Amazon Relational Database Service User Guide. \n This setting
-                  doesn't apply to RDS Custom."
-                type: boolean
               engine:
                 description: "The name of the database engine to be used for this
                   instance. \n Not every database engine is available for every Amazon
@@ -468,6 +461,13 @@ spec:
                   from a DB instance after it is associated with a DB instance. \n
                   This setting doesn't apply to RDS Custom."
                 type: string
+              performanceInsightsEnabled:
+                description: "A value that indicates whether to enable Performance
+                  Insights for the DB instance. For more information, see Using Amazon
+                  Performance Insights (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html)
+                  in the Amazon Relational Database Service User Guide. \n This setting
+                  doesn't apply to RDS Custom."
+                type: boolean
               performanceInsightsKMSKeyID:
                 description: "The Amazon Web Services KMS key identifier for encryption
                   of Performance Insights data. \n The Amazon Web Services KMS key
@@ -1035,10 +1035,6 @@ spec:
                   storageType:
                     type: string
                 type: object
-              performanceInsightsEnabled:
-                description: True if Performance Insights is enabled for the DB instance,
-                  and otherwise false.
-                type: boolean
               readReplicaDBClusterIdentifiers:
                 description: "Contains one or more identifiers of Aurora DB clusters
                   to which the RDS DB instance is replicated as a read replica. For

--- a/pkg/resource/db_instance/delta.go
+++ b/pkg/resource/db_instance/delta.go
@@ -185,13 +185,6 @@ func newResourceDelta(
 			delta.Add("Spec.EnableIAMDatabaseAuthentication", a.ko.Spec.EnableIAMDatabaseAuthentication, b.ko.Spec.EnableIAMDatabaseAuthentication)
 		}
 	}
-	if ackcompare.HasNilDifference(a.ko.Spec.EnablePerformanceInsights, b.ko.Spec.EnablePerformanceInsights) {
-		delta.Add("Spec.EnablePerformanceInsights", a.ko.Spec.EnablePerformanceInsights, b.ko.Spec.EnablePerformanceInsights)
-	} else if a.ko.Spec.EnablePerformanceInsights != nil && b.ko.Spec.EnablePerformanceInsights != nil {
-		if *a.ko.Spec.EnablePerformanceInsights != *b.ko.Spec.EnablePerformanceInsights {
-			delta.Add("Spec.EnablePerformanceInsights", a.ko.Spec.EnablePerformanceInsights, b.ko.Spec.EnablePerformanceInsights)
-		}
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Engine, b.ko.Spec.Engine) {
 		delta.Add("Spec.Engine", a.ko.Spec.Engine, b.ko.Spec.Engine)
 	} else if a.ko.Spec.Engine != nil && b.ko.Spec.Engine != nil {
@@ -284,6 +277,13 @@ func newResourceDelta(
 	} else if a.ko.Spec.OptionGroupName != nil && b.ko.Spec.OptionGroupName != nil {
 		if *a.ko.Spec.OptionGroupName != *b.ko.Spec.OptionGroupName {
 			delta.Add("Spec.OptionGroupName", a.ko.Spec.OptionGroupName, b.ko.Spec.OptionGroupName)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.PerformanceInsightsEnabled, b.ko.Spec.PerformanceInsightsEnabled) {
+		delta.Add("Spec.PerformanceInsightsEnabled", a.ko.Spec.PerformanceInsightsEnabled, b.ko.Spec.PerformanceInsightsEnabled)
+	} else if a.ko.Spec.PerformanceInsightsEnabled != nil && b.ko.Spec.PerformanceInsightsEnabled != nil {
+		if *a.ko.Spec.PerformanceInsightsEnabled != *b.ko.Spec.PerformanceInsightsEnabled {
+			delta.Add("Spec.PerformanceInsightsEnabled", a.ko.Spec.PerformanceInsightsEnabled, b.ko.Spec.PerformanceInsightsEnabled)
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.PerformanceInsightsKMSKeyID, b.ko.Spec.PerformanceInsightsKMSKeyID) {

--- a/pkg/resource/db_instance/sdk.go
+++ b/pkg/resource/db_instance/sdk.go
@@ -567,9 +567,9 @@ func (rm *resourceManager) sdkFind(
 			ko.Status.PendingModifiedValues = nil
 		}
 		if elem.PerformanceInsightsEnabled != nil {
-			ko.Status.PerformanceInsightsEnabled = elem.PerformanceInsightsEnabled
+			ko.Spec.PerformanceInsightsEnabled = elem.PerformanceInsightsEnabled
 		} else {
-			ko.Status.PerformanceInsightsEnabled = nil
+			ko.Spec.PerformanceInsightsEnabled = nil
 		}
 		if elem.PerformanceInsightsKMSKeyId != nil {
 			ko.Spec.PerformanceInsightsKMSKeyID = elem.PerformanceInsightsKMSKeyId
@@ -1284,9 +1284,9 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.PendingModifiedValues = nil
 	}
 	if resp.DBInstance.PerformanceInsightsEnabled != nil {
-		ko.Status.PerformanceInsightsEnabled = resp.DBInstance.PerformanceInsightsEnabled
+		ko.Spec.PerformanceInsightsEnabled = resp.DBInstance.PerformanceInsightsEnabled
 	} else {
-		ko.Status.PerformanceInsightsEnabled = nil
+		ko.Spec.PerformanceInsightsEnabled = nil
 	}
 	if resp.DBInstance.PerformanceInsightsKMSKeyId != nil {
 		ko.Spec.PerformanceInsightsKMSKeyID = resp.DBInstance.PerformanceInsightsKMSKeyId
@@ -1545,8 +1545,8 @@ func (rm *resourceManager) newCreateRequestPayload(
 	if r.ko.Spec.EnableIAMDatabaseAuthentication != nil {
 		res.SetEnableIAMDatabaseAuthentication(*r.ko.Spec.EnableIAMDatabaseAuthentication)
 	}
-	if r.ko.Spec.EnablePerformanceInsights != nil {
-		res.SetEnablePerformanceInsights(*r.ko.Spec.EnablePerformanceInsights)
+	if r.ko.Spec.PerformanceInsightsEnabled != nil {
+		res.SetEnablePerformanceInsights(*r.ko.Spec.PerformanceInsightsEnabled)
 	}
 	if r.ko.Spec.Engine != nil {
 		res.SetEngine(*r.ko.Spec.Engine)
@@ -2212,9 +2212,9 @@ func (rm *resourceManager) sdkUpdate(
 		ko.Status.PendingModifiedValues = nil
 	}
 	if resp.DBInstance.PerformanceInsightsEnabled != nil {
-		ko.Status.PerformanceInsightsEnabled = resp.DBInstance.PerformanceInsightsEnabled
+		ko.Spec.PerformanceInsightsEnabled = resp.DBInstance.PerformanceInsightsEnabled
 	} else {
-		ko.Status.PerformanceInsightsEnabled = nil
+		ko.Spec.PerformanceInsightsEnabled = nil
 	}
 	if resp.DBInstance.PerformanceInsightsKMSKeyId != nil {
 		ko.Spec.PerformanceInsightsKMSKeyID = resp.DBInstance.PerformanceInsightsKMSKeyId
@@ -2457,8 +2457,8 @@ func (rm *resourceManager) newUpdateRequestPayload(
 	if r.ko.Spec.EnableIAMDatabaseAuthentication != nil {
 		res.SetEnableIAMDatabaseAuthentication(*r.ko.Spec.EnableIAMDatabaseAuthentication)
 	}
-	if r.ko.Spec.EnablePerformanceInsights != nil {
-		res.SetEnablePerformanceInsights(*r.ko.Spec.EnablePerformanceInsights)
+	if r.ko.Spec.PerformanceInsightsEnabled != nil {
+		res.SetEnablePerformanceInsights(*r.ko.Spec.PerformanceInsightsEnabled)
 	}
 	if r.ko.Spec.EngineVersion != nil {
 		res.SetEngineVersion(*r.ko.Spec.EngineVersion)


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/1251

Rename EnablePerformanceInsights to PerformanceInsightsEnabled for RDS API CreateDBInstance and ModifyDBInstance to avoid conflict with DecribeDBInstance PerformanceInsightsEnabled status

Description of changes:

Rename EnablePerformanceInsights to PerformanceInsightsEnabled for RDS API CreateDBInstance and ModifyDBInstance to avoid conflict with DecribeDBInstance PerformanceInsightsEnabled status

1. make the change in generator.yaml file to rename EnablePerformanceInsights to PerformanceInsightsEnabled
2. run existing rds controller test and passed 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
