### PR TITLE
Remove DBParameterGroupNotFound and DBSubnetGroupNotFoundFault from terminal exception

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-06-13T22:52:20Z"
+  build_date: "2022-06-15T16:28:00Z"
   build_hash: 6acf40fe3e3cfd97b799ef7cbf1e89e01c3db8f7
   go_version: go1.18.2
   version: v0.18.4-15-g6acf40f
@@ -7,7 +7,7 @@ api_directory_checksum: 4bdcfc19ab3ec6ae11525e6eb3a201e4a25b00fa
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: a014f16db9e990ad756052e50cbce7d0d9b84c0b
+  file_checksum: ea4f4bb6cbad704d4503e27b18ee391ee73c8286
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-06-15T16:28:00Z"
+  build_date: "2022-06-15T17:44:45Z"
   build_hash: 6acf40fe3e3cfd97b799ef7cbf1e89e01c3db8f7
   go_version: go1.18.2
   version: v0.18.4-15-g6acf40f
@@ -7,7 +7,7 @@ api_directory_checksum: 4bdcfc19ab3ec6ae11525e6eb3a201e4a25b00fa
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: ea4f4bb6cbad704d4503e27b18ee391ee73c8286
+  file_checksum: 3049ff7069227f7f94fb47a8d05e19a4ec83400d
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-06-15T17:44:45Z"
+  build_date: "2022-06-15T18:55:14Z"
   build_hash: 6acf40fe3e3cfd97b799ef7cbf1e89e01c3db8f7
   go_version: go1.18.2
   version: v0.18.4-15-g6acf40f
@@ -7,7 +7,7 @@ api_directory_checksum: 4bdcfc19ab3ec6ae11525e6eb3a201e4a25b00fa
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 3049ff7069227f7f94fb47a8d05e19a4ec83400d
+  file_checksum: 3ff30261a7e6e7df5e498e37acf114f3c121173a
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -90,8 +90,6 @@ resources:
     exceptions:
       terminal_codes:
         - DBClusterQuotaExceededFault
-        - DBParameterGroupNotFound
-        - DBSubnetGroupNotFoundFault
         - DBSubnetGroupDoesNotCoverEnoughAZs
         - DomainNotFoundFault
         - InsufficientStorageClusterCapacity
@@ -166,8 +164,6 @@ resources:
         - InvalidParameter
         - InvalidParameterValue
         - InvalidParameterCombination
-        - DBSubnetGroupNotFoundFault
-        - DBParameterGroupNotFound
     fields:
       AvailabilityZone:
         late_initialize: {}

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -91,7 +91,6 @@ resources:
       terminal_codes:
         - DBClusterQuotaExceededFault
         - DBSubnetGroupDoesNotCoverEnoughAZs
-        - DomainNotFoundFault
         - InsufficientStorageClusterCapacity
         - InvalidParameter
         - InvalidParameterValue

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -97,7 +97,6 @@ resources:
         - InvalidParameterValue
         - InvalidParameterCombination
         - InvalidSubnet
-        - KMSKeyNotAccessibleFault
         - StorageQuotaExceeded
     fields:
       DBClusterIdentifier:

--- a/generator.yaml
+++ b/generator.yaml
@@ -90,8 +90,6 @@ resources:
     exceptions:
       terminal_codes:
         - DBClusterQuotaExceededFault
-        - DBParameterGroupNotFound
-        - DBSubnetGroupNotFoundFault
         - DBSubnetGroupDoesNotCoverEnoughAZs
         - DomainNotFoundFault
         - InsufficientStorageClusterCapacity
@@ -166,8 +164,6 @@ resources:
         - InvalidParameter
         - InvalidParameterValue
         - InvalidParameterCombination
-        - DBSubnetGroupNotFoundFault
-        - DBParameterGroupNotFound
     fields:
       AvailabilityZone:
         late_initialize: {}

--- a/generator.yaml
+++ b/generator.yaml
@@ -91,7 +91,6 @@ resources:
       terminal_codes:
         - DBClusterQuotaExceededFault
         - DBSubnetGroupDoesNotCoverEnoughAZs
-        - DomainNotFoundFault
         - InsufficientStorageClusterCapacity
         - InvalidParameter
         - InvalidParameterValue

--- a/generator.yaml
+++ b/generator.yaml
@@ -97,7 +97,6 @@ resources:
         - InvalidParameterValue
         - InvalidParameterCombination
         - InvalidSubnet
-        - KMSKeyNotAccessibleFault
         - StorageQuotaExceeded
     fields:
       DBClusterIdentifier:

--- a/pkg/resource/db_cluster/sdk.go
+++ b/pkg/resource/db_cluster/sdk.go
@@ -1400,7 +1400,6 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 		"InvalidParameterValue",
 		"InvalidParameterCombination",
 		"InvalidSubnet",
-		"KMSKeyNotAccessibleFault",
 		"StorageQuotaExceeded":
 		return true
 	default:

--- a/pkg/resource/db_cluster/sdk.go
+++ b/pkg/resource/db_cluster/sdk.go
@@ -1393,8 +1393,6 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 	}
 	switch awsErr.Code() {
 	case "DBClusterQuotaExceededFault",
-		"DBParameterGroupNotFound",
-		"DBSubnetGroupNotFoundFault",
 		"DBSubnetGroupDoesNotCoverEnoughAZs",
 		"DomainNotFoundFault",
 		"InsufficientStorageClusterCapacity",

--- a/pkg/resource/db_cluster/sdk.go
+++ b/pkg/resource/db_cluster/sdk.go
@@ -1394,7 +1394,6 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 	switch awsErr.Code() {
 	case "DBClusterQuotaExceededFault",
 		"DBSubnetGroupDoesNotCoverEnoughAZs",
-		"DomainNotFoundFault",
 		"InsufficientStorageClusterCapacity",
 		"InvalidParameter",
 		"InvalidParameterValue",

--- a/pkg/resource/db_instance/sdk.go
+++ b/pkg/resource/db_instance/sdk.go
@@ -2673,9 +2673,7 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 	switch awsErr.Code() {
 	case "InvalidParameter",
 		"InvalidParameterValue",
-		"InvalidParameterCombination",
-		"DBSubnetGroupNotFoundFault",
-		"DBParameterGroupNotFound":
+		"InvalidParameterCombination":
 		return true
 	default:
 		return false


### PR DESCRIPTION
Remove DBParameterGroupNotFound and DBSubnetGroupNotFoundFault from terminal exception

Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/1257

Description of changes:
Since `DBParameterGroup` and `DBSubnetGroup` are resource can be created by controller, controller should retry create `dbinstance/dbcluster` when these resource are created and available in k8s.
Remove them from terminal code so controller can keep retrying. 
Tested by create instance with new db subnet group/param group, and validated controller keep retrying creating and create successfully when new subnet group/param group created in k8s.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.