### PR TITLE
Issue 1251

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-06-07T23:00:05Z"
+  build_date: "2022-06-07T23:05:45Z"
   build_hash: 6acf40fe3e3cfd97b799ef7cbf1e89e01c3db8f7
   go_version: go1.18.2
   version: v0.18.4-15-g6acf40f
@@ -7,7 +7,7 @@ api_directory_checksum: 87b52907f41b223b1f4400eafc338658f3c51487
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 973f4314a60e1212c451f93269d4cd24628e03da
+  file_checksum: 19c51b0a0357ba31224e8e3c0dfe1a36098971b2
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-06-06T20:33:58Z"
+  build_date: "2022-06-07T23:00:05Z"
   build_hash: 6acf40fe3e3cfd97b799ef7cbf1e89e01c3db8f7
   go_version: go1.18.2
   version: v0.18.4-15-g6acf40f
-api_directory_checksum: 4bdcfc19ab3ec6ae11525e6eb3a201e4a25b00fa
+api_directory_checksum: 87b52907f41b223b1f4400eafc338658f3c51487
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: be2f6ab659a5917ad15f559404d76af3a9f03372
+  file_checksum: 973f4314a60e1212c451f93269d4cd24628e03da
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-06-02T18:10:06Z"
+  build_date: "2022-06-06T20:33:58Z"
   build_hash: 6acf40fe3e3cfd97b799ef7cbf1e89e01c3db8f7
   go_version: go1.18.2
   version: v0.18.4-15-g6acf40f
