### PR TITLE
Add values settings for using a shared credentials file

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -36,3 +36,13 @@ If release name contains chart name it will be used as a full name.
 {{- .Release.Namespace -}}
 {{- end -}}
 {{- end -}}
+
+{{/* The mount path for the shared credentials file */}}
+{{- define "aws.credentials.secret_mount_path" -}}
+{{- "/var/run/secrets/aws" -}}
+{{- end -}}
+
+{{/* The path the shared credentials file is mounted */}}
+{{- define "aws.credentials.path" -}}
+{{- printf "%s/%s" (include "aws.credentials.secret_mount_path" .) .Values.aws.credentials.secretKey -}}
+{{- end -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -80,6 +80,16 @@ spec:
           value: {{ .Values.log.level | quote }}
         - name: ACK_RESOURCE_TAGS
           value: {{ join "," .Values.resourceTags | quote }}
+        {{- if .Values.aws.credentials.secretName }}
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: {{ include "aws.credentials.path" . }}
+        - name: AWS_PROFILE
+          value: {{ .Values.aws.credentials.profile }}
+        volumeMounts:
+          - name: {{ .Values.aws.credentials.secretName }}
+            mountPath: {{ include "aws.credentials.secret_mount_path" . }}
+            readOnly: true
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false
@@ -101,3 +111,9 @@ spec:
       hostIPC: false
       hostNetwork: false
       hostPID: false
+      {{ if .Values.aws.credentials.secretName -}}
+      volumes:
+          - name: {{ .Values.aws.credentials.secretName }}
+            secret:
+              secretName: {{ .Values.aws.credentials.secretName }}
+      {{ end -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -113,7 +113,7 @@ spec:
       hostPID: false
       {{ if .Values.aws.credentials.secretName -}}
       volumes:
-          - name: {{ .Values.aws.credentials.secretName }}
-            secret:
-              secretName: {{ .Values.aws.credentials.secretName }}
+        - name: {{ .Values.aws.credentials.secretName }}
+          secret:
+            secretName: {{ .Values.aws.credentials.secretName }}
       {{ end -}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -50,6 +50,13 @@ aws:
   # If specified, use the AWS region for AWS API calls
   region: ""
   endpoint_url: ""
+  credentials:
+    # If specified, Secret with shared credentials file to use.
+    secretName: ""
+    # Secret stringData key that contains the credentials
+    secretKey: "credentials"
+    # Profile used for AWS credentials
+    profile: "default"
 
 # log level for the controller
 log:


### PR DESCRIPTION
Issue #, if available:

Description of changes:

In the [documentation on using a shared credentials file](https://aws-controllers-k8s.github.io/community/docs/user-docs/authentication/#use-a-shared-credentials-file) there are instructions for mounting a secret containing AWS credentials on the pod for an ACK controller, so it can use those credentials. However, for this controller there is no way to specify which secret to use when following the [installation instructions with Helm](https://aws-controllers-k8s.github.io/community/docs/tutorials/rds-example/#install-the-ack-service-controller-for-rds). This change adds new values settings that can be used to specify that secret. 

## Manual testing

- Render template

```bash
# new volume, volume mount, and env vars are visible
helm -n testns template rds-ack helm/ --debug \
   --set aws.credentials.secretName=aws-creds \
   --set aws.credentials.profile=ack > render_with_secret.yaml
# no new stuff is visible
helm -n testns template rds-ack helm/ --debug  > render_without_secret.yaml
```

- Deploy to minikube: 

```bash
# Create secret with AWS credential as described in https://aws-controllers-k8s.github.io/community/docs/user-docs/authentication/#use-a-shared-credentials-file
## Assuming AWS_SHARED_CREDENTIALS_FILE is properly set
CREDS_CONTENT=$(cat ${AWS_SHARED_CREDENTIALS_FILE} | sed 's/^/    /';)
kubectl create namespace testns
kubectl -n testns apply -f - <<EOF
apiVersion: v1
kind: Secret
metadata:
  name: aws-creds
type: Opaque
stringData:
  credentials: |
$CREDS_CONTENT
EOF

# Install chart as in https://aws-controllers-k8s.github.io/community/docs/tutorials/rds-example/#install-the-ack-service-controller-for-rds
# Without new values setting, the controller fails to find the credentials 

helm -n testns install rds-ack helm/ --set=aws.region=us-east-1 

$ kubectl -n testns logs -f -l "app.kubernetes.io/instance=rds-ack"
1.6549699331998787e+09  ERROR   setup   Unable to create controller manager     {"aws.service": "rds", "error": "unable to determine account ID: unable to get caller identity: NoCredentialProviders: no valid providers in chain. Deprecated.\n\tFor verbose messaging see aws.Config.CredentialsChainVerboseErrors"}
main.main

# Using the additional values settings it is able to get the credentials

helm -n testns upgrade rds-ack helm/ \
   --set=aws.region=us-east-1 \
   --set aws.credentials.secretName=aws-creds \
   --set aws.credentials.profile=ack

kubectl -n testns logs -f -l "app.kubernetes.io/instance=rds-ack"
...
1.6549700458727725e+09  INFO    controller.dbcluster    Starting Controller     {"reconciler group": "rds.services.k8s.aws", "reconciler kind": "DBCluster"}

$ helm -n testns uninstall rds-ack 
release "rds-ack" uninstalled
```

Compared to version v0.0.24 the CRD helm/crds/rds.services.k8s.aws_dbsecuritygroups.yaml is missing, and that eventually leads to a crash of the controler pod. Even when adding that CR, the pod eventually crashes with the following message. This doesn't seem to be related to this change. 

```
1.654970165727896e+09   ERROR   error received after stop sequence was engaged  {"error": "failed to wait for globalcluster caches to sync: timed out waiting for cache to be synced"}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
