### PR TITLE
Add DBCluster serverlessV2ScalingConfiguration update support

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2022-06-23T23:45:42Z"
-  build_hash: 4b54669d709a0eb2c1fab659e329060350a40e84
-  go_version: go1.18.3
-  version: v0.19.2
+  build_date: "2022-07-05T18:24:04Z"
+  build_hash: f9ab7cca7c2ea2ac77d0c4d2dfeb0b42ade56f38
+  go_version: go1.18.2
+  version: v0.19.2-4-gf9ab7cc
 api_directory_checksum: b0c5acd3d10a1214f5cc46d2fb8b887d9ecc2fe4
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.27

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-07-05T20:48:52Z"
+  build_date: "2022-07-05T21:44:24Z"
   build_hash: f9ab7cca7c2ea2ac77d0c4d2dfeb0b42ade56f38
   go_version: go1.18.2
   version: v0.19.2-4-gf9ab7cc
-api_directory_checksum: 1f3688b3d71ec3362906b5f89188c3fef3efd7d2
+api_directory_checksum: d6c6f02d6f5547b3092054e9c7c35f5840f8bef9
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.27
 generator_config_info:
-  file_checksum: 43c3c6f1fd651494117ec60004339ce9cf8fb6c2
+  file_checksum: 2d0c40614a7482376d47885f84cdb713d4307392
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-07-05T21:44:24Z"
+  build_date: "2022-07-06T21:17:58Z"
   build_hash: f9ab7cca7c2ea2ac77d0c4d2dfeb0b42ade56f38
   go_version: go1.18.2
   version: v0.19.2-4-gf9ab7cc

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-07-05T18:24:04Z"
+  build_date: "2022-07-05T20:48:52Z"
   build_hash: f9ab7cca7c2ea2ac77d0c4d2dfeb0b42ade56f38
   go_version: go1.18.2
   version: v0.19.2-4-gf9ab7cc
-api_directory_checksum: b0c5acd3d10a1214f5cc46d2fb8b887d9ecc2fe4
+api_directory_checksum: 1f3688b3d71ec3362906b5f89188c3fef3efd7d2
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.27
 generator_config_info:
-  file_checksum: 48d07f9a7b6ea79f8398bcd10254d912cd90cb6d
+  file_checksum: 43c3c6f1fd651494117ec60004339ce9cf8fb6c2
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/db_cluster.go
+++ b/apis/v1alpha1/db_cluster.go
@@ -587,7 +587,7 @@ type DBClusterSpec struct {
 	// DB cluster.
 	//
 	// Valid for: Aurora DB clusters only
-	ScalingConfiguration *ScalingConfiguration `json:"scalingConfiguration,omitempty"`
+	ScalingConfigurationInfo *ScalingConfiguration `json:"scalingConfigurationInfo,omitempty"`
 
 	ServerlessV2ScalingConfiguration *ServerlessV2ScalingConfiguration `json:"serverlessV2ScalingConfiguration,omitempty"`
 	// SourceRegion is the source region where the resource exists. This is not
@@ -792,9 +792,6 @@ type DBClusterStatus struct {
 	// then reconnect to the reader endpoint.
 	// +kubebuilder:validation:Optional
 	ReaderEndpoint *string `json:"readerEndpoint,omitempty"`
-
-	// +kubebuilder:validation:Optional
-	ScalingConfigurationInfo *ScalingConfigurationInfo `json:"scalingConfigurationInfo,omitempty"`
 	// Specifies the current state of this DB cluster.
 	// +kubebuilder:validation:Optional
 	Status *string `json:"status,omitempty"`

--- a/apis/v1alpha1/db_cluster.go
+++ b/apis/v1alpha1/db_cluster.go
@@ -587,7 +587,7 @@ type DBClusterSpec struct {
 	// DB cluster.
 	//
 	// Valid for: Aurora DB clusters only
-	ScalingConfigurationInfo *ScalingConfiguration `json:"scalingConfigurationInfo,omitempty"`
+	ScalingConfiguration *ScalingConfiguration `json:"scalingConfiguration,omitempty"`
 
 	ServerlessV2ScalingConfiguration *ServerlessV2ScalingConfiguration `json:"serverlessV2ScalingConfiguration,omitempty"`
 	// SourceRegion is the source region where the resource exists. This is not

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -110,11 +110,11 @@ resources:
     renames:
       operations:
         CreateDBCluster:
-          input_fields:
-            ScalingConfiguration: ScalingConfigurationInfo
+          output_fields:
+            ScalingConfigurationInfo: ScalingConfiguration
         ModifyDBCluster:
-          input_fields:
-            ScalingConfiguration: ScalingConfigurationInfo
+          output_fields:
+            ScalingConfigurationInfo: ScalingConfiguration
   DBClusterParameterGroup:
     renames:
       operations:

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -107,6 +107,14 @@ resources:
           resource: Key
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
+    renames:
+      operations:
+        CreateDBCluster:
+          input_fields:
+            ScalingConfiguration: ScalingConfigurationInfo
+        ModifyDBCluster:
+          input_fields:
+            ScalingConfiguration: ScalingConfigurationInfo
   DBClusterParameterGroup:
     renames:
       operations:

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1139,8 +1139,8 @@ func (in *DBClusterSpec) DeepCopyInto(out *DBClusterSpec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.ScalingConfiguration != nil {
-		in, out := &in.ScalingConfiguration, &out.ScalingConfiguration
+	if in.ScalingConfigurationInfo != nil {
+		in, out := &in.ScalingConfigurationInfo, &out.ScalingConfigurationInfo
 		*out = new(ScalingConfiguration)
 		(*in).DeepCopyInto(*out)
 	}
@@ -1423,11 +1423,6 @@ func (in *DBClusterStatus) DeepCopyInto(out *DBClusterStatus) {
 		in, out := &in.ReaderEndpoint, &out.ReaderEndpoint
 		*out = new(string)
 		**out = **in
-	}
-	if in.ScalingConfigurationInfo != nil {
-		in, out := &in.ScalingConfigurationInfo, &out.ScalingConfigurationInfo
-		*out = new(ScalingConfigurationInfo)
-		(*in).DeepCopyInto(*out)
 	}
 	if in.Status != nil {
 		in, out := &in.Status, &out.Status

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1139,8 +1139,8 @@ func (in *DBClusterSpec) DeepCopyInto(out *DBClusterSpec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.ScalingConfigurationInfo != nil {
-		in, out := &in.ScalingConfigurationInfo, &out.ScalingConfigurationInfo
+	if in.ScalingConfiguration != nil {
+		in, out := &in.ScalingConfiguration, &out.ScalingConfiguration
 		*out = new(ScalingConfiguration)
 		(*in).DeepCopyInto(*out)
 	}

--- a/config/crd/bases/rds.services.k8s.aws_dbclusters.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbclusters.yaml
@@ -484,7 +484,7 @@ spec:
                   or DB cluster if this DB cluster is created as a read replica. \n
                   Valid for: Aurora DB clusters only"
                 type: string
-              scalingConfiguration:
+              scalingConfigurationInfo:
                 description: "For DB clusters in serverless DB engine mode, the scaling
                   properties of the DB cluster. \n Valid for: Aurora DB clusters only"
                 properties:
@@ -869,29 +869,6 @@ spec:
                   to other Aurora Replicas in the cluster, you can then reconnect
                   to the reader endpoint."
                 type: string
-              scalingConfigurationInfo:
-                description: "Shows the scaling configuration for an Aurora DB cluster
-                  in serverless DB engine mode. \n For more information, see Using
-                  Amazon Aurora Serverless v1 (https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html)
-                  in the Amazon Aurora User Guide."
-                properties:
-                  autoPause:
-                    type: boolean
-                  maxCapacity:
-                    format: int64
-                    type: integer
-                  minCapacity:
-                    format: int64
-                    type: integer
-                  secondsBeforeTimeout:
-                    format: int64
-                    type: integer
-                  secondsUntilAutoPause:
-                    format: int64
-                    type: integer
-                  timeoutAction:
-                    type: string
-                type: object
               status:
                 description: Specifies the current state of this DB cluster.
                 type: string

--- a/config/crd/bases/rds.services.k8s.aws_dbclusters.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbclusters.yaml
@@ -484,7 +484,7 @@ spec:
                   or DB cluster if this DB cluster is created as a read replica. \n
                   Valid for: Aurora DB clusters only"
                 type: string
-              scalingConfigurationInfo:
+              scalingConfiguration:
                 description: "For DB clusters in serverless DB engine mode, the scaling
                   properties of the DB cluster. \n Valid for: Aurora DB clusters only"
                 properties:

--- a/generator.yaml
+++ b/generator.yaml
@@ -110,11 +110,11 @@ resources:
     renames:
       operations:
         CreateDBCluster:
-          input_fields:
-            ScalingConfiguration: ScalingConfigurationInfo
+          output_fields:
+            ScalingConfigurationInfo: ScalingConfiguration
         ModifyDBCluster:
-          input_fields:
-            ScalingConfiguration: ScalingConfigurationInfo
+          output_fields:
+            ScalingConfigurationInfo: ScalingConfiguration
   DBClusterParameterGroup:
     renames:
       operations:

--- a/generator.yaml
+++ b/generator.yaml
@@ -107,6 +107,14 @@ resources:
           resource: Key
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
+    renames:
+      operations:
+        CreateDBCluster:
+          input_fields:
+            ScalingConfiguration: ScalingConfigurationInfo
+        ModifyDBCluster:
+          input_fields:
+            ScalingConfiguration: ScalingConfigurationInfo
   DBClusterParameterGroup:
     renames:
       operations:

--- a/helm/crds/rds.services.k8s.aws_dbclusters.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbclusters.yaml
@@ -484,7 +484,7 @@ spec:
                   or DB cluster if this DB cluster is created as a read replica. \n
                   Valid for: Aurora DB clusters only"
                 type: string
-              scalingConfiguration:
+              scalingConfigurationInfo:
                 description: "For DB clusters in serverless DB engine mode, the scaling
                   properties of the DB cluster. \n Valid for: Aurora DB clusters only"
                 properties:
@@ -869,29 +869,6 @@ spec:
                   to other Aurora Replicas in the cluster, you can then reconnect
                   to the reader endpoint."
                 type: string
-              scalingConfigurationInfo:
-                description: "Shows the scaling configuration for an Aurora DB cluster
-                  in serverless DB engine mode. \n For more information, see Using
-                  Amazon Aurora Serverless v1 (https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html)
-                  in the Amazon Aurora User Guide."
-                properties:
-                  autoPause:
-                    type: boolean
-                  maxCapacity:
-                    format: int64
-                    type: integer
-                  minCapacity:
-                    format: int64
-                    type: integer
-                  secondsBeforeTimeout:
-                    format: int64
-                    type: integer
-                  secondsUntilAutoPause:
-                    format: int64
-                    type: integer
-                  timeoutAction:
-                    type: string
-                type: object
               status:
                 description: Specifies the current state of this DB cluster.
                 type: string

--- a/helm/crds/rds.services.k8s.aws_dbclusters.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbclusters.yaml
@@ -484,7 +484,7 @@ spec:
                   or DB cluster if this DB cluster is created as a read replica. \n
                   Valid for: Aurora DB clusters only"
                 type: string
-              scalingConfigurationInfo:
+              scalingConfiguration:
                 description: "For DB clusters in serverless DB engine mode, the scaling
                   properties of the DB cluster. \n Valid for: Aurora DB clusters only"
                 properties:

--- a/pkg/resource/db_cluster/custom_update.go
+++ b/pkg/resource/db_cluster/custom_update.go
@@ -611,13 +611,13 @@ func (rm *resourceManager) newCustomUpdateRequestPayload(
 	// For ServerlessV2ScalingConfiguration, MaxCapacity and MinCapacity,  both need appear in modify call to get ServerlessV2ScalingConfiguration modified
 	if r.ko.Spec.ServerlessV2ScalingConfiguration != nil && delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration") {
 		f23 := &svcsdk.ServerlessV2ScalingConfiguration{}
-		if r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity != nil && r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity != nil && delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration.MaxCapacity") {
-			f23.SetMaxCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity)
-			f23.SetMinCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity)
-		}
-		if r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity != nil && r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity != nil && delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration.MinCapacity") {
-			f23.SetMaxCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity)
-			f23.SetMinCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity)
+		if delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration.MaxCapacity") || delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration.MinCapacity") {
+			if r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity != nil {
+				f23.SetMaxCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity)
+			}
+			if r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity != nil {
+				f23.SetMinCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity)
+			}
 		}
 		res.SetServerlessV2ScalingConfiguration(f23)
 	}

