### PR TITLE
Allow major version upgrade by setting AllowMajorVersionUpgrade to true

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-06-08T00:23:42Z"
+  build_date: "2022-06-08T02:04:16Z"
   build_hash: 6acf40fe3e3cfd97b799ef7cbf1e89e01c3db8f7
   go_version: go1.18.2
   version: v0.18.4-15-g6acf40f

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-06-02T18:10:06Z"
+  build_date: "2022-06-08T00:23:42Z"
   build_hash: 6acf40fe3e3cfd97b799ef7cbf1e89e01c3db8f7
   go_version: go1.18.2
   version: v0.18.4-15-g6acf40f
-api_directory_checksum: f8a740e73423e911df6a1b5fbcb9fbbb03cd9899
+api_directory_checksum: 4bdcfc19ab3ec6ae11525e6eb3a201e4a25b00fa
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: c9f1d6ca4596ac8e84312495f50a8b901843744f
+  file_checksum: a014f16db9e990ad756052e50cbce7d0d9b84c0b
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -35,6 +35,11 @@ operations:
       # makes to a resource's Spec to be reconciled by the ACK service
       # controller, not a different service.
       ApplyImmediately: true
+      # We override the value of AllowMajorVersionUpgrade field in the modify
+      # call since any engine version change should apply directly.
+      # This flag was designed as a protect flag but not necessary in controller
+      # side when customer need to make the engine version change
+      AllowMajorVersionUpgrade: true
   DeleteDBCluster:
     override_values:
       # Clearly this is not ideal, but will suffice until we add custom hook
@@ -55,6 +60,11 @@ operations:
       # makes to a resource's Spec to be reconciled by the ACK service
       # controller, not a different service.
       ApplyImmediately: true
+      # We override the value of the ApplyImmediately field in the modify
+      # operations to "true" because we want changes that a Kubernetes user
+      # makes to a resource's Spec to be reconciled by the ACK service
+      # controller, not a different service.
+      AllowMajorVersionUpgrade: true
   DeleteDBInstance:
     override_values:
       # Clearly this is not ideal, but will suffice until we add custom hook

--- a/generator.yaml
+++ b/generator.yaml
@@ -35,6 +35,11 @@ operations:
       # makes to a resource's Spec to be reconciled by the ACK service
       # controller, not a different service.
       ApplyImmediately: true
+      # We override the value of AllowMajorVersionUpgrade field in the modify
+      # call since any engine version change should apply directly.
+      # This flag was designed as a protect flag but not necessary in controller
+      # side when customer need to make the engine version change
+      AllowMajorVersionUpgrade: true
   DeleteDBCluster:
     override_values:
       # Clearly this is not ideal, but will suffice until we add custom hook
@@ -55,6 +60,11 @@ operations:
       # makes to a resource's Spec to be reconciled by the ACK service
       # controller, not a different service.
       ApplyImmediately: true
+      # We override the value of the ApplyImmediately field in the modify
+      # operations to "true" because we want changes that a Kubernetes user
+      # makes to a resource's Spec to be reconciled by the ACK service
+      # controller, not a different service.
+      AllowMajorVersionUpgrade: true
   DeleteDBInstance:
     override_values:
       # Clearly this is not ideal, but will suffice until we add custom hook

--- a/pkg/resource/db_cluster/custom_update.go
+++ b/pkg/resource/db_cluster/custom_update.go
@@ -542,6 +542,7 @@ func (rm *resourceManager) newCustomUpdateRequestPayload(
 	res := &svcsdk.ModifyDBClusterInput{}
 
 	res.SetApplyImmediately(true)
+	res.SetAllowMajorVersionUpgrade(true)
 	if r.ko.Spec.BacktrackWindow != nil && delta.DifferentAt("Spec.BacktrackWindow") {
 		res.SetBacktrackWindow(*r.ko.Spec.BacktrackWindow)
 	}

--- a/pkg/resource/db_instance/sdk.go
+++ b/pkg/resource/db_instance/sdk.go
@@ -2368,6 +2368,7 @@ func (rm *resourceManager) newUpdateRequestPayload(
 	if r.ko.Spec.AllocatedStorage != nil {
 		res.SetAllocatedStorage(*r.ko.Spec.AllocatedStorage)
 	}
+	res.SetAllowMajorVersionUpgrade(true)
 	res.SetApplyImmediately(true)
 	if r.ko.Spec.AutoMinorVersionUpgrade != nil {
 		res.SetAutoMinorVersionUpgrade(*r.ko.Spec.AutoMinorVersionUpgrade)


### PR DESCRIPTION
Fixes aws-controllers-k8s/community#1265

Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/1265

Description of changes:
This PR is setting AllowMajorVersionUpgrade to true for both modify db instance and modify db cluster.
This flag was designed as protect flag to avoid accidentally engine version upgrade, however this is not necessary for controller side. whenever customer make change to engine version, ACK controller should take instance to target engine version. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
