### PR TITLE
Fix rename of DBParameterGroup family for AdoptedResource

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-06-15T18:55:14Z"
+  build_date: "2022-06-15T23:33:58Z"
   build_hash: 6acf40fe3e3cfd97b799ef7cbf1e89e01c3db8f7
   go_version: go1.18.2
   version: v0.18.4-15-g6acf40f
-api_directory_checksum: 4bdcfc19ab3ec6ae11525e6eb3a201e4a25b00fa
+api_directory_checksum: 7ded8dc716ff929b62e5d5b43a2c656a55f85985
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 3ff30261a7e6e7df5e498e37acf114f3c121173a
+  file_checksum: 88ac4e4fff9ca9605e40c329178021face7472a8
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -205,6 +205,7 @@ resources:
         DescribeDBParameterGroups:
           input_fields:
             DBParameterGroupName: Name
+            DBParameterGroupFamily: Family
         CreateDBParameterGroup:
           input_fields:
             DBParameterGroupName: Name
@@ -212,6 +213,10 @@ resources:
         DeleteDBParameterGroup:
           input_fields:
             DBParameterGroupName: Name
+        ModifyDBParameterGroup:
+          input_fields:
+            DBParameterGroupName: Name
+            DBParameterGroupFamily: Family
     update_operation:
       # We need a custom update implementation until the issue behind
       # https://github.com/aws-controllers-k8s/community/issues/869 is
@@ -235,6 +240,7 @@ resources:
         DescribeDBSubnetGroups:
           input_fields:
             DBSubnetGroupName: Name
+            DBSubnetGroupDescription: Description
         CreateDBSubnetGroup:
           input_fields:
             DBSubnetGroupName: Name

--- a/generator.yaml
+++ b/generator.yaml
@@ -205,6 +205,7 @@ resources:
         DescribeDBParameterGroups:
           input_fields:
             DBParameterGroupName: Name
+            DBParameterGroupFamily: Family
         CreateDBParameterGroup:
           input_fields:
             DBParameterGroupName: Name
@@ -212,6 +213,10 @@ resources:
         DeleteDBParameterGroup:
           input_fields:
             DBParameterGroupName: Name
+        ModifyDBParameterGroup:
+          input_fields:
+            DBParameterGroupName: Name
+            DBParameterGroupFamily: Family
     update_operation:
       # We need a custom update implementation until the issue behind
       # https://github.com/aws-controllers-k8s/community/issues/869 is
@@ -235,6 +240,7 @@ resources:
         DescribeDBSubnetGroups:
           input_fields:
             DBSubnetGroupName: Name
+            DBSubnetGroupDescription: Description
         CreateDBSubnetGroup:
           input_fields:
             DBSubnetGroupName: Name

--- a/pkg/resource/db_parameter_group/sdk.go
+++ b/pkg/resource/db_parameter_group/sdk.go
@@ -89,6 +89,11 @@ func (rm *resourceManager) sdkFind(
 			tmpARN := ackv1alpha1.AWSResourceName(*elem.DBParameterGroupArn)
 			ko.Status.ACKResourceMetadata.ARN = &tmpARN
 		}
+		if elem.DBParameterGroupFamily != nil {
+			ko.Spec.Family = elem.DBParameterGroupFamily
+		} else {
+			ko.Spec.Family = nil
+		}
 		if elem.DBParameterGroupName != nil {
 			ko.Spec.Name = elem.DBParameterGroupName
 		} else {

--- a/pkg/resource/db_subnet_group/sdk.go
+++ b/pkg/resource/db_subnet_group/sdk.go
@@ -89,6 +89,11 @@ func (rm *resourceManager) sdkFind(
 			tmpARN := ackv1alpha1.AWSResourceName(*elem.DBSubnetGroupArn)
 			ko.Status.ACKResourceMetadata.ARN = &tmpARN
 		}
+		if elem.DBSubnetGroupDescription != nil {
+			ko.Spec.Description = elem.DBSubnetGroupDescription
+		} else {
+			ko.Spec.Description = nil
+		}
 		if elem.DBSubnetGroupName != nil {
 			ko.Spec.Name = elem.DBSubnetGroupName
 		} else {


### PR DESCRIPTION
Issue #, if available:

https://github.com/aws-controllers-k8s/community/issues/1264

Description of changes:

issue-1264 was due to `DBParameterGroupFamily` is not renamed to` Family` for `DescribeDBParameterGroups` operation. 
Adding corresponding rename so AdoptedResource of db param group can work. 

basically create and read `DBParameterGroup`/`DBSubnetGroup` operations should have same rename strategy, hence align all of them here  


Previous error is: 
```
1.6553342486477876e+09	ERROR	controller.adoptedresource	Reconciler error	{"reconciler group": "services.k8s.aws", "reconciler kind": "AdoptedResource", "name": "brucegu-ack-pg-1", "namespace": "default", "error": "DBParameterGroup.rds.services.k8s.aws \"brucegu-ack-pg-1\" is invalid: spec.family: Required value"}
```

After this update, no Reconciler error. 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