--- a/pkg/resource/db_cluster/custom_update.go
+++ b/pkg/resource/db_cluster/custom_update.go
@@ -580,22 +580,22 @@ func (rm *resourceManager) newCustomUpdateRequestPayload(
 	if r.ko.Spec.PreferredMaintenanceWindow != nil && delta.DifferentAt("Spec.PreferredMaintenanceWindow") {
 		res.SetPreferredMaintenanceWindow(*r.ko.Spec.PreferredMaintenanceWindow)
 	}
-	if r.ko.Spec.ScalingConfigurationInfo != nil && delta.DifferentAt("Spec.ScalingConfigurationInfo") {
+	if r.ko.Spec.ScalingConfiguration != nil && delta.DifferentAt("Spec.ScalingConfiguration") {
 		f22 := &svcsdk.ScalingConfiguration{}
-		if r.ko.Spec.ScalingConfigurationInfo.AutoPause != nil && delta.DifferentAt("Spec.ScalingConfigurationInfo.AutoPause") {
-			f22.SetAutoPause(*r.ko.Spec.ScalingConfigurationInfo.AutoPause)
+		if r.ko.Spec.ScalingConfiguration.AutoPause != nil && delta.DifferentAt("Spec.ScalingConfiguration.AutoPause") {
+			f22.SetAutoPause(*r.ko.Spec.ScalingConfiguration.AutoPause)
 		}
-		if r.ko.Spec.ScalingConfigurationInfo.MaxCapacity != nil && delta.DifferentAt("Spec.ScalingConfigurationInfo.MaxCapacity") {
-			f22.SetMaxCapacity(*r.ko.Spec.ScalingConfigurationInfo.MaxCapacity)
+		if r.ko.Spec.ScalingConfiguration.MaxCapacity != nil && delta.DifferentAt("Spec.ScalingConfiguration.MaxCapacity") {
+			f22.SetMaxCapacity(*r.ko.Spec.ScalingConfiguration.MaxCapacity)
 		}
-		if r.ko.Spec.ScalingConfigurationInfo.MinCapacity != nil && delta.DifferentAt("Spec.ScalingConfigurationInfo.MinCapacity") {
-			f22.SetMinCapacity(*r.ko.Spec.ScalingConfigurationInfo.MinCapacity)
+		if r.ko.Spec.ScalingConfiguration.MinCapacity != nil && delta.DifferentAt("Spec.ScalingConfiguration.MinCapacity") {
+			f22.SetMinCapacity(*r.ko.Spec.ScalingConfiguration.MinCapacity)
 		}
-		if r.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause != nil && delta.DifferentAt("Spec.ScalingConfigurationInfo.SecondsUntilAutoPause") {
-			f22.SetSecondsUntilAutoPause(*r.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause)
+		if r.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause != nil && delta.DifferentAt("Spec.ScalingConfiguration.SecondsUntilAutoPause") {
+			f22.SetSecondsUntilAutoPause(*r.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause)
 		}
-		if r.ko.Spec.ScalingConfigurationInfo.TimeoutAction != nil && delta.DifferentAt("Spec.ScalingConfigurationInfo.TimeoutAction") {
-			f22.SetTimeoutAction(*r.ko.Spec.ScalingConfigurationInfo.TimeoutAction)
+		if r.ko.Spec.ScalingConfiguration.TimeoutAction != nil && delta.DifferentAt("Spec.ScalingConfiguration.TimeoutAction") {
+			f22.SetTimeoutAction(*r.ko.Spec.ScalingConfiguration.TimeoutAction)
 		}
 		res.SetScalingConfiguration(f22)
 	}
@@ -608,16 +608,18 @@ func (rm *resourceManager) newCustomUpdateRequestPayload(
 		}
 		res.SetVpcSecurityGroupIds(f23)
 	}
-        // For ServerlessV2ScalingConfiguration, MaxCapacity and MinCapacity,  both need appear in modify call to be modified
+	// For ServerlessV2ScalingConfiguration, MaxCapacity and MinCapacity,  both need appear in modify call to be modified
 	if r.ko.Spec.ServerlessV2ScalingConfiguration != nil && delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration") {
 		f23 := &svcsdk.ServerlessV2ScalingConfiguration{}
-                if r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity != nil && r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity != nil {
-                        if delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration.MaxCapacity") || delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration.MinCapacity") {
-                                f23.SetMaxCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity)
-                                f23.SetMinCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity)
-                        }
-                }
-                res.SetServerlessV2ScalingConfiguration(f23)
+		if r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity != nil && delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration.MaxCapacity") {
+			f23.SetMaxCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity)
+			f23.SetMinCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity)
+		}
+		if r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity != nil && delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration.MinCapacity") {
+			f23.SetMaxCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity)
+			f23.SetMinCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity)
+		}
+		res.SetServerlessV2ScalingConfiguration(f23)
 	}
 	return res, nil
 }

