### PR TITLE
Ignore NetworkType param if no change, not consider diff when engine version diff in minor version

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-06-20T17:29:19Z"
+  build_date: "2022-06-20T18:16:33Z"
   build_hash: a45f3b900849ec03c5e16ed2778c0b8e2923ffee
   go_version: go1.18.2
   version: v0.19.1

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2022-06-17T22:34:21Z"
+  build_date: "2022-06-20T17:29:19Z"
   build_hash: a45f3b900849ec03c5e16ed2778c0b8e2923ffee
-  go_version: go1.18.3
-  version: v0.19.0-5-ga45f3b9
+  go_version: go1.18.2
+  version: v0.19.1
 api_directory_checksum: 7567208aa7463aaa3c937e45107f520e6fc2946f
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.27

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-06-20T18:16:33Z"
+  build_date: "2022-06-20T19:21:08Z"
   build_hash: a45f3b900849ec03c5e16ed2778c0b8e2923ffee
   go_version: go1.18.2
   version: v0.19.1

--- a/pkg/resource/db_instance/delta.go
+++ b/pkg/resource/db_instance/delta.go
@@ -18,7 +18,6 @@ package db_instance
 import (
 	"bytes"
 	"reflect"
-        "strings"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 )
@@ -58,9 +57,7 @@ func newResourceDelta(
 	// engine major version is provided and controler should not
 	// treat them as different, sunch as spec has 14, status has 14.1
 	// controller should treat them as same
-	if a != nil && b != nil && strings.HasPrefix(*b.ko.Spec.EngineVersion, *a.ko.Spec.EngineVersion) {
-		a.ko.Spec.EngineVersion = b.ko.Spec.EngineVersion
-	}
+	reconcileEngineVersion(a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.AllocatedStorage, b.ko.Spec.AllocatedStorage) {
 		delta.Add("Spec.AllocatedStorage", a.ko.Spec.AllocatedStorage, b.ko.Spec.AllocatedStorage)

--- a/pkg/resource/db_instance/delta.go
+++ b/pkg/resource/db_instance/delta.go
@@ -55,7 +55,7 @@ func newResourceDelta(
 
 	// RDS will choose preferred engine minor version if only
 	// engine major version is provided and controler should not
-	// treat them as different, sunch as spec has 14, status has 14.1
+	// treat them as different, such as spec has 14, status has 14.1
 	// controller should treat them as same
 	reconcileEngineVersion(a, b)
 

--- a/pkg/resource/db_instance/delta.go
+++ b/pkg/resource/db_instance/delta.go
@@ -18,6 +18,7 @@ package db_instance
 import (
 	"bytes"
 	"reflect"
+        "strings"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 )
@@ -51,6 +52,14 @@ func newResourceDelta(
 	// reconciler will keep updating the dbinstance and constantly requeueing it.
 	if a != nil && a.ko.Spec.AvailabilityZone == nil && b != nil && b.ko.Spec.AvailabilityZone != nil {
 		a.ko.Spec.AvailabilityZone = b.ko.Spec.AvailabilityZone
+	}
+
+	// RDS will choose preferred engine minor version if only
+	// engine major version is provided and controler should not
+	// treat them as different, sunch as spec has 14, status has 14.1
+	// controller should treat them as same
+	if a != nil && b != nil && strings.HasPrefix(*b.ko.Spec.EngineVersion, *a.ko.Spec.EngineVersion) {
+		a.ko.Spec.EngineVersion = b.ko.Spec.EngineVersion
 	}
 
 	if ackcompare.HasNilDifference(a.ko.Spec.AllocatedStorage, b.ko.Spec.AllocatedStorage) {

--- a/pkg/resource/db_instance/hooks.go
+++ b/pkg/resource/db_instance/hooks.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
@@ -193,4 +194,17 @@ func (rm *resourceManager) restoreDbInstanceFromDbSnapshot(
 		return &resource{r.ko}, nil
 	}
 	return &resource{r.ko}, nil
+}
+
+// RDS will choose preferred engine minor version if only
+// engine major version is provided and controler should not
+// treat them as different, sunch as spec has 14, status has 14.1
+// controller should treat them as same
+func reconcileEngineVersion(
+	a *resource,
+	b *resource,
+) {
+	if a != nil && b != nil && strings.HasPrefix(*b.ko.Spec.EngineVersion, *a.ko.Spec.EngineVersion) {
+		a.ko.Spec.EngineVersion = b.ko.Spec.EngineVersion
+	}
 }

--- a/pkg/resource/db_instance/hooks.go
+++ b/pkg/resource/db_instance/hooks.go
@@ -198,7 +198,7 @@ func (rm *resourceManager) restoreDbInstanceFromDbSnapshot(
 
 // RDS will choose preferred engine minor version if only
 // engine major version is provided and controler should not
-// treat them as different, sunch as spec has 14, status has 14.1
+// treat them as different, such as spec has 14, status has 14.1
 // controller should treat them as same
 func reconcileEngineVersion(
 	a *resource,

--- a/pkg/resource/db_instance/sdk.go
+++ b/pkg/resource/db_instance/sdk.go
@@ -1744,7 +1744,7 @@ func (rm *resourceManager) sdkUpdate(
 
 	// RDS will not compare diff value and accept any modify db call
 	// for below values, MonitoringInterval, CACertificateIdentifier
-	// and user master password
+	// and user master password, NetworkType
 	// hence if there is no delta between desired
 	// and latest, exclude it from ModifyDBInstanceRequest
 	if !delta.DifferentAt("Spec.MonitoringInterval") {
@@ -1755,6 +1755,9 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	if !delta.DifferentAt("Spec.MasterUserPassword.Name") {
 		input.MasterUserPassword = nil
+	}
+	if !delta.DifferentAt("Spec.NetworkType") {
+		input.NetworkType = nil
 	}
 
 	var resp *svcsdk.ModifyDBInstanceOutput

--- a/templates/hooks/db_instance/delta_pre_compare.go.tpl
+++ b/templates/hooks/db_instance/delta_pre_compare.go.tpl
@@ -15,6 +15,4 @@
     // engine major version is provided and controler should not
     // treat them as different, sunch as spec has 14, status has 14.1
     // controller should treat them as same
-    if a != nil && b != nil && strings.HasPrefix(*b.ko.Spec.EngineVersion, *a.ko.Spec.EngineVersion) {
-        a.ko.Spec.EngineVersion = b.ko.Spec.EngineVersion
-    }
+    reconcileEngineVersion(a, b)

--- a/templates/hooks/db_instance/delta_pre_compare.go.tpl
+++ b/templates/hooks/db_instance/delta_pre_compare.go.tpl
@@ -13,6 +13,6 @@
 
     // RDS will choose preferred engine minor version if only
     // engine major version is provided and controler should not
-    // treat them as different, sunch as spec has 14, status has 14.1
+    // treat them as different, such as spec has 14, status has 14.1
     // controller should treat them as same
     reconcileEngineVersion(a, b)

--- a/templates/hooks/db_instance/delta_pre_compare.go.tpl
+++ b/templates/hooks/db_instance/delta_pre_compare.go.tpl
@@ -10,3 +10,11 @@
     if a != nil && a.ko.Spec.AvailabilityZone == nil && b != nil && b.ko.Spec.AvailabilityZone != nil {
         a.ko.Spec.AvailabilityZone = b.ko.Spec.AvailabilityZone
     }
+
+    // RDS will choose preferred engine minor version if only
+    // engine major version is provided and controler should not
+    // treat them as different, sunch as spec has 14, status has 14.1
+    // controller should treat them as same
+    if a != nil && b != nil && strings.HasPrefix(*b.ko.Spec.EngineVersion, *a.ko.Spec.EngineVersion) {
+        a.ko.Spec.EngineVersion = b.ko.Spec.EngineVersion
+    }

--- a/templates/hooks/db_instance/sdk_update_post_build_request.go.tpl
+++ b/templates/hooks/db_instance/sdk_update_post_build_request.go.tpl
@@ -9,7 +9,7 @@
 
         // RDS will not compare diff value and accept any modify db call
         // for below values, MonitoringInterval, CACertificateIdentifier
-        // and user master password
+        // and user master password, NetworkType
         // hence if there is no delta between desired 
         // and latest, exclude it from ModifyDBInstanceRequest
         if !delta.DifferentAt("Spec.MonitoringInterval") {
@@ -21,3 +21,6 @@
         if !delta.DifferentAt("Spec.MasterUserPassword.Name") {
 		input.MasterUserPassword = nil
 	}
+        if !delta.DifferentAt("Spec.NetworkType") {
+                input.NetworkType = nil
+        }


### PR DESCRIPTION
Issue #, if available:

no issue number 

Description of changes:
2 changes in this pr

1. ignore NetworkType param when no delta found. RDS coral service will accept request when param has NetworkType param and trigger workflow, although inside rds workflow, it will do noop. it's still not best experience for customer since instance will leave active/none state when this happen.  (this is introduced recently by updating rds api version)

3. RDS will choose preferred engine minor version when only major version give. controller should not try to take them as different and try to sync them. e.g. spec has `14`, rds status shows `14.1`, they should be treated same. Before this fix, controller is trying to sync them forever.  Previous error log: 
```
1.6557458184530575e+09	INFO	ackrt	desired resource state has changed	{"account": "980401675890", "role": "", "region": "us-west-2", "kind": "DBInstance", "namespace": "default", "name": "brucegu-test-tag-2", "is_adopted": false, "generation": 3, "diff": [{"Path":{"Parts":["Spec","EngineVersion"]},"A":"14","B":"14.1"}]}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
