### PR TITLE
Add immutable tag to AvailabilityZone in DBInstance

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-05-27T02:20:26Z"
-  build_hash: c651d2bb60694df1f7a5dad823258472a1a6fc8a
+  build_date: "2022-05-27T18:41:36Z"
+  build_hash: 6acf40fe3e3cfd97b799ef7cbf1e89e01c3db8f7
   go_version: go1.18.2
-  version: v0.18.4-12-gc651d2b
-api_directory_checksum: 5e8e1929ea3e768826601ad5737bcf14bcfc4977
+  version: v0.18.4-15-g6acf40f
+api_directory_checksum: 68d22d197b3187ea9f81567aca22f0a95ceaf00a
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 18450c6db05caecfb0d53eec6fdbd80f3f0ce502
+  file_checksum: 89eb9928dcfbe0af48b80281c4fbe934cd7ddb23
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -160,6 +160,7 @@ resources:
     fields:
       AvailabilityZone:
         late_initialize: {}
+        is_immutable: true
       DBInstanceIdentifier:
         is_primary_key: true
       # Because the Create input and Create/Update/ReadOne output shapes for

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -865,7 +865,7 @@ type EventSubscription struct {
 	CustomerAWSID            *string `json:"customerAWSID,omitempty"`
 	Enabled                  *bool   `json:"enabled,omitempty"`
 	EventSubscriptionARN     *string `json:"eventSubscriptionARN,omitempty"`
-	SnsTopicARN              *string `json:"snsTopicARN,omitempty"`
+	SNSTopicARN              *string `json:"snsTopicARN,omitempty"`
 	SourceType               *string `json:"sourceType,omitempty"`
 	Status                   *string `json:"status,omitempty"`
 	SubscriptionCreationTime *string `json:"subscriptionCreationTime,omitempty"`

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -4593,8 +4593,8 @@ func (in *EventSubscription) DeepCopyInto(out *EventSubscription) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.SnsTopicARN != nil {
-		in, out := &in.SnsTopicARN, &out.SnsTopicARN
+	if in.SNSTopicARN != nil {
+		in, out := &in.SNSTopicARN, &out.SNSTopicARN
 		*out = new(string)
 		**out = **in
 	}

--- a/generator.yaml
+++ b/generator.yaml
@@ -160,6 +160,7 @@ resources:
     fields:
       AvailabilityZone:
         late_initialize: {}
+        is_immutable: true
       DBInstanceIdentifier:
         is_primary_key: true
       # Because the Create input and Create/Update/ReadOne output shapes for


### PR DESCRIPTION
Issue #, if available:[ issue-1138 ](https://github.com/aws-controllers-k8s/community/issues/1138)

Description of changes:

Add is_immutable = true for AvailabilityZone in DBInstance CRD. AvailabilityZone is not able to be changed after db instance is created. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