--- a/pkg/resource/db_cluster/custom_update.go
+++ b/pkg/resource/db_cluster/custom_update.go
@@ -608,14 +608,14 @@ func (rm *resourceManager) newCustomUpdateRequestPayload(
 		}
 		res.SetVpcSecurityGroupIds(f23)
 	}
-	// For ServerlessV2ScalingConfiguration, MaxCapacity and MinCapacity,  both need appear in modify call to be modified
+	// For ServerlessV2ScalingConfiguration, MaxCapacity and MinCapacity,  both need appear in modify call to get ServerlessV2ScalingConfiguration modified
 	if r.ko.Spec.ServerlessV2ScalingConfiguration != nil && delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration") {
 		f23 := &svcsdk.ServerlessV2ScalingConfiguration{}
-		if r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity != nil && delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration.MaxCapacity") {
+		if r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity != nil && r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity != nil && delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration.MaxCapacity") {
 			f23.SetMaxCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity)
 			f23.SetMinCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity)
 		}
-		if r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity != nil && delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration.MinCapacity") {
+		if r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity != nil && r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity != nil && delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration.MinCapacity") {
 			f23.SetMaxCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity)
 			f23.SetMinCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity)
 		}

--- a/pkg/resource/db_cluster/custom_update.go
+++ b/pkg/resource/db_cluster/custom_update.go
@@ -15,6 +15,7 @@ package db_cluster
 
 import (
 	"context"
+	"fmt"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -480,6 +481,18 @@ func (rm *resourceManager) customUpdate(
 	} else {
 		ko.Status.ScalingConfigurationInfo = nil
 	}
+	if resp.DBCluster.ServerlessV2ScalingConfigurationInfo != nil {
+		f52 := &svcapitypes.ServerlessV2ScalingConfigurationInfo{}
+		if resp.DBCluster.ServerlessV2ScalingConfigurationInfo.MinCapacity != nil {
+			f52.MinCapacity = resp.DBCluster.ServerlessV2ScalingConfigurationInfo.MinCapacity
+		}
+		if resp.DBCluster.ServerlessV2ScalingConfigurationInfo.MaxCapacity != nil {
+			f52.MaxCapacity = resp.DBCluster.ServerlessV2ScalingConfigurationInfo.MaxCapacity
+		}
+		ko.Status.ServerlessV2ScalingConfigurationInfo = f52
+	} else {
+		ko.Status.ServerlessV2ScalingConfigurationInfo = nil
+	}
 	if resp.DBCluster.Status != nil {
 		ko.Status.Status = resp.DBCluster.Status
 	} else {
@@ -630,6 +643,14 @@ func (rm *resourceManager) newCustomUpdateRequestPayload(
 		}
 		res.SetVpcSecurityGroupIds(f23)
 	}
-
+	if r.ko.Spec.ServerlessV2ScalingConfiguration != nil && delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration") {
+		f23 := &svcsdk.ServerlessV2ScalingConfiguration{}
+		if r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity != nil && delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration.MaxCapacity") {
+			f23.SetMaxCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity)
+		}
+		if r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity != nil && delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration.MinCapacity") {
+			f23.SetMinCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity)
+		}
+	}
 	return res, nil
 }