-api_directory_checksum: f8a740e73423e911df6a1b5fbcb9fbbb03cd9899
+api_directory_checksum: 4bdcfc19ab3ec6ae11525e6eb3a201e4a25b00fa
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: c9f1d6ca4596ac8e84312495f50a8b901843744f
+  file_checksum: be2f6ab659a5917ad15f559404d76af3a9f03372
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/db_instance.go
+++ b/apis/v1alpha1/db_instance.go
@@ -424,6 +424,12 @@ type DBInstanceSpec struct {
 	// (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html)
 	// in the Amazon RDS User Guide.
 	EnableIAMDatabaseAuthentication *bool `json:"enableIAMDatabaseAuthentication,omitempty"`
+	// A value that indicates whether to enable Performance Insights for the DB
+	// instance. For more information, see Using Amazon Performance Insights (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html)
+	// in the Amazon Relational Database Service User Guide.
+	//
+	// This setting doesn't apply to RDS Custom.
+	EnablePerformanceInsights *bool `json:"enablePerformanceInsights,omitempty"`
 	// The name of the database engine to be used for this instance.
 	//
 	// Not every database engine is available for every Amazon Web Services Region.
@@ -689,12 +695,6 @@ type DBInstanceSpec struct {
 	//
 	// This setting doesn't apply to RDS Custom.
 	OptionGroupName *string `json:"optionGroupName,omitempty"`
-	// A value that indicates whether to enable Performance Insights for the DB
-	// instance. For more information, see Using Amazon Performance Insights (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html)
-	// in the Amazon Relational Database Service User Guide.
-	//
-	// This setting doesn't apply to RDS Custom.
-	PerformanceInsightsEnabled *bool `json:"performanceInsightsEnabled,omitempty"`
 	// The Amazon Web Services KMS key identifier for encryption of Performance
 	// Insights data.
 	//
@@ -1039,6 +1039,10 @@ type DBInstanceStatus struct {
 	// by subelements.
 	// +kubebuilder:validation:Optional
 	PendingModifiedValues *PendingModifiedValues `json:"pendingModifiedValues,omitempty"`
+	// True if Performance Insights is enabled for the DB instance, and otherwise
+	// false.
+	// +kubebuilder:validation:Optional
+	PerformanceInsightsEnabled *bool `json:"performanceInsightsEnabled,omitempty"`
 	// Contains one or more identifiers of Aurora DB clusters to which the RDS DB
 	// instance is replicated as a read replica. For example, when you create an
 	// Aurora read replica of an RDS MySQL DB instance, the Aurora MySQL DB cluster

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -179,6 +179,10 @@ resources:
         from:
           operation: RestoreDBInstanceFromDBSnapshot
           path: UseDefaultProcessorFeatures
+      PerformanceInsightsKMSKeyID:
+        late_initialize: {}
+      PerformanceInsightsRetentionPeriod:
+        late_initialize: {}
     renames:
       operations:
         CreateDBInstance:

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -35,6 +35,11 @@ operations:
       # makes to a resource's Spec to be reconciled by the ACK service
       # controller, not a different service.
       ApplyImmediately: true
+      # We override the value of AllowMajorVersionUpgrade field in the modify
+      # call since any engine version change should apply directly.
+      # This flag was designed as a protect flag but not necessary in controller
+      # side when customer need to make the engine version change
+      AllowMajorVersionUpgrade: true
   DeleteDBCluster:
     override_values:
       # Clearly this is not ideal, but will suffice until we add custom hook
@@ -55,6 +60,10 @@ operations:
       # makes to a resource's Spec to be reconciled by the ACK service
       # controller, not a different service.
       ApplyImmediately: true
+      # We override the value of the ApplyImmediately field in the modify
+      # operations to "true" because we want changes that a Kubernetes user
+      # makes to a resource's Spec to be reconciled by the ACK service
+      # controller, not a different service.
       AllowMajorVersionUpgrade: true
   DeleteDBInstance:
     override_values:

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -55,6 +55,7 @@ operations:
       # makes to a resource's Spec to be reconciled by the ACK service
       # controller, not a different service.
       ApplyImmediately: true
+      AllowMajorVersionUpgrade: true
   DeleteDBInstance:
     override_values:
       # Clearly this is not ideal, but will suffice until we add custom hook
@@ -179,18 +180,6 @@ resources:
         from:
           operation: RestoreDBInstanceFromDBSnapshot
           path: UseDefaultProcessorFeatures
-      PerformanceInsightsKMSKeyID:
-        late_initialize: {}
-      PerformanceInsightsRetentionPeriod:
-        late_initialize: {}
-    renames:
-      operations:
-        CreateDBInstance:
-          input_fields:
-            EnablePerformanceInsights: PerformanceInsightsEnabled
-        ModifyDBInstance:
-          input_fields:
-            EnablePerformanceInsights: PerformanceInsightsEnabled
   GlobalCluster:
     exceptions:
       terminal_codes:

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -2283,6 +2283,11 @@ func (in *DBInstanceSpec) DeepCopyInto(out *DBInstanceSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnablePerformanceInsights != nil {
+		in, out := &in.EnablePerformanceInsights, &out.EnablePerformanceInsights
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Engine != nil {
 		in, out := &in.Engine, &out.Engine
 		*out = new(string)
@@ -2351,11 +2356,6 @@ func (in *DBInstanceSpec) DeepCopyInto(out *DBInstanceSpec) {
 	if in.OptionGroupName != nil {
 		in, out := &in.OptionGroupName, &out.OptionGroupName
 		*out = new(string)
-		**out = **in
-	}
-	if in.PerformanceInsightsEnabled != nil {
-		in, out := &in.PerformanceInsightsEnabled, &out.PerformanceInsightsEnabled
-		*out = new(bool)
 		**out = **in
 	}
 	if in.PerformanceInsightsKMSKeyID != nil {
@@ -2654,6 +2654,11 @@ func (in *DBInstanceStatus) DeepCopyInto(out *DBInstanceStatus) {
 		in, out := &in.PendingModifiedValues, &out.PendingModifiedValues
 		*out = new(PendingModifiedValues)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.PerformanceInsightsEnabled != nil {
+		in, out := &in.PerformanceInsightsEnabled, &out.PerformanceInsightsEnabled
+		*out = new(bool)
+		**out = **in
 	}
 	if in.ReadReplicaDBClusterIdentifiers != nil {
 		in, out := &in.ReadReplicaDBClusterIdentifiers, &out.ReadReplicaDBClusterIdentifiers

--- a/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
@@ -284,6 +284,13 @@ spec:
                   for MySQL and PostgreSQL (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html)
                   in the Amazon RDS User Guide."
                 type: boolean
+              enablePerformanceInsights:
+                description: "A value that indicates whether to enable Performance
+                  Insights for the DB instance. For more information, see Using Amazon
+                  Performance Insights (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html)
+                  in the Amazon Relational Database Service User Guide. \n This setting
+                  doesn't apply to RDS Custom."
+                type: boolean
               engine:
                 description: "The name of the database engine to be used for this
                   instance. \n Not every database engine is available for every Amazon
@@ -461,13 +468,6 @@ spec:
                   from a DB instance after it is associated with a DB instance. \n
                   This setting doesn't apply to RDS Custom."
                 type: string
-              performanceInsightsEnabled:
-                description: "A value that indicates whether to enable Performance
-                  Insights for the DB instance. For more information, see Using Amazon
-                  Performance Insights (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html)
-                  in the Amazon Relational Database Service User Guide. \n This setting
-                  doesn't apply to RDS Custom."
-                type: boolean
               performanceInsightsKMSKeyID:
                 description: "The Amazon Web Services KMS key identifier for encryption
                   of Performance Insights data. \n The Amazon Web Services KMS key
@@ -1040,6 +1040,10 @@ spec:
                   storageType:
                     type: string
                 type: object
+              performanceInsightsEnabled:
+                description: True if Performance Insights is enabled for the DB instance,
+                  and otherwise false.
+                type: boolean
               readReplicaDBClusterIdentifiers:
                 description: "Contains one or more identifiers of Aurora DB clusters
                   to which the RDS DB instance is replicated as a read replica. For

--- a/generator.yaml
+++ b/generator.yaml
@@ -179,6 +179,10 @@ resources:
         from:
           operation: RestoreDBInstanceFromDBSnapshot
           path: UseDefaultProcessorFeatures
+      PerformanceInsightsKMSKeyID:
+        late_initialize: {}
+      PerformanceInsightsRetentionPeriod:
+        late_initialize: {}
     renames:
       operations:
         CreateDBInstance:

--- a/generator.yaml
+++ b/generator.yaml
@@ -35,6 +35,11 @@ operations:
       # makes to a resource's Spec to be reconciled by the ACK service
       # controller, not a different service.
       ApplyImmediately: true
+      # We override the value of AllowMajorVersionUpgrade field in the modify
+      # call since any engine version change should apply directly.
+      # This flag was designed as a protect flag but not necessary in controller
+      # side when customer need to make the engine version change
+      AllowMajorVersionUpgrade: true
   DeleteDBCluster:
     override_values:
       # Clearly this is not ideal, but will suffice until we add custom hook
@@ -55,6 +60,10 @@ operations:
       # makes to a resource's Spec to be reconciled by the ACK service
       # controller, not a different service.
       ApplyImmediately: true
+      # We override the value of the ApplyImmediately field in the modify
+      # operations to "true" because we want changes that a Kubernetes user
+      # makes to a resource's Spec to be reconciled by the ACK service
+      # controller, not a different service.
       AllowMajorVersionUpgrade: true
   DeleteDBInstance:
     override_values:

--- a/generator.yaml
+++ b/generator.yaml
@@ -55,6 +55,7 @@ operations:
       # makes to a resource's Spec to be reconciled by the ACK service
       # controller, not a different service.
       ApplyImmediately: true
+      AllowMajorVersionUpgrade: true
   DeleteDBInstance:
     override_values:
       # Clearly this is not ideal, but will suffice until we add custom hook
@@ -179,18 +180,6 @@ resources:
         from:
           operation: RestoreDBInstanceFromDBSnapshot
           path: UseDefaultProcessorFeatures
-      PerformanceInsightsKMSKeyID:
-        late_initialize: {}
-      PerformanceInsightsRetentionPeriod:
-        late_initialize: {}
-    renames:
-      operations:
-        CreateDBInstance:
-          input_fields:
-            EnablePerformanceInsights: PerformanceInsightsEnabled
-        ModifyDBInstance:
-          input_fields:
-            EnablePerformanceInsights: PerformanceInsightsEnabled
   GlobalCluster:
     exceptions:
       terminal_codes:

--- a/generator.yaml
+++ b/generator.yaml
@@ -60,10 +60,10 @@ operations:
       # makes to a resource's Spec to be reconciled by the ACK service
       # controller, not a different service.
       ApplyImmediately: true
-      # We override the value of the ApplyImmediately field in the modify
-      # operations to "true" because we want changes that a Kubernetes user
-      # makes to a resource's Spec to be reconciled by the ACK service
-      # controller, not a different service.
+      # We override the value of AllowMajorVersionUpgrade field in the modify
+      # call since any engine version change should apply directly.
+      # This flag was designed as a protect flag but not necessary in controller
+      # side when customer need to make the engine version change
       AllowMajorVersionUpgrade: true
   DeleteDBInstance:
     override_values:

--- a/helm/crds/rds.services.k8s.aws_dbinstances.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbinstances.yaml
@@ -284,6 +284,13 @@ spec:
                   for MySQL and PostgreSQL (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html)
                   in the Amazon RDS User Guide."
                 type: boolean
+              enablePerformanceInsights:
+                description: "A value that indicates whether to enable Performance
+                  Insights for the DB instance. For more information, see Using Amazon
+                  Performance Insights (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html)
+                  in the Amazon Relational Database Service User Guide. \n This setting
+                  doesn't apply to RDS Custom."
+                type: boolean
               engine:
                 description: "The name of the database engine to be used for this
                   instance. \n Not every database engine is available for every Amazon
@@ -461,13 +468,6 @@ spec:
                   from a DB instance after it is associated with a DB instance. \n
                   This setting doesn't apply to RDS Custom."
                 type: string
-              performanceInsightsEnabled:
-                description: "A value that indicates whether to enable Performance
-                  Insights for the DB instance. For more information, see Using Amazon
-                  Performance Insights (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html)
-                  in the Amazon Relational Database Service User Guide. \n This setting
-                  doesn't apply to RDS Custom."
-                type: boolean
               performanceInsightsKMSKeyID:
                 description: "The Amazon Web Services KMS key identifier for encryption
                   of Performance Insights data. \n The Amazon Web Services KMS key
@@ -1040,6 +1040,10 @@ spec:
                   storageType:
                     type: string
                 type: object
+              performanceInsightsEnabled:
+                description: True if Performance Insights is enabled for the DB instance,
+                  and otherwise false.
+                type: boolean
               readReplicaDBClusterIdentifiers:
                 description: "Contains one or more identifiers of Aurora DB clusters
                   to which the RDS DB instance is replicated as a read replica. For

--- a/pkg/resource/db_instance/delta.go
+++ b/pkg/resource/db_instance/delta.go
@@ -189,6 +189,13 @@ func newResourceDelta(
 			delta.Add("Spec.EnableIAMDatabaseAuthentication", a.ko.Spec.EnableIAMDatabaseAuthentication, b.ko.Spec.EnableIAMDatabaseAuthentication)
 		}
 	}
+	if ackcompare.HasNilDifference(a.ko.Spec.EnablePerformanceInsights, b.ko.Spec.EnablePerformanceInsights) {
+		delta.Add("Spec.EnablePerformanceInsights", a.ko.Spec.EnablePerformanceInsights, b.ko.Spec.EnablePerformanceInsights)
+	} else if a.ko.Spec.EnablePerformanceInsights != nil && b.ko.Spec.EnablePerformanceInsights != nil {
+		if *a.ko.Spec.EnablePerformanceInsights != *b.ko.Spec.EnablePerformanceInsights {
+			delta.Add("Spec.EnablePerformanceInsights", a.ko.Spec.EnablePerformanceInsights, b.ko.Spec.EnablePerformanceInsights)
+		}
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Engine, b.ko.Spec.Engine) {
 		delta.Add("Spec.Engine", a.ko.Spec.Engine, b.ko.Spec.Engine)
 	} else if a.ko.Spec.Engine != nil && b.ko.Spec.Engine != nil {
@@ -281,13 +288,6 @@ func newResourceDelta(
 	} else if a.ko.Spec.OptionGroupName != nil && b.ko.Spec.OptionGroupName != nil {
 		if *a.ko.Spec.OptionGroupName != *b.ko.Spec.OptionGroupName {
 			delta.Add("Spec.OptionGroupName", a.ko.Spec.OptionGroupName, b.ko.Spec.OptionGroupName)
-		}
-	}
-	if ackcompare.HasNilDifference(a.ko.Spec.PerformanceInsightsEnabled, b.ko.Spec.PerformanceInsightsEnabled) {
-		delta.Add("Spec.PerformanceInsightsEnabled", a.ko.Spec.PerformanceInsightsEnabled, b.ko.Spec.PerformanceInsightsEnabled)
-	} else if a.ko.Spec.PerformanceInsightsEnabled != nil && b.ko.Spec.PerformanceInsightsEnabled != nil {
-		if *a.ko.Spec.PerformanceInsightsEnabled != *b.ko.Spec.PerformanceInsightsEnabled {
-			delta.Add("Spec.PerformanceInsightsEnabled", a.ko.Spec.PerformanceInsightsEnabled, b.ko.Spec.PerformanceInsightsEnabled)
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.PerformanceInsightsKMSKeyID, b.ko.Spec.PerformanceInsightsKMSKeyID) {

--- a/pkg/resource/db_instance/manager.go
+++ b/pkg/resource/db_instance/manager.go
@@ -45,7 +45,7 @@ var (
 // +kubebuilder:rbac:groups=rds.services.k8s.aws,resources=dbinstances,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rds.services.k8s.aws,resources=dbinstances/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{"AvailabilityZone", "PerformanceInsightsKMSKeyID", "PerformanceInsightsRetentionPeriod"}
+var lateInitializeFieldNames = []string{"AvailabilityZone"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -240,12 +240,6 @@ func (rm *resourceManager) incompleteLateInitialization(
 	if ko.Spec.AvailabilityZone == nil {
 		return true
 	}
-	if ko.Spec.PerformanceInsightsKMSKeyID == nil {
-		return true
-	}
-	if ko.Spec.PerformanceInsightsRetentionPeriod == nil {
-		return true
-	}
 	return false
 }
 
@@ -259,12 +253,6 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	latestKo := rm.concreteResource(latest).ko.DeepCopy()
 	if observedKo.Spec.AvailabilityZone != nil && latestKo.Spec.AvailabilityZone == nil {
 		latestKo.Spec.AvailabilityZone = observedKo.Spec.AvailabilityZone
-	}
-	if observedKo.Spec.PerformanceInsightsKMSKeyID != nil && latestKo.Spec.PerformanceInsightsKMSKeyID == nil {
-		latestKo.Spec.PerformanceInsightsKMSKeyID = observedKo.Spec.PerformanceInsightsKMSKeyID
-	}
-	if observedKo.Spec.PerformanceInsightsRetentionPeriod != nil && latestKo.Spec.PerformanceInsightsRetentionPeriod == nil {
-		latestKo.Spec.PerformanceInsightsRetentionPeriod = observedKo.Spec.PerformanceInsightsRetentionPeriod
 	}
 	return &resource{latestKo}
 }

--- a/pkg/resource/db_instance/manager.go
+++ b/pkg/resource/db_instance/manager.go
@@ -45,7 +45,7 @@ var (
 // +kubebuilder:rbac:groups=rds.services.k8s.aws,resources=dbinstances,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rds.services.k8s.aws,resources=dbinstances/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{"AvailabilityZone"}
+var lateInitializeFieldNames = []string{"AvailabilityZone", "PerformanceInsightsKMSKeyID", "PerformanceInsightsRetentionPeriod"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -240,6 +240,12 @@ func (rm *resourceManager) incompleteLateInitialization(
 	if ko.Spec.AvailabilityZone == nil {
 		return true
 	}
+	if ko.Spec.PerformanceInsightsKMSKeyID == nil {
+		return true
+	}
+	if ko.Spec.PerformanceInsightsRetentionPeriod == nil {
+		return true
+	}
 	return false
 }
 
@@ -253,6 +259,12 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	latestKo := rm.concreteResource(latest).ko.DeepCopy()
 	if observedKo.Spec.AvailabilityZone != nil && latestKo.Spec.AvailabilityZone == nil {
 		latestKo.Spec.AvailabilityZone = observedKo.Spec.AvailabilityZone
+	}
+	if observedKo.Spec.PerformanceInsightsKMSKeyID != nil && latestKo.Spec.PerformanceInsightsKMSKeyID == nil {
+		latestKo.Spec.PerformanceInsightsKMSKeyID = observedKo.Spec.PerformanceInsightsKMSKeyID
+	}
+	if observedKo.Spec.PerformanceInsightsRetentionPeriod != nil && latestKo.Spec.PerformanceInsightsRetentionPeriod == nil {
+		latestKo.Spec.PerformanceInsightsRetentionPeriod = observedKo.Spec.PerformanceInsightsRetentionPeriod
 	}
 	return &resource{latestKo}
 }

--- a/pkg/resource/db_instance/sdk.go
+++ b/pkg/resource/db_instance/sdk.go
@@ -556,9 +556,9 @@ func (rm *resourceManager) sdkFind(
 			ko.Status.PendingModifiedValues = nil
 		}
 		if elem.PerformanceInsightsEnabled != nil {
-			ko.Spec.PerformanceInsightsEnabled = elem.PerformanceInsightsEnabled
+			ko.Status.PerformanceInsightsEnabled = elem.PerformanceInsightsEnabled
 		} else {
-			ko.Spec.PerformanceInsightsEnabled = nil
+			ko.Status.PerformanceInsightsEnabled = nil
 		}
 		if elem.PerformanceInsightsKMSKeyId != nil {
 			ko.Spec.PerformanceInsightsKMSKeyID = elem.PerformanceInsightsKMSKeyId
@@ -1269,9 +1269,9 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.PendingModifiedValues = nil
 	}
 	if resp.DBInstance.PerformanceInsightsEnabled != nil {
-		ko.Spec.PerformanceInsightsEnabled = resp.DBInstance.PerformanceInsightsEnabled
+		ko.Status.PerformanceInsightsEnabled = resp.DBInstance.PerformanceInsightsEnabled
 	} else {
-		ko.Spec.PerformanceInsightsEnabled = nil
+		ko.Status.PerformanceInsightsEnabled = nil
 	}
 	if resp.DBInstance.PerformanceInsightsKMSKeyId != nil {
 		ko.Spec.PerformanceInsightsKMSKeyID = resp.DBInstance.PerformanceInsightsKMSKeyId
@@ -1521,8 +1521,8 @@ func (rm *resourceManager) newCreateRequestPayload(
 	if r.ko.Spec.EnableIAMDatabaseAuthentication != nil {
 		res.SetEnableIAMDatabaseAuthentication(*r.ko.Spec.EnableIAMDatabaseAuthentication)
 	}
-	if r.ko.Spec.PerformanceInsightsEnabled != nil {
-		res.SetEnablePerformanceInsights(*r.ko.Spec.PerformanceInsightsEnabled)
+	if r.ko.Spec.EnablePerformanceInsights != nil {
+		res.SetEnablePerformanceInsights(*r.ko.Spec.EnablePerformanceInsights)
 	}
 	if r.ko.Spec.Engine != nil {
 		res.SetEngine(*r.ko.Spec.Engine)
@@ -2178,9 +2178,9 @@ func (rm *resourceManager) sdkUpdate(
 		ko.Status.PendingModifiedValues = nil
 	}
 	if resp.DBInstance.PerformanceInsightsEnabled != nil {
-		ko.Spec.PerformanceInsightsEnabled = resp.DBInstance.PerformanceInsightsEnabled
+		ko.Status.PerformanceInsightsEnabled = resp.DBInstance.PerformanceInsightsEnabled
 	} else {
-		ko.Spec.PerformanceInsightsEnabled = nil
+		ko.Status.PerformanceInsightsEnabled = nil
 	}
 	if resp.DBInstance.PerformanceInsightsKMSKeyId != nil {
 		ko.Spec.PerformanceInsightsKMSKeyID = resp.DBInstance.PerformanceInsightsKMSKeyId
@@ -2368,6 +2368,7 @@ func (rm *resourceManager) newUpdateRequestPayload(
 	if r.ko.Spec.AllocatedStorage != nil {
 		res.SetAllocatedStorage(*r.ko.Spec.AllocatedStorage)
 	}
+	res.SetAllowMajorVersionUpgrade(true)
 	res.SetApplyImmediately(true)
 	if r.ko.Spec.AutoMinorVersionUpgrade != nil {
 		res.SetAutoMinorVersionUpgrade(*r.ko.Spec.AutoMinorVersionUpgrade)
@@ -2414,8 +2415,8 @@ func (rm *resourceManager) newUpdateRequestPayload(
 	if r.ko.Spec.EnableIAMDatabaseAuthentication != nil {
 		res.SetEnableIAMDatabaseAuthentication(*r.ko.Spec.EnableIAMDatabaseAuthentication)
 	}
-	if r.ko.Spec.PerformanceInsightsEnabled != nil {
-		res.SetEnablePerformanceInsights(*r.ko.Spec.PerformanceInsightsEnabled)
+	if r.ko.Spec.EnablePerformanceInsights != nil {
+		res.SetEnablePerformanceInsights(*r.ko.Spec.EnablePerformanceInsights)
 	}
 	if r.ko.Spec.EngineVersion != nil {
 		res.SetEngineVersion(*r.ko.Spec.EngineVersion)
@@ -3337,9 +3338,9 @@ func (rm *resourceManager) setResourceFromRestoreDBInstanceFromDBSnapshotOutput(
 		r.ko.Status.PendingModifiedValues = nil
 	}
 	if resp.DBInstance.PerformanceInsightsEnabled != nil {
-		r.ko.Spec.PerformanceInsightsEnabled = resp.DBInstance.PerformanceInsightsEnabled
+		r.ko.Status.PerformanceInsightsEnabled = resp.DBInstance.PerformanceInsightsEnabled
 	} else {
-		r.ko.Spec.PerformanceInsightsEnabled = nil
+		r.ko.Status.PerformanceInsightsEnabled = nil
 	}
 	if resp.DBInstance.PerformanceInsightsKMSKeyId != nil {
 		r.ko.Spec.PerformanceInsightsKMSKeyID = resp.DBInstance.PerformanceInsightsKMSKeyId


### PR DESCRIPTION
Issue #, if available:
both
https://github.com/aws-controllers-k8s/community/issues/1265
and
https://github.com/aws-controllers-k8s/community/issues/1251

Description of changes:
1. For issue 1251, the root cause is found an addressed here https://github.com/aws-controllers-k8s/runtime/pull/92, so this pr will remove the unnecessary rename PI part, also we don't need to rename for other fields like enableIAM, enableCloudWatch as well. 

2. During engine version testing, 1265 is a low hanging fruit, we just need override AllowMajorVersionUpgrade to true so customer can do major version upgrade. This flag AllowMajorVersionUpgrade was designed to protect instance from accidentally upgrade , but it's not applying to controller, we can override it to true as always. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
