### PR TITLE
Ignore several fields for rds modify call when no delta in yaml file

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-06-08T02:04:16Z"
+  build_date: "2022-06-13T22:52:20Z"
   build_hash: 6acf40fe3e3cfd97b799ef7cbf1e89e01c3db8f7
   go_version: go1.18.2
   version: v0.18.4-15-g6acf40f

--- a/pkg/resource/db_instance/sdk.go
+++ b/pkg/resource/db_instance/sdk.go
@@ -1692,6 +1692,21 @@ func (rm *resourceManager) sdkUpdate(
 		input.DBSubnetGroupName = nil
 	}
 
+	// RDS will not compare diff value and accept any modify db call
+	// for below values, MonitoringInterval, CACertificateIdentifier
+	// and user master password
+	// hence if there is no delta between desired
+	// and latest, exclude it from ModifyDBInstanceRequest
+	if !delta.DifferentAt("Spec.MonitoringInterval") {
+		input.MonitoringInterval = nil
+	}
+	if !delta.DifferentAt("Spec.CACertificateIdentifier") {
+		input.CACertificateIdentifier = nil
+	}
+	if !delta.DifferentAt("Spec.MasterUserPassword.Name") {
+		input.MasterUserPassword = nil
+	}
+
 	var resp *svcsdk.ModifyDBInstanceOutput
 	_ = resp
 	resp, err = rm.sdkapi.ModifyDBInstanceWithContext(ctx, input)

--- a/templates/hooks/db_instance/sdk_update_post_build_request.go.tpl
+++ b/templates/hooks/db_instance/sdk_update_post_build_request.go.tpl
@@ -6,3 +6,18 @@
 	if !delta.DifferentAt("Spec.DBSubnetGroupName") {
 		input.DBSubnetGroupName = nil
 	}
+
+        // RDS will not compare diff value and accept any modify db call
+        // for below values, MonitoringInterval, CACertificateIdentifier
+        // and user master password
+        // hence if there is no delta between desired 
+        // and latest, exclude it from ModifyDBInstanceRequest
+        if !delta.DifferentAt("Spec.MonitoringInterval") {
+		input.MonitoringInterval = nil
+	}
+        if !delta.DifferentAt("Spec.CACertificateIdentifier") {
+		input.CACertificateIdentifier = nil
+	}
+        if !delta.DifferentAt("Spec.MasterUserPassword.Name") {
+		input.MasterUserPassword = nil
+	}


### PR DESCRIPTION
Issue #, if available:

This is the reason why rds instance has unnecessary modify workflows for now.
instance will have action of `reset_master_pwd`, r`otate_credential` and `config_enhanced_monitoring` whenever an unrelated param get updated.  RDS side doesn't compare diff of these params and trigger workflow anyway which is pretty annoying and increase sync/wait time. 

- MonitoringInterval -> cause new config_enhanced_monitoring action
- CACertificateIdentifier -> cause rotate_credential action
- MasterUserPassword -> cause reset_master_pwd action 

Description of changes:
We first check whether input has delta or not, if not, we don't put it inside rds modify db instance request. If it has delta, it's added into modify request. 

Tested by flipping `CopyTagsToSnapshot` filed and not see instance has unnecessary workflow anymore.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