--- a/pkg/resource/db_cluster/custom_update.go
+++ b/pkg/resource/db_cluster/custom_update.go
@@ -15,7 +15,6 @@ package db_cluster
 
 import (
 	"context"
-	"fmt"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -63,7 +62,6 @@ func (rm *resourceManager) customUpdate(
 		ackcondition.SetSynced(desired, corev1.ConditionTrue, nil, nil)
 		return desired, nil
 	}
-
 	input, err := rm.newCustomUpdateRequestPayload(ctx, desired, delta)
 	if err != nil {
 		return nil, err
@@ -460,39 +458,6 @@ func (rm *resourceManager) customUpdate(
 	} else {
 		ko.Spec.ReplicationSourceIdentifier = nil
 	}
-	if resp.DBCluster.ScalingConfigurationInfo != nil {
-		f51 := &svcapitypes.ScalingConfigurationInfo{}
-		if resp.DBCluster.ScalingConfigurationInfo.AutoPause != nil {
-			f51.AutoPause = resp.DBCluster.ScalingConfigurationInfo.AutoPause
-		}
-		if resp.DBCluster.ScalingConfigurationInfo.MaxCapacity != nil {
-			f51.MaxCapacity = resp.DBCluster.ScalingConfigurationInfo.MaxCapacity
-		}
-		if resp.DBCluster.ScalingConfigurationInfo.MinCapacity != nil {
-			f51.MinCapacity = resp.DBCluster.ScalingConfigurationInfo.MinCapacity
-		}
-		if resp.DBCluster.ScalingConfigurationInfo.SecondsUntilAutoPause != nil {
-			f51.SecondsUntilAutoPause = resp.DBCluster.ScalingConfigurationInfo.SecondsUntilAutoPause
-		}
-		if resp.DBCluster.ScalingConfigurationInfo.TimeoutAction != nil {
-			f51.TimeoutAction = resp.DBCluster.ScalingConfigurationInfo.TimeoutAction
-		}
-		ko.Status.ScalingConfigurationInfo = f51
-	} else {
-		ko.Status.ScalingConfigurationInfo = nil
-	}
-	if resp.DBCluster.ServerlessV2ScalingConfigurationInfo != nil {
-		f52 := &svcapitypes.ServerlessV2ScalingConfigurationInfo{}
-		if resp.DBCluster.ServerlessV2ScalingConfigurationInfo.MinCapacity != nil {
-			f52.MinCapacity = resp.DBCluster.ServerlessV2ScalingConfigurationInfo.MinCapacity
-		}
-		if resp.DBCluster.ServerlessV2ScalingConfigurationInfo.MaxCapacity != nil {
-			f52.MaxCapacity = resp.DBCluster.ServerlessV2ScalingConfigurationInfo.MaxCapacity
-		}
-		ko.Status.ServerlessV2ScalingConfigurationInfo = f52
-	} else {
-		ko.Status.ServerlessV2ScalingConfigurationInfo = nil
-	}
 	if resp.DBCluster.Status != nil {
 		ko.Status.Status = resp.DBCluster.Status
 	} else {
@@ -615,22 +580,22 @@ func (rm *resourceManager) newCustomUpdateRequestPayload(
 	if r.ko.Spec.PreferredMaintenanceWindow != nil && delta.DifferentAt("Spec.PreferredMaintenanceWindow") {
 		res.SetPreferredMaintenanceWindow(*r.ko.Spec.PreferredMaintenanceWindow)
 	}
-	if r.ko.Spec.ScalingConfiguration != nil && delta.DifferentAt("Spec.ScalingConfiguration") {
+	if r.ko.Spec.ScalingConfigurationInfo != nil && delta.DifferentAt("Spec.ScalingConfigurationInfo") {
 		f22 := &svcsdk.ScalingConfiguration{}
-		if r.ko.Spec.ScalingConfiguration.AutoPause != nil && delta.DifferentAt("Spec.ScalingConfiguration.AutoPause") {
-			f22.SetAutoPause(*r.ko.Spec.ScalingConfiguration.AutoPause)
+		if r.ko.Spec.ScalingConfigurationInfo.AutoPause != nil && delta.DifferentAt("Spec.ScalingConfigurationInfo.AutoPause") {
+			f22.SetAutoPause(*r.ko.Spec.ScalingConfigurationInfo.AutoPause)
 		}
-		if r.ko.Spec.ScalingConfiguration.MaxCapacity != nil && delta.DifferentAt("Spec.ScalingConfiguration.MaxCapacity") {
-			f22.SetMaxCapacity(*r.ko.Spec.ScalingConfiguration.MaxCapacity)
+		if r.ko.Spec.ScalingConfigurationInfo.MaxCapacity != nil && delta.DifferentAt("Spec.ScalingConfigurationInfo.MaxCapacity") {
+			f22.SetMaxCapacity(*r.ko.Spec.ScalingConfigurationInfo.MaxCapacity)
 		}
-		if r.ko.Spec.ScalingConfiguration.MinCapacity != nil && delta.DifferentAt("Spec.ScalingConfiguration.MinCapacity") {
-			f22.SetMinCapacity(*r.ko.Spec.ScalingConfiguration.MinCapacity)
+		if r.ko.Spec.ScalingConfigurationInfo.MinCapacity != nil && delta.DifferentAt("Spec.ScalingConfigurationInfo.MinCapacity") {
+			f22.SetMinCapacity(*r.ko.Spec.ScalingConfigurationInfo.MinCapacity)
 		}
-		if r.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause != nil && delta.DifferentAt("Spec.ScalingConfiguration.SecondsUntilAutoPause") {
-			f22.SetSecondsUntilAutoPause(*r.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause)
+		if r.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause != nil && delta.DifferentAt("Spec.ScalingConfigurationInfo.SecondsUntilAutoPause") {
+			f22.SetSecondsUntilAutoPause(*r.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause)
 		}
-		if r.ko.Spec.ScalingConfiguration.TimeoutAction != nil && delta.DifferentAt("Spec.ScalingConfiguration.TimeoutAction") {
-			f22.SetTimeoutAction(*r.ko.Spec.ScalingConfiguration.TimeoutAction)
+		if r.ko.Spec.ScalingConfigurationInfo.TimeoutAction != nil && delta.DifferentAt("Spec.ScalingConfigurationInfo.TimeoutAction") {
+			f22.SetTimeoutAction(*r.ko.Spec.ScalingConfigurationInfo.TimeoutAction)
 		}
 		res.SetScalingConfiguration(f22)
 	}
@@ -643,14 +608,16 @@ func (rm *resourceManager) newCustomUpdateRequestPayload(
 		}
 		res.SetVpcSecurityGroupIds(f23)
 	}
+        // For ServerlessV2ScalingConfiguration, MaxCapacity and MinCapacity,  both need appear in modify call to be modified
 	if r.ko.Spec.ServerlessV2ScalingConfiguration != nil && delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration") {
 		f23 := &svcsdk.ServerlessV2ScalingConfiguration{}
-		if r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity != nil && delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration.MaxCapacity") {
-			f23.SetMaxCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity)
-		}
-		if r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity != nil && delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration.MinCapacity") {
-			f23.SetMinCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity)
-		}
+                if r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity != nil && r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity != nil {
+                        if delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration.MaxCapacity") || delta.DifferentAt("Spec.ServerlessV2ScalingConfiguration.MinCapacity") {
+                                f23.SetMaxCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MaxCapacity)
+                                f23.SetMinCapacity(*r.ko.Spec.ServerlessV2ScalingConfiguration.MinCapacity)
+                        }
+                }
+                res.SetServerlessV2ScalingConfiguration(f23)
 	}
 	return res, nil
 }

--- a/pkg/resource/db_cluster/delta.go
+++ b/pkg/resource/db_cluster/delta.go
@@ -317,49 +317,49 @@ func newResourceDelta(
 			delta.Add("Spec.ReplicationSourceIdentifier", a.ko.Spec.ReplicationSourceIdentifier, b.ko.Spec.ReplicationSourceIdentifier)
 		}
 	}
-	if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfiguration, b.ko.Spec.ScalingConfiguration) {
-		delta.Add("Spec.ScalingConfiguration", a.ko.Spec.ScalingConfiguration, b.ko.Spec.ScalingConfiguration)
-	} else if a.ko.Spec.ScalingConfiguration != nil && b.ko.Spec.ScalingConfiguration != nil {
-		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfiguration.AutoPause, b.ko.Spec.ScalingConfiguration.AutoPause) {
-			delta.Add("Spec.ScalingConfiguration.AutoPause", a.ko.Spec.ScalingConfiguration.AutoPause, b.ko.Spec.ScalingConfiguration.AutoPause)
-		} else if a.ko.Spec.ScalingConfiguration.AutoPause != nil && b.ko.Spec.ScalingConfiguration.AutoPause != nil {
-			if *a.ko.Spec.ScalingConfiguration.AutoPause != *b.ko.Spec.ScalingConfiguration.AutoPause {
-				delta.Add("Spec.ScalingConfiguration.AutoPause", a.ko.Spec.ScalingConfiguration.AutoPause, b.ko.Spec.ScalingConfiguration.AutoPause)
+	if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfigurationInfo, b.ko.Spec.ScalingConfigurationInfo) {
+		delta.Add("Spec.ScalingConfigurationInfo", a.ko.Spec.ScalingConfigurationInfo, b.ko.Spec.ScalingConfigurationInfo)
+	} else if a.ko.Spec.ScalingConfigurationInfo != nil && b.ko.Spec.ScalingConfigurationInfo != nil {
+		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfigurationInfo.AutoPause, b.ko.Spec.ScalingConfigurationInfo.AutoPause) {
+			delta.Add("Spec.ScalingConfigurationInfo.AutoPause", a.ko.Spec.ScalingConfigurationInfo.AutoPause, b.ko.Spec.ScalingConfigurationInfo.AutoPause)
+		} else if a.ko.Spec.ScalingConfigurationInfo.AutoPause != nil && b.ko.Spec.ScalingConfigurationInfo.AutoPause != nil {
+			if *a.ko.Spec.ScalingConfigurationInfo.AutoPause != *b.ko.Spec.ScalingConfigurationInfo.AutoPause {
+				delta.Add("Spec.ScalingConfigurationInfo.AutoPause", a.ko.Spec.ScalingConfigurationInfo.AutoPause, b.ko.Spec.ScalingConfigurationInfo.AutoPause)
 			}
 		}
-		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfiguration.MaxCapacity, b.ko.Spec.ScalingConfiguration.MaxCapacity) {
-			delta.Add("Spec.ScalingConfiguration.MaxCapacity", a.ko.Spec.ScalingConfiguration.MaxCapacity, b.ko.Spec.ScalingConfiguration.MaxCapacity)
-		} else if a.ko.Spec.ScalingConfiguration.MaxCapacity != nil && b.ko.Spec.ScalingConfiguration.MaxCapacity != nil {
-			if *a.ko.Spec.ScalingConfiguration.MaxCapacity != *b.ko.Spec.ScalingConfiguration.MaxCapacity {
-				delta.Add("Spec.ScalingConfiguration.MaxCapacity", a.ko.Spec.ScalingConfiguration.MaxCapacity, b.ko.Spec.ScalingConfiguration.MaxCapacity)
+		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfigurationInfo.MaxCapacity, b.ko.Spec.ScalingConfigurationInfo.MaxCapacity) {
+			delta.Add("Spec.ScalingConfigurationInfo.MaxCapacity", a.ko.Spec.ScalingConfigurationInfo.MaxCapacity, b.ko.Spec.ScalingConfigurationInfo.MaxCapacity)
+		} else if a.ko.Spec.ScalingConfigurationInfo.MaxCapacity != nil && b.ko.Spec.ScalingConfigurationInfo.MaxCapacity != nil {
+			if *a.ko.Spec.ScalingConfigurationInfo.MaxCapacity != *b.ko.Spec.ScalingConfigurationInfo.MaxCapacity {
+				delta.Add("Spec.ScalingConfigurationInfo.MaxCapacity", a.ko.Spec.ScalingConfigurationInfo.MaxCapacity, b.ko.Spec.ScalingConfigurationInfo.MaxCapacity)
 			}
 		}
-		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfiguration.MinCapacity, b.ko.Spec.ScalingConfiguration.MinCapacity) {
-			delta.Add("Spec.ScalingConfiguration.MinCapacity", a.ko.Spec.ScalingConfiguration.MinCapacity, b.ko.Spec.ScalingConfiguration.MinCapacity)
-		} else if a.ko.Spec.ScalingConfiguration.MinCapacity != nil && b.ko.Spec.ScalingConfiguration.MinCapacity != nil {
-			if *a.ko.Spec.ScalingConfiguration.MinCapacity != *b.ko.Spec.ScalingConfiguration.MinCapacity {
-				delta.Add("Spec.ScalingConfiguration.MinCapacity", a.ko.Spec.ScalingConfiguration.MinCapacity, b.ko.Spec.ScalingConfiguration.MinCapacity)
+		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfigurationInfo.MinCapacity, b.ko.Spec.ScalingConfigurationInfo.MinCapacity) {
+			delta.Add("Spec.ScalingConfigurationInfo.MinCapacity", a.ko.Spec.ScalingConfigurationInfo.MinCapacity, b.ko.Spec.ScalingConfigurationInfo.MinCapacity)
+		} else if a.ko.Spec.ScalingConfigurationInfo.MinCapacity != nil && b.ko.Spec.ScalingConfigurationInfo.MinCapacity != nil {
+			if *a.ko.Spec.ScalingConfigurationInfo.MinCapacity != *b.ko.Spec.ScalingConfigurationInfo.MinCapacity {
+				delta.Add("Spec.ScalingConfigurationInfo.MinCapacity", a.ko.Spec.ScalingConfigurationInfo.MinCapacity, b.ko.Spec.ScalingConfigurationInfo.MinCapacity)
 			}
 		}
-		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout, b.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout) {
-			delta.Add("Spec.ScalingConfiguration.SecondsBeforeTimeout", a.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout, b.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout)
-		} else if a.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout != nil && b.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout != nil {
-			if *a.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout != *b.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout {
-				delta.Add("Spec.ScalingConfiguration.SecondsBeforeTimeout", a.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout, b.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout)
+		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout, b.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout) {
+			delta.Add("Spec.ScalingConfigurationInfo.SecondsBeforeTimeout", a.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout, b.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout)
+		} else if a.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout != nil && b.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout != nil {
+			if *a.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout != *b.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout {
+				delta.Add("Spec.ScalingConfigurationInfo.SecondsBeforeTimeout", a.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout, b.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout)
 			}
 		}
-		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause, b.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause) {
-			delta.Add("Spec.ScalingConfiguration.SecondsUntilAutoPause", a.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause, b.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause)
-		} else if a.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause != nil && b.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause != nil {
-			if *a.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause != *b.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause {
-				delta.Add("Spec.ScalingConfiguration.SecondsUntilAutoPause", a.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause, b.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause)
+		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause, b.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause) {
+			delta.Add("Spec.ScalingConfigurationInfo.SecondsUntilAutoPause", a.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause, b.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause)
+		} else if a.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause != nil && b.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause != nil {
+			if *a.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause != *b.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause {
+				delta.Add("Spec.ScalingConfigurationInfo.SecondsUntilAutoPause", a.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause, b.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause)
 			}
 		}
-		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfiguration.TimeoutAction, b.ko.Spec.ScalingConfiguration.TimeoutAction) {
-			delta.Add("Spec.ScalingConfiguration.TimeoutAction", a.ko.Spec.ScalingConfiguration.TimeoutAction, b.ko.Spec.ScalingConfiguration.TimeoutAction)
-		} else if a.ko.Spec.ScalingConfiguration.TimeoutAction != nil && b.ko.Spec.ScalingConfiguration.TimeoutAction != nil {
-			if *a.ko.Spec.ScalingConfiguration.TimeoutAction != *b.ko.Spec.ScalingConfiguration.TimeoutAction {
-				delta.Add("Spec.ScalingConfiguration.TimeoutAction", a.ko.Spec.ScalingConfiguration.TimeoutAction, b.ko.Spec.ScalingConfiguration.TimeoutAction)
+		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfigurationInfo.TimeoutAction, b.ko.Spec.ScalingConfigurationInfo.TimeoutAction) {
+			delta.Add("Spec.ScalingConfigurationInfo.TimeoutAction", a.ko.Spec.ScalingConfigurationInfo.TimeoutAction, b.ko.Spec.ScalingConfigurationInfo.TimeoutAction)
+		} else if a.ko.Spec.ScalingConfigurationInfo.TimeoutAction != nil && b.ko.Spec.ScalingConfigurationInfo.TimeoutAction != nil {
+			if *a.ko.Spec.ScalingConfigurationInfo.TimeoutAction != *b.ko.Spec.ScalingConfigurationInfo.TimeoutAction {
+				delta.Add("Spec.ScalingConfigurationInfo.TimeoutAction", a.ko.Spec.ScalingConfigurationInfo.TimeoutAction, b.ko.Spec.ScalingConfigurationInfo.TimeoutAction)
 			}
 		}
 	}

--- a/pkg/resource/db_cluster/delta.go
+++ b/pkg/resource/db_cluster/delta.go
@@ -317,49 +317,49 @@ func newResourceDelta(
 			delta.Add("Spec.ReplicationSourceIdentifier", a.ko.Spec.ReplicationSourceIdentifier, b.ko.Spec.ReplicationSourceIdentifier)
 		}
 	}
-	if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfigurationInfo, b.ko.Spec.ScalingConfigurationInfo) {
-		delta.Add("Spec.ScalingConfigurationInfo", a.ko.Spec.ScalingConfigurationInfo, b.ko.Spec.ScalingConfigurationInfo)
-	} else if a.ko.Spec.ScalingConfigurationInfo != nil && b.ko.Spec.ScalingConfigurationInfo != nil {
-		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfigurationInfo.AutoPause, b.ko.Spec.ScalingConfigurationInfo.AutoPause) {
-			delta.Add("Spec.ScalingConfigurationInfo.AutoPause", a.ko.Spec.ScalingConfigurationInfo.AutoPause, b.ko.Spec.ScalingConfigurationInfo.AutoPause)
-		} else if a.ko.Spec.ScalingConfigurationInfo.AutoPause != nil && b.ko.Spec.ScalingConfigurationInfo.AutoPause != nil {
-			if *a.ko.Spec.ScalingConfigurationInfo.AutoPause != *b.ko.Spec.ScalingConfigurationInfo.AutoPause {
-				delta.Add("Spec.ScalingConfigurationInfo.AutoPause", a.ko.Spec.ScalingConfigurationInfo.AutoPause, b.ko.Spec.ScalingConfigurationInfo.AutoPause)
+	if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfiguration, b.ko.Spec.ScalingConfiguration) {
+		delta.Add("Spec.ScalingConfiguration", a.ko.Spec.ScalingConfiguration, b.ko.Spec.ScalingConfiguration)
+	} else if a.ko.Spec.ScalingConfiguration != nil && b.ko.Spec.ScalingConfiguration != nil {
+		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfiguration.AutoPause, b.ko.Spec.ScalingConfiguration.AutoPause) {
+			delta.Add("Spec.ScalingConfiguration.AutoPause", a.ko.Spec.ScalingConfiguration.AutoPause, b.ko.Spec.ScalingConfiguration.AutoPause)
+		} else if a.ko.Spec.ScalingConfiguration.AutoPause != nil && b.ko.Spec.ScalingConfiguration.AutoPause != nil {
+			if *a.ko.Spec.ScalingConfiguration.AutoPause != *b.ko.Spec.ScalingConfiguration.AutoPause {
+				delta.Add("Spec.ScalingConfiguration.AutoPause", a.ko.Spec.ScalingConfiguration.AutoPause, b.ko.Spec.ScalingConfiguration.AutoPause)
 			}
 		}
-		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfigurationInfo.MaxCapacity, b.ko.Spec.ScalingConfigurationInfo.MaxCapacity) {
-			delta.Add("Spec.ScalingConfigurationInfo.MaxCapacity", a.ko.Spec.ScalingConfigurationInfo.MaxCapacity, b.ko.Spec.ScalingConfigurationInfo.MaxCapacity)
-		} else if a.ko.Spec.ScalingConfigurationInfo.MaxCapacity != nil && b.ko.Spec.ScalingConfigurationInfo.MaxCapacity != nil {
-			if *a.ko.Spec.ScalingConfigurationInfo.MaxCapacity != *b.ko.Spec.ScalingConfigurationInfo.MaxCapacity {
-				delta.Add("Spec.ScalingConfigurationInfo.MaxCapacity", a.ko.Spec.ScalingConfigurationInfo.MaxCapacity, b.ko.Spec.ScalingConfigurationInfo.MaxCapacity)
+		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfiguration.MaxCapacity, b.ko.Spec.ScalingConfiguration.MaxCapacity) {
+			delta.Add("Spec.ScalingConfiguration.MaxCapacity", a.ko.Spec.ScalingConfiguration.MaxCapacity, b.ko.Spec.ScalingConfiguration.MaxCapacity)
+		} else if a.ko.Spec.ScalingConfiguration.MaxCapacity != nil && b.ko.Spec.ScalingConfiguration.MaxCapacity != nil {
+			if *a.ko.Spec.ScalingConfiguration.MaxCapacity != *b.ko.Spec.ScalingConfiguration.MaxCapacity {
+				delta.Add("Spec.ScalingConfiguration.MaxCapacity", a.ko.Spec.ScalingConfiguration.MaxCapacity, b.ko.Spec.ScalingConfiguration.MaxCapacity)
 			}
 		}
-		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfigurationInfo.MinCapacity, b.ko.Spec.ScalingConfigurationInfo.MinCapacity) {
-			delta.Add("Spec.ScalingConfigurationInfo.MinCapacity", a.ko.Spec.ScalingConfigurationInfo.MinCapacity, b.ko.Spec.ScalingConfigurationInfo.MinCapacity)
-		} else if a.ko.Spec.ScalingConfigurationInfo.MinCapacity != nil && b.ko.Spec.ScalingConfigurationInfo.MinCapacity != nil {
-			if *a.ko.Spec.ScalingConfigurationInfo.MinCapacity != *b.ko.Spec.ScalingConfigurationInfo.MinCapacity {
-				delta.Add("Spec.ScalingConfigurationInfo.MinCapacity", a.ko.Spec.ScalingConfigurationInfo.MinCapacity, b.ko.Spec.ScalingConfigurationInfo.MinCapacity)
+		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfiguration.MinCapacity, b.ko.Spec.ScalingConfiguration.MinCapacity) {
+			delta.Add("Spec.ScalingConfiguration.MinCapacity", a.ko.Spec.ScalingConfiguration.MinCapacity, b.ko.Spec.ScalingConfiguration.MinCapacity)
+		} else if a.ko.Spec.ScalingConfiguration.MinCapacity != nil && b.ko.Spec.ScalingConfiguration.MinCapacity != nil {
+			if *a.ko.Spec.ScalingConfiguration.MinCapacity != *b.ko.Spec.ScalingConfiguration.MinCapacity {
+				delta.Add("Spec.ScalingConfiguration.MinCapacity", a.ko.Spec.ScalingConfiguration.MinCapacity, b.ko.Spec.ScalingConfiguration.MinCapacity)
 			}
 		}
-		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout, b.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout) {
-			delta.Add("Spec.ScalingConfigurationInfo.SecondsBeforeTimeout", a.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout, b.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout)
-		} else if a.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout != nil && b.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout != nil {
-			if *a.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout != *b.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout {
-				delta.Add("Spec.ScalingConfigurationInfo.SecondsBeforeTimeout", a.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout, b.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout)
+		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout, b.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout) {
+			delta.Add("Spec.ScalingConfiguration.SecondsBeforeTimeout", a.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout, b.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout)
+		} else if a.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout != nil && b.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout != nil {
+			if *a.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout != *b.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout {
+				delta.Add("Spec.ScalingConfiguration.SecondsBeforeTimeout", a.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout, b.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout)
 			}
 		}
-		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause, b.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause) {
-			delta.Add("Spec.ScalingConfigurationInfo.SecondsUntilAutoPause", a.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause, b.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause)
-		} else if a.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause != nil && b.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause != nil {
-			if *a.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause != *b.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause {
-				delta.Add("Spec.ScalingConfigurationInfo.SecondsUntilAutoPause", a.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause, b.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause)
+		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause, b.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause) {
+			delta.Add("Spec.ScalingConfiguration.SecondsUntilAutoPause", a.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause, b.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause)
+		} else if a.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause != nil && b.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause != nil {
+			if *a.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause != *b.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause {
+				delta.Add("Spec.ScalingConfiguration.SecondsUntilAutoPause", a.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause, b.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause)
 			}
 		}
-		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfigurationInfo.TimeoutAction, b.ko.Spec.ScalingConfigurationInfo.TimeoutAction) {
-			delta.Add("Spec.ScalingConfigurationInfo.TimeoutAction", a.ko.Spec.ScalingConfigurationInfo.TimeoutAction, b.ko.Spec.ScalingConfigurationInfo.TimeoutAction)
-		} else if a.ko.Spec.ScalingConfigurationInfo.TimeoutAction != nil && b.ko.Spec.ScalingConfigurationInfo.TimeoutAction != nil {
-			if *a.ko.Spec.ScalingConfigurationInfo.TimeoutAction != *b.ko.Spec.ScalingConfigurationInfo.TimeoutAction {
-				delta.Add("Spec.ScalingConfigurationInfo.TimeoutAction", a.ko.Spec.ScalingConfigurationInfo.TimeoutAction, b.ko.Spec.ScalingConfigurationInfo.TimeoutAction)
+		if ackcompare.HasNilDifference(a.ko.Spec.ScalingConfiguration.TimeoutAction, b.ko.Spec.ScalingConfiguration.TimeoutAction) {
+			delta.Add("Spec.ScalingConfiguration.TimeoutAction", a.ko.Spec.ScalingConfiguration.TimeoutAction, b.ko.Spec.ScalingConfiguration.TimeoutAction)
+		} else if a.ko.Spec.ScalingConfiguration.TimeoutAction != nil && b.ko.Spec.ScalingConfiguration.TimeoutAction != nil {
+			if *a.ko.Spec.ScalingConfiguration.TimeoutAction != *b.ko.Spec.ScalingConfiguration.TimeoutAction {
+				delta.Add("Spec.ScalingConfiguration.TimeoutAction", a.ko.Spec.ScalingConfiguration.TimeoutAction, b.ko.Spec.ScalingConfiguration.TimeoutAction)
 			}
 		}
 	}

--- a/pkg/resource/db_cluster/sdk.go
+++ b/pkg/resource/db_cluster/sdk.go
@@ -18,6 +18,7 @@ package db_cluster
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -25,6 +26,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/rds"
@@ -45,6 +47,8 @@ var (
 	_ = &ackerr.NotFound
 	_ = &ackcondition.NotManagedMessage
 	_ = &reflect.Value{}
+	_ = fmt.Sprintf("")
+	_ = &ackrequeue.NoRequeue{}
 )
 
 // sdkFind returns SDK-specific information about a supplied resource
@@ -1297,7 +1301,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 	if r.ko.Spec.MasterUserPassword != nil {
 		tmpSecret, err := rm.rr.SecretValueFromReference(ctx, r.ko.Spec.MasterUserPassword)
 		if err != nil {
-			return nil, err
+			return nil, ackrequeue.Needed(err)
 		}
 		if tmpSecret != "" {
 			res.SetMasterUserPassword(tmpSecret)

--- a/pkg/resource/db_cluster/sdk.go
+++ b/pkg/resource/db_cluster/sdk.go
@@ -514,7 +514,7 @@ func (rm *resourceManager) sdkFind(
 			ko.Spec.ReplicationSourceIdentifier = nil
 		}
 		if elem.ScalingConfigurationInfo != nil {
-			f61 := &svcapitypes.ScalingConfigurationInfo{}
+			f61 := &svcapitypes.ScalingConfiguration{}
 			if elem.ScalingConfigurationInfo.AutoPause != nil {
 				f61.AutoPause = elem.ScalingConfigurationInfo.AutoPause
 			}
@@ -533,9 +533,9 @@ func (rm *resourceManager) sdkFind(
 			if elem.ScalingConfigurationInfo.TimeoutAction != nil {
 				f61.TimeoutAction = elem.ScalingConfigurationInfo.TimeoutAction
 			}
-			ko.Status.ScalingConfigurationInfo = f61
+			ko.Spec.ScalingConfigurationInfo = f61
 		} else {
-			ko.Status.ScalingConfigurationInfo = nil
+			ko.Spec.ScalingConfigurationInfo = nil
 		}
 		if elem.ServerlessV2ScalingConfiguration != nil {
 			f62 := &svcapitypes.ServerlessV2ScalingConfiguration{}
@@ -1100,7 +1100,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Spec.ReplicationSourceIdentifier = nil
 	}
 	if resp.DBCluster.ScalingConfigurationInfo != nil {
-		f61 := &svcapitypes.ScalingConfigurationInfo{}
+		f61 := &svcapitypes.ScalingConfiguration{}
 		if resp.DBCluster.ScalingConfigurationInfo.AutoPause != nil {
 			f61.AutoPause = resp.DBCluster.ScalingConfigurationInfo.AutoPause
 		}
@@ -1119,9 +1119,9 @@ func (rm *resourceManager) sdkCreate(
 		if resp.DBCluster.ScalingConfigurationInfo.TimeoutAction != nil {
 			f61.TimeoutAction = resp.DBCluster.ScalingConfigurationInfo.TimeoutAction
 		}
-		ko.Status.ScalingConfigurationInfo = f61
+		ko.Spec.ScalingConfigurationInfo = f61
 	} else {
-		ko.Status.ScalingConfigurationInfo = nil
+		ko.Spec.ScalingConfigurationInfo = nil
 	}
 	if resp.DBCluster.ServerlessV2ScalingConfiguration != nil {
 		f62 := &svcapitypes.ServerlessV2ScalingConfiguration{}
@@ -1343,25 +1343,25 @@ func (rm *resourceManager) newCreateRequestPayload(
 	if r.ko.Spec.ReplicationSourceIdentifier != nil {
 		res.SetReplicationSourceIdentifier(*r.ko.Spec.ReplicationSourceIdentifier)
 	}
-	if r.ko.Spec.ScalingConfiguration != nil {
+	if r.ko.Spec.ScalingConfigurationInfo != nil {
 		f40 := &svcsdk.ScalingConfiguration{}
-		if r.ko.Spec.ScalingConfiguration.AutoPause != nil {
-			f40.SetAutoPause(*r.ko.Spec.ScalingConfiguration.AutoPause)
+		if r.ko.Spec.ScalingConfigurationInfo.AutoPause != nil {
+			f40.SetAutoPause(*r.ko.Spec.ScalingConfigurationInfo.AutoPause)
 		}
-		if r.ko.Spec.ScalingConfiguration.MaxCapacity != nil {
-			f40.SetMaxCapacity(*r.ko.Spec.ScalingConfiguration.MaxCapacity)
+		if r.ko.Spec.ScalingConfigurationInfo.MaxCapacity != nil {
+			f40.SetMaxCapacity(*r.ko.Spec.ScalingConfigurationInfo.MaxCapacity)
 		}
-		if r.ko.Spec.ScalingConfiguration.MinCapacity != nil {
-			f40.SetMinCapacity(*r.ko.Spec.ScalingConfiguration.MinCapacity)
+		if r.ko.Spec.ScalingConfigurationInfo.MinCapacity != nil {
+			f40.SetMinCapacity(*r.ko.Spec.ScalingConfigurationInfo.MinCapacity)
 		}
-		if r.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout != nil {
-			f40.SetSecondsBeforeTimeout(*r.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout)
+		if r.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout != nil {
+			f40.SetSecondsBeforeTimeout(*r.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout)
 		}
-		if r.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause != nil {
-			f40.SetSecondsUntilAutoPause(*r.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause)
+		if r.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause != nil {
+			f40.SetSecondsUntilAutoPause(*r.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause)
 		}
-		if r.ko.Spec.ScalingConfiguration.TimeoutAction != nil {
-			f40.SetTimeoutAction(*r.ko.Spec.ScalingConfiguration.TimeoutAction)
+		if r.ko.Spec.ScalingConfigurationInfo.TimeoutAction != nil {
+			f40.SetTimeoutAction(*r.ko.Spec.ScalingConfigurationInfo.TimeoutAction)
 		}
 		res.SetScalingConfiguration(f40)
 	}

--- a/pkg/resource/db_cluster/sdk.go
+++ b/pkg/resource/db_cluster/sdk.go
@@ -513,30 +513,6 @@ func (rm *resourceManager) sdkFind(
 		} else {
 			ko.Spec.ReplicationSourceIdentifier = nil
 		}
-		if elem.ScalingConfigurationInfo != nil {
-			f61 := &svcapitypes.ScalingConfiguration{}
-			if elem.ScalingConfigurationInfo.AutoPause != nil {
-				f61.AutoPause = elem.ScalingConfigurationInfo.AutoPause
-			}
-			if elem.ScalingConfigurationInfo.MaxCapacity != nil {
-				f61.MaxCapacity = elem.ScalingConfigurationInfo.MaxCapacity
-			}
-			if elem.ScalingConfigurationInfo.MinCapacity != nil {
-				f61.MinCapacity = elem.ScalingConfigurationInfo.MinCapacity
-			}
-			if elem.ScalingConfigurationInfo.SecondsBeforeTimeout != nil {
-				f61.SecondsBeforeTimeout = elem.ScalingConfigurationInfo.SecondsBeforeTimeout
-			}
-			if elem.ScalingConfigurationInfo.SecondsUntilAutoPause != nil {
-				f61.SecondsUntilAutoPause = elem.ScalingConfigurationInfo.SecondsUntilAutoPause
-			}
-			if elem.ScalingConfigurationInfo.TimeoutAction != nil {
-				f61.TimeoutAction = elem.ScalingConfigurationInfo.TimeoutAction
-			}
-			ko.Spec.ScalingConfigurationInfo = f61
-		} else {
-			ko.Spec.ScalingConfigurationInfo = nil
-		}
 		if elem.ServerlessV2ScalingConfiguration != nil {
 			f62 := &svcapitypes.ServerlessV2ScalingConfiguration{}
 			if elem.ServerlessV2ScalingConfiguration.MaxCapacity != nil {
@@ -1119,9 +1095,9 @@ func (rm *resourceManager) sdkCreate(
 		if resp.DBCluster.ScalingConfigurationInfo.TimeoutAction != nil {
 			f61.TimeoutAction = resp.DBCluster.ScalingConfigurationInfo.TimeoutAction
 		}
-		ko.Spec.ScalingConfigurationInfo = f61
+		ko.Spec.ScalingConfiguration = f61
 	} else {
-		ko.Spec.ScalingConfigurationInfo = nil
+		ko.Spec.ScalingConfiguration = nil
 	}
 	if resp.DBCluster.ServerlessV2ScalingConfiguration != nil {
 		f62 := &svcapitypes.ServerlessV2ScalingConfiguration{}
@@ -1343,25 +1319,25 @@ func (rm *resourceManager) newCreateRequestPayload(
 	if r.ko.Spec.ReplicationSourceIdentifier != nil {
 		res.SetReplicationSourceIdentifier(*r.ko.Spec.ReplicationSourceIdentifier)
 	}
-	if r.ko.Spec.ScalingConfigurationInfo != nil {
+	if r.ko.Spec.ScalingConfiguration != nil {
 		f40 := &svcsdk.ScalingConfiguration{}
-		if r.ko.Spec.ScalingConfigurationInfo.AutoPause != nil {
-			f40.SetAutoPause(*r.ko.Spec.ScalingConfigurationInfo.AutoPause)
+		if r.ko.Spec.ScalingConfiguration.AutoPause != nil {
+			f40.SetAutoPause(*r.ko.Spec.ScalingConfiguration.AutoPause)
 		}
-		if r.ko.Spec.ScalingConfigurationInfo.MaxCapacity != nil {
-			f40.SetMaxCapacity(*r.ko.Spec.ScalingConfigurationInfo.MaxCapacity)
+		if r.ko.Spec.ScalingConfiguration.MaxCapacity != nil {
+			f40.SetMaxCapacity(*r.ko.Spec.ScalingConfiguration.MaxCapacity)
 		}
-		if r.ko.Spec.ScalingConfigurationInfo.MinCapacity != nil {
-			f40.SetMinCapacity(*r.ko.Spec.ScalingConfigurationInfo.MinCapacity)
+		if r.ko.Spec.ScalingConfiguration.MinCapacity != nil {
+			f40.SetMinCapacity(*r.ko.Spec.ScalingConfiguration.MinCapacity)
 		}
-		if r.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout != nil {
-			f40.SetSecondsBeforeTimeout(*r.ko.Spec.ScalingConfigurationInfo.SecondsBeforeTimeout)
+		if r.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout != nil {
+			f40.SetSecondsBeforeTimeout(*r.ko.Spec.ScalingConfiguration.SecondsBeforeTimeout)
 		}
-		if r.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause != nil {
-			f40.SetSecondsUntilAutoPause(*r.ko.Spec.ScalingConfigurationInfo.SecondsUntilAutoPause)
+		if r.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause != nil {
+			f40.SetSecondsUntilAutoPause(*r.ko.Spec.ScalingConfiguration.SecondsUntilAutoPause)
 		}
-		if r.ko.Spec.ScalingConfigurationInfo.TimeoutAction != nil {
-			f40.SetTimeoutAction(*r.ko.Spec.ScalingConfigurationInfo.TimeoutAction)
+		if r.ko.Spec.ScalingConfiguration.TimeoutAction != nil {
+			f40.SetTimeoutAction(*r.ko.Spec.ScalingConfiguration.TimeoutAction)
 		}
 		res.SetScalingConfiguration(f40)
 	}

--- a/pkg/resource/db_cluster_parameter_group/sdk.go
+++ b/pkg/resource/db_cluster_parameter_group/sdk.go
@@ -18,6 +18,7 @@ package db_cluster_parameter_group
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -25,6 +26,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/rds"
@@ -45,6 +47,8 @@ var (
 	_ = &ackerr.NotFound
 	_ = &ackcondition.NotManagedMessage
 	_ = &reflect.Value{}
+	_ = fmt.Sprintf("")
+	_ = &ackrequeue.NoRequeue{}
 )
 
 // sdkFind returns SDK-specific information about a supplied resource

--- a/pkg/resource/db_parameter_group/sdk.go
+++ b/pkg/resource/db_parameter_group/sdk.go
@@ -18,6 +18,7 @@ package db_parameter_group
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -25,6 +26,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/rds"
@@ -45,6 +47,8 @@ var (
 	_ = &ackerr.NotFound
 	_ = &ackcondition.NotManagedMessage
 	_ = &reflect.Value{}
+	_ = fmt.Sprintf("")
+	_ = &ackrequeue.NoRequeue{}
 )
 
 // sdkFind returns SDK-specific information about a supplied resource

--- a/pkg/resource/db_subnet_group/sdk.go
+++ b/pkg/resource/db_subnet_group/sdk.go
@@ -18,6 +18,7 @@ package db_subnet_group
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -25,6 +26,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/rds"
@@ -45,6 +47,8 @@ var (
 	_ = &ackerr.NotFound
 	_ = &ackcondition.NotManagedMessage
 	_ = &reflect.Value{}
+	_ = fmt.Sprintf("")
+	_ = &ackrequeue.NoRequeue{}
 )
 
 // sdkFind returns SDK-specific information about a supplied resource

--- a/pkg/resource/global_cluster/sdk.go
+++ b/pkg/resource/global_cluster/sdk.go
@@ -18,6 +18,7 @@ package global_cluster
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -25,6 +26,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/rds"
@@ -45,6 +47,8 @@ var (
 	_ = &ackerr.NotFound
 	_ = &ackcondition.NotManagedMessage
 	_ = &reflect.Value{}
+	_ = fmt.Sprintf("")
+	_ = &ackrequeue.NoRequeue{}
 )
 
 // sdkFind returns SDK-specific information about a supplied resource


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/1373

Description of changes:

2 changes here + auto build which takes latest runtime changes in rds

1.  rename the scalingConfiguration to scalingConfigurationInfo in Create/ModifyDBClusterInput, so it only appear in Spec instead of Status of cluster.
2. fix issue of 1373, it is due to we currently still use custom update logic, and need update it based on rds api update.  see [pkg/resource/db_cluster/custom_update.go](https://github.com/aws-controllers-k8s/rds-controller/compare/main...brucegucode:rds-controller:issue-1373?expand=1#diff-1f439d0df6b144c73ac51eff110e99fe2262d68871d881f6c6eda8db5bfbe9b1) for detail 

Testing:
Verified by updating serverlessV2ScalingConfiguration minCap or maxCap and verified it got applied on rds end and k8s object is in sync with rds end. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
