### PR TITLE
Add reference for db instance/cluster param/subnet/vpcsecurity group

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-07-07T17:37:31Z"
+  build_date: "2022-07-07T19:58:37Z"
   build_hash: 0aa529e87bd86c6ba52db8c3524ddecb2876bafe
   go_version: go1.18.2
   version: v0.19.2-5-g0aa529e
-api_directory_checksum: d6c6f02d6f5547b3092054e9c7c35f5840f8bef9
+api_directory_checksum: a60467e94dc7e76bf34ff50f21691507d576fefc
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.27
 generator_config_info:
-  file_checksum: d960a93a106cdb03b83f490cdb3152729a9ff14c
+  file_checksum: bb74db41177efd5c2c2dee2b106ff4ad8e9adcdb
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-07-06T21:17:58Z"
-  build_hash: f9ab7cca7c2ea2ac77d0c4d2dfeb0b42ade56f38
+  build_date: "2022-07-07T17:37:31Z"
+  build_hash: 0aa529e87bd86c6ba52db8c3524ddecb2876bafe
   go_version: go1.18.2
-  version: v0.19.2-4-gf9ab7cc
+  version: v0.19.2-5-g0aa529e
 api_directory_checksum: d6c6f02d6f5547b3092054e9c7c35f5840f8bef9
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.27
 generator_config_info:
-  file_checksum: 2d0c40614a7482376d47885f84cdb713d4307392
+  file_checksum: d960a93a106cdb03b83f490cdb3152729a9ff14c
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/db_cluster.go
+++ b/apis/v1alpha1/db_cluster.go
@@ -132,7 +132,8 @@ type DBClusterSpec struct {
 	//    group.
 	//
 	// Valid for: Aurora DB clusters and Multi-AZ DB clusters
-	DBClusterParameterGroupName *string `json:"dbClusterParameterGroupName,omitempty"`
+	DBClusterParameterGroupName *string                                  `json:"dbClusterParameterGroupName,omitempty"`
+	DBClusterParameterGroupRef  *ackv1alpha1.AWSResourceReferenceWrapper `json:"dbClusterParameterGroupRef,omitempty"`
 	// A DB subnet group to associate with this DB cluster.
 	//
 	// This setting is required to create a Multi-AZ DB cluster.
@@ -143,7 +144,8 @@ type DBClusterSpec struct {
 	// Example: mydbsubnetgroup
 	//
 	// Valid for: Aurora DB clusters and Multi-AZ DB clusters
-	DBSubnetGroupName *string `json:"dbSubnetGroupName,omitempty"`
+	DBSubnetGroupName *string                                  `json:"dbSubnetGroupName,omitempty"`
+	DBSubnetGroupRef  *ackv1alpha1.AWSResourceReferenceWrapper `json:"dbSubnetGroupRef,omitempty"`
 	// The name for your database of up to 64 alphanumeric characters. If you do
 	// not provide a name, Amazon RDS doesn't create a database in the DB cluster
 	// you are creating.
@@ -617,7 +619,8 @@ type DBClusterSpec struct {
 	// A list of EC2 VPC security groups to associate with this DB cluster.
 	//
 	// Valid for: Aurora DB clusters and Multi-AZ DB clusters
-	VPCSecurityGroupIDs []*string `json:"vpcSecurityGroupIDs,omitempty"`
+	VPCSecurityGroupIDs  []*string                                  `json:"vpcSecurityGroupIDs,omitempty"`
+	VPCSecurityGroupRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"vpcSecurityGroupRefs,omitempty"`
 }
 
 // DBClusterStatus defines the observed state of DBCluster

--- a/apis/v1alpha1/db_instance.go
+++ b/apis/v1alpha1/db_instance.go
@@ -341,7 +341,8 @@ type DBInstanceSpec struct {
 	//    * First character must be a letter
 	//
 	//    * Can't end with a hyphen or contain two consecutive hyphens
-	DBParameterGroupName *string `json:"dbParameterGroupName,omitempty"`
+	DBParameterGroupName *string                                  `json:"dbParameterGroupName,omitempty"`
+	DBParameterGroupRef  *ackv1alpha1.AWSResourceReferenceWrapper `json:"dbParameterGroupRef,omitempty"`
 	// The identifier for the DB snapshot to restore from.
 	//
 	// Constraints:
@@ -357,7 +358,8 @@ type DBInstanceSpec struct {
 	// default.
 	//
 	// Example: mydbsubnetgroup
-	DBSubnetGroupName *string `json:"dbSubnetGroupName,omitempty"`
+	DBSubnetGroupName *string                                  `json:"dbSubnetGroupName,omitempty"`
+	DBSubnetGroupRef  *ackv1alpha1.AWSResourceReferenceWrapper `json:"dbSubnetGroupRef,omitempty"`
 	// A value that indicates whether the DB instance has deletion protection enabled.
 	// The database can't be deleted when deletion protection is enabled. By default,
 	// deletion protection isn't enabled. For more information, see Deleting a DB
@@ -1004,7 +1006,8 @@ type DBInstanceSpec struct {
 	// by the DB cluster.
 	//
 	// Default: The default EC2 VPC security group for the DB subnet group's VPC.
-	VPCSecurityGroupIDs []*string `json:"vpcSecurityGroupIDs,omitempty"`
+	VPCSecurityGroupIDs  []*string                                  `json:"vpcSecurityGroupIDs,omitempty"`
+	VPCSecurityGroupRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"vpcSecurityGroupRefs,omitempty"`
 }
 
 // DBInstanceStatus defines the observed state of DBInstance

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -107,6 +107,19 @@ resources:
           resource: Key
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
+      DBClusterParameterGroupName:
+        reference:
+          resource: DBClusterParameterGroup
+          path: Spec.Name
+      DBSubnetGroupName:
+        reference:
+          resource: DBSubnetGroup
+          path: Spec.Name
+      VpcSecurityGroupIds:
+        reference:
+          resource: SecurityGroup
+          service_name: ec2
+          path: Status.ID
     renames:
       operations:
         CreateDBCluster:
@@ -186,6 +199,19 @@ resources:
           resource: Key
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
+      DBParameterGroupName:
+        reference:
+          resource: DBParameterGroup
+          path: Spec.Name
+      DBSubnetGroupName:
+        reference:
+          resource: DBSubnetGroup
+          path: Spec.Name
+      VpcSecurityGroupIds:
+        reference:
+          resource: SecurityGroup
+          service_name: ec2
+          path: Status.ID
       BackupTarget:
         late_initialize: {}
       NetworkType:

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -108,15 +108,15 @@ resources:
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
       DBClusterParameterGroupName:
-        reference:
+        references:
           resource: DBClusterParameterGroup
           path: Spec.Name
       DBSubnetGroupName:
-        reference:
+        references:
           resource: DBSubnetGroup
           path: Spec.Name
       VpcSecurityGroupIds:
-        reference:
+        references:
           resource: SecurityGroup
           service_name: ec2
           path: Status.ID
@@ -200,15 +200,15 @@ resources:
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
       DBParameterGroupName:
-        reference:
+        references:
           resource: DBParameterGroup
           path: Spec.Name
       DBSubnetGroupName:
-        reference:
+        references:
           resource: DBSubnetGroup
           path: Spec.Name
       VpcSecurityGroupIds:
-        reference:
+        references:
           resource: SecurityGroup
           service_name: ec2
           path: Status.ID

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -978,10 +978,20 @@ func (in *DBClusterSpec) DeepCopyInto(out *DBClusterSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DBClusterParameterGroupRef != nil {
+		in, out := &in.DBClusterParameterGroupRef, &out.DBClusterParameterGroupRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.DBSubnetGroupName != nil {
 		in, out := &in.DBSubnetGroupName, &out.DBSubnetGroupName
 		*out = new(string)
 		**out = **in
+	}
+	if in.DBSubnetGroupRef != nil {
+		in, out := &in.DBSubnetGroupRef, &out.DBSubnetGroupRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DatabaseName != nil {
 		in, out := &in.DatabaseName, &out.DatabaseName
@@ -1183,6 +1193,17 @@ func (in *DBClusterSpec) DeepCopyInto(out *DBClusterSpec) {
 				in, out := &(*in)[i], &(*out)[i]
 				*out = new(string)
 				**out = **in
+			}
+		}
+	}
+	if in.VPCSecurityGroupRefs != nil {
+		in, out := &in.VPCSecurityGroupRefs, &out.VPCSecurityGroupRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+				(*in).DeepCopyInto(*out)
 			}
 		}
 	}
@@ -2332,6 +2353,11 @@ func (in *DBInstanceSpec) DeepCopyInto(out *DBInstanceSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DBParameterGroupRef != nil {
+		in, out := &in.DBParameterGroupRef, &out.DBParameterGroupRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.DBSnapshotIdentifier != nil {
 		in, out := &in.DBSnapshotIdentifier, &out.DBSnapshotIdentifier
 		*out = new(string)
@@ -2341,6 +2367,11 @@ func (in *DBInstanceSpec) DeepCopyInto(out *DBInstanceSpec) {
 		in, out := &in.DBSubnetGroupName, &out.DBSubnetGroupName
 		*out = new(string)
 		**out = **in
+	}
+	if in.DBSubnetGroupRef != nil {
+		in, out := &in.DBSubnetGroupRef, &out.DBSubnetGroupRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DeletionProtection != nil {
 		in, out := &in.DeletionProtection, &out.DeletionProtection
@@ -2578,6 +2609,17 @@ func (in *DBInstanceSpec) DeepCopyInto(out *DBInstanceSpec) {
 				in, out := &(*in)[i], &(*out)[i]
 				*out = new(string)
 				**out = **in
+			}
+		}
+	}
+	if in.VPCSecurityGroupRefs != nil {
+		in, out := &in.VPCSecurityGroupRefs, &out.VPCSecurityGroupRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+				(*in).DeepCopyInto(*out)
 			}
 		}
 	}

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"os"
 
+	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
@@ -58,6 +59,7 @@ func init() {
 
 	_ = svctypes.AddToScheme(scheme)
 	_ = ackv1alpha1.AddToScheme(scheme)
+	_ = ec2apitypes.AddToScheme(scheme)
 	_ = kmsapitypes.AddToScheme(scheme)
 }
 

--- a/config/crd/bases/rds.services.k8s.aws_dbclusters.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbclusters.yaml
@@ -130,6 +130,20 @@ spec:
                   of an existing DB cluster parameter    group. \n Valid for: Aurora
                   DB clusters and Multi-AZ DB clusters"
                 type: string
+              dbClusterParameterGroupRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               dbSubnetGroupName:
                 description: "A DB subnet group to associate with this DB cluster.
                   \n This setting is required to create a Multi-AZ DB cluster. \n
@@ -137,6 +151,20 @@ spec:
                   not be default. \n Example: mydbsubnetgroup \n Valid for: Aurora
                   DB clusters and Multi-AZ DB clusters"
                 type: string
+              dbSubnetGroupRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               deletionProtection:
                 description: "A value that indicates whether the DB cluster has deletion
                   protection enabled. The database can't be deleted when deletion
@@ -551,6 +579,22 @@ spec:
                   clusters"
                 items:
                   type: string
+                type: array
+              vpcSecurityGroupRefs:
+                items:
+                  description: 'AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference type to provide more user friendly syntax
+                    for references using ''from'' field Ex: APIIDRef:   from:     name:
+                    my-api'
+                  properties:
+                    from:
+                      description: AWSResourceReference provides all the values necessary
+                        to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                  type: object
                 type: array
             required:
             - dbClusterIdentifier

--- a/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
@@ -229,6 +229,20 @@ spec:
                   character must be a letter \n    * Can't end with a hyphen or contain
                   two consecutive hyphens"
                 type: string
+              dbParameterGroupRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               dbSnapshotIdentifier:
                 description: "The identifier for the DB snapshot to restore from.
                   \n Constraints: \n    * Must match the identifier of an existing
@@ -241,6 +255,20 @@ spec:
                   \n Constraints: Must match the name of an existing DBSubnetGroup.
                   Must not be default. \n Example: mydbsubnetgroup"
                 type: string
+              dbSubnetGroupRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               deletionProtection:
                 description: "A value that indicates whether the DB instance has deletion
                   protection enabled. The database can't be deleted when deletion
@@ -757,6 +785,22 @@ spec:
                   VPC."
                 items:
                   type: string
+                type: array
+              vpcSecurityGroupRefs:
+                items:
+                  description: 'AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference type to provide more user friendly syntax
+                    for references using ''from'' field Ex: APIIDRef:   from:     name:
+                    my-api'
+                  properties:
+                    from:
+                      description: AWSResourceReference provides all the values necessary
+                        to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                  type: object
                 type: array
             required:
             - dbInstanceClass

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -33,6 +33,20 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - securitygroups
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - securitygroups/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - kms.services.k8s.aws
   resources:
   - keys

--- a/generator.yaml
+++ b/generator.yaml
@@ -107,6 +107,19 @@ resources:
           resource: Key
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
+      DBClusterParameterGroupName:
+        reference:
+          resource: DBClusterParameterGroup
+          path: Spec.Name
+      DBSubnetGroupName:
+        reference:
+          resource: DBSubnetGroup
+          path: Spec.Name
+      VpcSecurityGroupIds:
+        reference:
+          resource: SecurityGroup
+          service_name: ec2
+          path: Status.ID
     renames:
       operations:
         CreateDBCluster:
@@ -186,6 +199,19 @@ resources:
           resource: Key
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
+      DBParameterGroupName:
+        reference:
+          resource: DBParameterGroup
+          path: Spec.Name
+      DBSubnetGroupName:
+        reference:
+          resource: DBSubnetGroup
+          path: Spec.Name
+      VpcSecurityGroupIds:
+        reference:
+          resource: SecurityGroup
+          service_name: ec2
+          path: Status.ID
       BackupTarget:
         late_initialize: {}
       NetworkType:

--- a/generator.yaml
+++ b/generator.yaml
@@ -108,15 +108,15 @@ resources:
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
       DBClusterParameterGroupName:
-        reference:
+        references:
           resource: DBClusterParameterGroup
           path: Spec.Name
       DBSubnetGroupName:
-        reference:
+        references:
           resource: DBSubnetGroup
           path: Spec.Name
       VpcSecurityGroupIds:
-        reference:
+        references:
           resource: SecurityGroup
           service_name: ec2
           path: Status.ID
@@ -200,15 +200,15 @@ resources:
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
       DBParameterGroupName:
-        reference:
+        references:
           resource: DBParameterGroup
           path: Spec.Name
       DBSubnetGroupName:
-        reference:
+        references:
           resource: DBSubnetGroup
           path: Spec.Name
       VpcSecurityGroupIds:
-        reference:
+        references:
           resource: SecurityGroup
           service_name: ec2
           path: Status.ID

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/aws-controllers-k8s/rds-controller
 go 1.17
 
 require (
+	github.com/aws-controllers-k8s/ec2-controller v0.0.16
 	github.com/aws-controllers-k8s/kms-controller v0.0.15
 	github.com/aws-controllers-k8s/runtime v0.19.2
 	github.com/aws/aws-sdk-go v1.44.27

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/aws-controllers-k8s/ec2-controller v0.0.16 h1:KCNeGks9WzMTf9QquV1qwBkhXCjgq1vfI8wSP/w6EoE=
+github.com/aws-controllers-k8s/ec2-controller v0.0.16/go.mod h1:ib1x1axY932YylqbnW8f4ltz7NNqCt38KoVZ6gwNWxw=
 github.com/aws-controllers-k8s/kms-controller v0.0.15 h1:v9LLAE2Q517CvlP80EgXNq2juGCTLUfpn1OjBGY+n8Y=
 github.com/aws-controllers-k8s/kms-controller v0.0.15/go.mod h1:EbxvdZDS2n3JCMmhfjhavSutzt/9J0jXSvGj2bufS68=
 github.com/aws-controllers-k8s/runtime v0.18.4/go.mod h1:oA8ML1/LL3chPn26P6SzBNu1CUI2nekB+PTqykNs0qU=

--- a/helm/crds/rds.services.k8s.aws_dbclusters.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbclusters.yaml
@@ -130,6 +130,20 @@ spec:
                   of an existing DB cluster parameter    group. \n Valid for: Aurora
                   DB clusters and Multi-AZ DB clusters"
                 type: string
+              dbClusterParameterGroupRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               dbSubnetGroupName:
                 description: "A DB subnet group to associate with this DB cluster.
                   \n This setting is required to create a Multi-AZ DB cluster. \n
@@ -137,6 +151,20 @@ spec:
                   not be default. \n Example: mydbsubnetgroup \n Valid for: Aurora
                   DB clusters and Multi-AZ DB clusters"
                 type: string
+              dbSubnetGroupRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               deletionProtection:
                 description: "A value that indicates whether the DB cluster has deletion
                   protection enabled. The database can't be deleted when deletion
@@ -551,6 +579,22 @@ spec:
                   clusters"
                 items:
                   type: string
+                type: array
+              vpcSecurityGroupRefs:
+                items:
+                  description: 'AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference type to provide more user friendly syntax
+                    for references using ''from'' field Ex: APIIDRef:   from:     name:
+                    my-api'
+                  properties:
+                    from:
+                      description: AWSResourceReference provides all the values necessary
+                        to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                  type: object
                 type: array
             required:
             - dbClusterIdentifier

--- a/helm/crds/rds.services.k8s.aws_dbinstances.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbinstances.yaml
@@ -229,6 +229,20 @@ spec:
                   character must be a letter \n    * Can't end with a hyphen or contain
                   two consecutive hyphens"
                 type: string
+              dbParameterGroupRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               dbSnapshotIdentifier:
                 description: "The identifier for the DB snapshot to restore from.
                   \n Constraints: \n    * Must match the identifier of an existing
@@ -241,6 +255,20 @@ spec:
                   \n Constraints: Must match the name of an existing DBSubnetGroup.
                   Must not be default. \n Example: mydbsubnetgroup"
                 type: string
+              dbSubnetGroupRef:
+                description: 'AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using ''from'' field Ex: APIIDRef:   from:     name:
+                  my-api'
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               deletionProtection:
                 description: "A value that indicates whether the DB instance has deletion
                   protection enabled. The database can't be deleted when deletion
@@ -757,6 +785,22 @@ spec:
                   VPC."
                 items:
                   type: string
+                type: array
+              vpcSecurityGroupRefs:
+                items:
+                  description: 'AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference type to provide more user friendly syntax
+                    for references using ''from'' field Ex: APIIDRef:   from:     name:
+                    my-api'
+                  properties:
+                    from:
+                      description: AWSResourceReference provides all the values necessary
+                        to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                  type: object
                 type: array
             required:
             - dbInstanceClass

--- a/helm/templates/cluster-role-controller.yaml
+++ b/helm/templates/cluster-role-controller.yaml
@@ -39,6 +39,20 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - securitygroups
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ec2.services.k8s.aws
+  resources:
+  - securitygroups/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - kms.services.k8s.aws
   resources:
   - keys

--- a/pkg/resource/db_cluster/delta.go
+++ b/pkg/resource/db_cluster/delta.go
@@ -108,12 +108,18 @@ func newResourceDelta(
 			delta.Add("Spec.DBClusterParameterGroupName", a.ko.Spec.DBClusterParameterGroupName, b.ko.Spec.DBClusterParameterGroupName)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.DBClusterParameterGroupRef, b.ko.Spec.DBClusterParameterGroupRef) {
+		delta.Add("Spec.DBClusterParameterGroupRef", a.ko.Spec.DBClusterParameterGroupRef, b.ko.Spec.DBClusterParameterGroupRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.DBSubnetGroupName, b.ko.Spec.DBSubnetGroupName) {
 		delta.Add("Spec.DBSubnetGroupName", a.ko.Spec.DBSubnetGroupName, b.ko.Spec.DBSubnetGroupName)
 	} else if a.ko.Spec.DBSubnetGroupName != nil && b.ko.Spec.DBSubnetGroupName != nil {
 		if *a.ko.Spec.DBSubnetGroupName != *b.ko.Spec.DBSubnetGroupName {
 			delta.Add("Spec.DBSubnetGroupName", a.ko.Spec.DBSubnetGroupName, b.ko.Spec.DBSubnetGroupName)
 		}
+	}
+	if !reflect.DeepEqual(a.ko.Spec.DBSubnetGroupRef, b.ko.Spec.DBSubnetGroupRef) {
+		delta.Add("Spec.DBSubnetGroupRef", a.ko.Spec.DBSubnetGroupRef, b.ko.Spec.DBSubnetGroupRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.DatabaseName, b.ko.Spec.DatabaseName) {
 		delta.Add("Spec.DatabaseName", a.ko.Spec.DatabaseName, b.ko.Spec.DatabaseName)
@@ -407,6 +413,9 @@ func newResourceDelta(
 	}
 	if !ackcompare.SliceStringPEqual(a.ko.Spec.VPCSecurityGroupIDs, b.ko.Spec.VPCSecurityGroupIDs) {
 		delta.Add("Spec.VPCSecurityGroupIDs", a.ko.Spec.VPCSecurityGroupIDs, b.ko.Spec.VPCSecurityGroupIDs)
+	}
+	if !reflect.DeepEqual(a.ko.Spec.VPCSecurityGroupRefs, b.ko.Spec.VPCSecurityGroupRefs) {
+		delta.Add("Spec.VPCSecurityGroupRefs", a.ko.Spec.VPCSecurityGroupRefs, b.ko.Spec.VPCSecurityGroupRefs)
 	}
 
 	return delta

--- a/pkg/resource/db_cluster/references.go
+++ b/pkg/resource/db_cluster/references.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
@@ -34,6 +35,9 @@ import (
 
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups,verbs=get;list
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups/status,verbs=get;list
 
 // ResolveReferences finds if there are any Reference field(s) present
 // inside AWSResource passed in the parameter and attempts to resolve
@@ -51,7 +55,16 @@ func (rm *resourceManager) ResolveReferences(
 	ko := rm.concreteResource(res).ko.DeepCopy()
 	err := validateReferenceFields(ko)
 	if err == nil {
+		err = resolveReferenceForDBClusterParameterGroupName(ctx, apiReader, namespace, ko)
+	}
+	if err == nil {
+		err = resolveReferenceForDBSubnetGroupName(ctx, apiReader, namespace, ko)
+	}
+	if err == nil {
 		err = resolveReferenceForKMSKeyID(ctx, apiReader, namespace, ko)
+	}
+	if err == nil {
+		err = resolveReferenceForVPCSecurityGroupIDs(ctx, apiReader, namespace, ko)
 	}
 
 	// If there was an error while resolving any reference, reset all the
@@ -68,8 +81,17 @@ func (rm *resourceManager) ResolveReferences(
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.DBCluster) error {
+	if ko.Spec.DBClusterParameterGroupRef != nil && ko.Spec.DBClusterParameterGroupName != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("DBClusterParameterGroupName", "DBClusterParameterGroupRef")
+	}
+	if ko.Spec.DBSubnetGroupRef != nil && ko.Spec.DBSubnetGroupName != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("DBSubnetGroupName", "DBSubnetGroupRef")
+	}
 	if ko.Spec.KMSKeyRef != nil && ko.Spec.KMSKeyID != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("KMSKeyID", "KMSKeyRef")
+	}
+	if ko.Spec.VPCSecurityGroupRefs != nil && ko.Spec.VPCSecurityGroupIDs != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("VPCSecurityGroupIDs", "VPCSecurityGroupRefs")
 	}
 	return nil
 }
@@ -77,7 +99,121 @@ func validateReferenceFields(ko *svcapitypes.DBCluster) error {
 // hasNonNilReferences returns true if resource contains a reference to another
 // resource
 func hasNonNilReferences(ko *svcapitypes.DBCluster) bool {
-	return false || (ko.Spec.KMSKeyRef != nil)
+	return false || (ko.Spec.DBClusterParameterGroupRef != nil) || (ko.Spec.DBSubnetGroupRef != nil) || (ko.Spec.KMSKeyRef != nil) || (ko.Spec.VPCSecurityGroupRefs != nil)
+}
+
+// resolveReferenceForDBClusterParameterGroupName reads the resource referenced
+// from DBClusterParameterGroupRef field and sets the DBClusterParameterGroupName
+// from referenced resource
+func resolveReferenceForDBClusterParameterGroupName(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.DBCluster,
+) error {
+	if ko.Spec.DBClusterParameterGroupRef != nil &&
+		ko.Spec.DBClusterParameterGroupRef.From != nil {
+		arr := ko.Spec.DBClusterParameterGroupRef.From
+		if arr == nil || arr.Name == nil || *arr.Name == "" {
+			return fmt.Errorf("provided resource reference is nil or empty")
+		}
+		namespacedName := types.NamespacedName{
+			Namespace: namespace,
+			Name:      *arr.Name,
+		}
+		obj := svcapitypes.DBClusterParameterGroup{}
+		err := apiReader.Get(ctx, namespacedName, &obj)
+		if err != nil {
+			return err
+		}
+		var refResourceSynced, refResourceTerminal bool
+		for _, cond := range obj.Status.Conditions {
+			if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceSynced = true
+			}
+			if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceTerminal = true
+			}
+		}
+		if refResourceTerminal {
+			return ackerr.ResourceReferenceTerminalFor(
+				"DBClusterParameterGroup",
+				namespace, *arr.Name)
+		}
+		if !refResourceSynced {
+			return ackerr.ResourceReferenceNotSyncedFor(
+				"DBClusterParameterGroup",
+				namespace, *arr.Name)
+		}
+		if obj.Spec.Name == nil {
+			return ackerr.ResourceReferenceMissingTargetFieldFor(
+				"DBClusterParameterGroup",
+				namespace, *arr.Name,
+				"Spec.Name")
+		}
+		referencedValue := string(*obj.Spec.Name)
+		ko.Spec.DBClusterParameterGroupName = &referencedValue
+	}
+	return nil
+}
+
+// resolveReferenceForDBSubnetGroupName reads the resource referenced
+// from DBSubnetGroupRef field and sets the DBSubnetGroupName
+// from referenced resource
+func resolveReferenceForDBSubnetGroupName(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.DBCluster,
+) error {
+	if ko.Spec.DBSubnetGroupRef != nil &&
+		ko.Spec.DBSubnetGroupRef.From != nil {
+		arr := ko.Spec.DBSubnetGroupRef.From
+		if arr == nil || arr.Name == nil || *arr.Name == "" {
+			return fmt.Errorf("provided resource reference is nil or empty")
+		}
+		namespacedName := types.NamespacedName{
+			Namespace: namespace,
+			Name:      *arr.Name,
+		}
+		obj := svcapitypes.DBSubnetGroup{}
+		err := apiReader.Get(ctx, namespacedName, &obj)
+		if err != nil {
+			return err
+		}
+		var refResourceSynced, refResourceTerminal bool
+		for _, cond := range obj.Status.Conditions {
+			if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceSynced = true
+			}
+			if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceTerminal = true
+			}
+		}
+		if refResourceTerminal {
+			return ackerr.ResourceReferenceTerminalFor(
+				"DBSubnetGroup",
+				namespace, *arr.Name)
+		}
+		if !refResourceSynced {
+			return ackerr.ResourceReferenceNotSyncedFor(
+				"DBSubnetGroup",
+				namespace, *arr.Name)
+		}
+		if obj.Spec.Name == nil {
+			return ackerr.ResourceReferenceMissingTargetFieldFor(
+				"DBSubnetGroup",
+				namespace, *arr.Name,
+				"Spec.Name")
+		}
+		referencedValue := string(*obj.Spec.Name)
+		ko.Spec.DBSubnetGroupName = &referencedValue
+	}
+	return nil
 }
 
 // resolveReferenceForKMSKeyID reads the resource referenced
@@ -133,6 +269,67 @@ func resolveReferenceForKMSKeyID(
 		}
 		referencedValue := string(*obj.Status.ACKResourceMetadata.ARN)
 		ko.Spec.KMSKeyID = &referencedValue
+	}
+	return nil
+}
+
+// resolveReferenceForVPCSecurityGroupIDs reads the resource referenced
+// from VPCSecurityGroupRefs field and sets the VPCSecurityGroupIDs
+// from referenced resource
+func resolveReferenceForVPCSecurityGroupIDs(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.DBCluster,
+) error {
+	if ko.Spec.VPCSecurityGroupRefs != nil &&
+		len(ko.Spec.VPCSecurityGroupRefs) > 0 {
+		resolvedReferences := []*string{}
+		for _, arrw := range ko.Spec.VPCSecurityGroupRefs {
+			arr := arrw.From
+			if arr == nil || arr.Name == nil || *arr.Name == "" {
+				return fmt.Errorf("provided resource reference is nil or empty")
+			}
+			namespacedName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      *arr.Name,
+			}
+			obj := ec2apitypes.SecurityGroup{}
+			err := apiReader.Get(ctx, namespacedName, &obj)
+			if err != nil {
+				return err
+			}
+			var refResourceSynced, refResourceTerminal bool
+			for _, cond := range obj.Status.Conditions {
+				if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+					cond.Status == corev1.ConditionTrue {
+					refResourceSynced = true
+				}
+				if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+					cond.Status == corev1.ConditionTrue {
+					refResourceTerminal = true
+				}
+			}
+			if refResourceTerminal {
+				return ackerr.ResourceReferenceTerminalFor(
+					"SecurityGroup",
+					namespace, *arr.Name)
+			}
+			if !refResourceSynced {
+				return ackerr.ResourceReferenceNotSyncedFor(
+					"SecurityGroup",
+					namespace, *arr.Name)
+			}
+			if obj.Status.ID == nil {
+				return ackerr.ResourceReferenceMissingTargetFieldFor(
+					"SecurityGroup",
+					namespace, *arr.Name,
+					"Status.ID")
+			}
+			referencedValue := string(*obj.Status.ID)
+			resolvedReferences = append(resolvedReferences, &referencedValue)
+		}
+		ko.Spec.VPCSecurityGroupIDs = resolvedReferences
 	}
 	return nil
 }

--- a/pkg/resource/db_instance/delta.go
+++ b/pkg/resource/db_instance/delta.go
@@ -133,6 +133,9 @@ func newResourceDelta(
 			delta.Add("Spec.DBParameterGroupName", a.ko.Spec.DBParameterGroupName, b.ko.Spec.DBParameterGroupName)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.DBParameterGroupRef, b.ko.Spec.DBParameterGroupRef) {
+		delta.Add("Spec.DBParameterGroupRef", a.ko.Spec.DBParameterGroupRef, b.ko.Spec.DBParameterGroupRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.DBSnapshotIdentifier, b.ko.Spec.DBSnapshotIdentifier) {
 		delta.Add("Spec.DBSnapshotIdentifier", a.ko.Spec.DBSnapshotIdentifier, b.ko.Spec.DBSnapshotIdentifier)
 	} else if a.ko.Spec.DBSnapshotIdentifier != nil && b.ko.Spec.DBSnapshotIdentifier != nil {
@@ -146,6 +149,9 @@ func newResourceDelta(
 		if *a.ko.Spec.DBSubnetGroupName != *b.ko.Spec.DBSubnetGroupName {
 			delta.Add("Spec.DBSubnetGroupName", a.ko.Spec.DBSubnetGroupName, b.ko.Spec.DBSubnetGroupName)
 		}
+	}
+	if !reflect.DeepEqual(a.ko.Spec.DBSubnetGroupRef, b.ko.Spec.DBSubnetGroupRef) {
+		delta.Add("Spec.DBSubnetGroupRef", a.ko.Spec.DBSubnetGroupRef, b.ko.Spec.DBSubnetGroupRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.DeletionProtection, b.ko.Spec.DeletionProtection) {
 		delta.Add("Spec.DeletionProtection", a.ko.Spec.DeletionProtection, b.ko.Spec.DeletionProtection)
@@ -427,6 +433,9 @@ func newResourceDelta(
 	}
 	if !ackcompare.SliceStringPEqual(a.ko.Spec.VPCSecurityGroupIDs, b.ko.Spec.VPCSecurityGroupIDs) {
 		delta.Add("Spec.VPCSecurityGroupIDs", a.ko.Spec.VPCSecurityGroupIDs, b.ko.Spec.VPCSecurityGroupIDs)
+	}
+	if !reflect.DeepEqual(a.ko.Spec.VPCSecurityGroupRefs, b.ko.Spec.VPCSecurityGroupRefs) {
+		delta.Add("Spec.VPCSecurityGroupRefs", a.ko.Spec.VPCSecurityGroupRefs, b.ko.Spec.VPCSecurityGroupRefs)
 	}
 
 	return delta

--- a/pkg/resource/db_instance/references.go
+++ b/pkg/resource/db_instance/references.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
@@ -34,6 +35,9 @@ import (
 
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups,verbs=get;list
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups/status,verbs=get;list
 
 // ResolveReferences finds if there are any Reference field(s) present
 // inside AWSResource passed in the parameter and attempts to resolve
@@ -51,7 +55,16 @@ func (rm *resourceManager) ResolveReferences(
 	ko := rm.concreteResource(res).ko.DeepCopy()
 	err := validateReferenceFields(ko)
 	if err == nil {
+		err = resolveReferenceForDBParameterGroupName(ctx, apiReader, namespace, ko)
+	}
+	if err == nil {
+		err = resolveReferenceForDBSubnetGroupName(ctx, apiReader, namespace, ko)
+	}
+	if err == nil {
 		err = resolveReferenceForKMSKeyID(ctx, apiReader, namespace, ko)
+	}
+	if err == nil {
+		err = resolveReferenceForVPCSecurityGroupIDs(ctx, apiReader, namespace, ko)
 	}
 
 	// If there was an error while resolving any reference, reset all the
@@ -68,8 +81,17 @@ func (rm *resourceManager) ResolveReferences(
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.DBInstance) error {
+	if ko.Spec.DBParameterGroupRef != nil && ko.Spec.DBParameterGroupName != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("DBParameterGroupName", "DBParameterGroupRef")
+	}
+	if ko.Spec.DBSubnetGroupRef != nil && ko.Spec.DBSubnetGroupName != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("DBSubnetGroupName", "DBSubnetGroupRef")
+	}
 	if ko.Spec.KMSKeyRef != nil && ko.Spec.KMSKeyID != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("KMSKeyID", "KMSKeyRef")
+	}
+	if ko.Spec.VPCSecurityGroupRefs != nil && ko.Spec.VPCSecurityGroupIDs != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("VPCSecurityGroupIDs", "VPCSecurityGroupRefs")
 	}
 	return nil
 }
@@ -77,7 +99,121 @@ func validateReferenceFields(ko *svcapitypes.DBInstance) error {
 // hasNonNilReferences returns true if resource contains a reference to another
 // resource
 func hasNonNilReferences(ko *svcapitypes.DBInstance) bool {
-	return false || (ko.Spec.KMSKeyRef != nil)
+	return false || (ko.Spec.DBParameterGroupRef != nil) || (ko.Spec.DBSubnetGroupRef != nil) || (ko.Spec.KMSKeyRef != nil) || (ko.Spec.VPCSecurityGroupRefs != nil)
+}
+
+// resolveReferenceForDBParameterGroupName reads the resource referenced
+// from DBParameterGroupRef field and sets the DBParameterGroupName
+// from referenced resource
+func resolveReferenceForDBParameterGroupName(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.DBInstance,
+) error {
+	if ko.Spec.DBParameterGroupRef != nil &&
+		ko.Spec.DBParameterGroupRef.From != nil {
+		arr := ko.Spec.DBParameterGroupRef.From
+		if arr == nil || arr.Name == nil || *arr.Name == "" {
+			return fmt.Errorf("provided resource reference is nil or empty")
+		}
+		namespacedName := types.NamespacedName{
+			Namespace: namespace,
+			Name:      *arr.Name,
+		}
+		obj := svcapitypes.DBParameterGroup{}
+		err := apiReader.Get(ctx, namespacedName, &obj)
+		if err != nil {
+			return err
+		}
+		var refResourceSynced, refResourceTerminal bool
+		for _, cond := range obj.Status.Conditions {
+			if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceSynced = true
+			}
+			if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceTerminal = true
+			}
+		}
+		if refResourceTerminal {
+			return ackerr.ResourceReferenceTerminalFor(
+				"DBParameterGroup",
+				namespace, *arr.Name)
+		}
+		if !refResourceSynced {
+			return ackerr.ResourceReferenceNotSyncedFor(
+				"DBParameterGroup",
+				namespace, *arr.Name)
+		}
+		if obj.Spec.Name == nil {
+			return ackerr.ResourceReferenceMissingTargetFieldFor(
+				"DBParameterGroup",
+				namespace, *arr.Name,
+				"Spec.Name")
+		}
+		referencedValue := string(*obj.Spec.Name)
+		ko.Spec.DBParameterGroupName = &referencedValue
+	}
+	return nil
+}
+
+// resolveReferenceForDBSubnetGroupName reads the resource referenced
+// from DBSubnetGroupRef field and sets the DBSubnetGroupName
+// from referenced resource
+func resolveReferenceForDBSubnetGroupName(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.DBInstance,
+) error {
+	if ko.Spec.DBSubnetGroupRef != nil &&
+		ko.Spec.DBSubnetGroupRef.From != nil {
+		arr := ko.Spec.DBSubnetGroupRef.From
+		if arr == nil || arr.Name == nil || *arr.Name == "" {
+			return fmt.Errorf("provided resource reference is nil or empty")
+		}
+		namespacedName := types.NamespacedName{
+			Namespace: namespace,
+			Name:      *arr.Name,
+		}
+		obj := svcapitypes.DBSubnetGroup{}
+		err := apiReader.Get(ctx, namespacedName, &obj)
+		if err != nil {
+			return err
+		}
+		var refResourceSynced, refResourceTerminal bool
+		for _, cond := range obj.Status.Conditions {
+			if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceSynced = true
+			}
+			if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+				cond.Status == corev1.ConditionTrue {
+				refResourceTerminal = true
+			}
+		}
+		if refResourceTerminal {
+			return ackerr.ResourceReferenceTerminalFor(
+				"DBSubnetGroup",
+				namespace, *arr.Name)
+		}
+		if !refResourceSynced {
+			return ackerr.ResourceReferenceNotSyncedFor(
+				"DBSubnetGroup",
+				namespace, *arr.Name)
+		}
+		if obj.Spec.Name == nil {
+			return ackerr.ResourceReferenceMissingTargetFieldFor(
+				"DBSubnetGroup",
+				namespace, *arr.Name,
+				"Spec.Name")
+		}
+		referencedValue := string(*obj.Spec.Name)
+		ko.Spec.DBSubnetGroupName = &referencedValue
+	}
+	return nil
 }
 
 // resolveReferenceForKMSKeyID reads the resource referenced
@@ -133,6 +269,67 @@ func resolveReferenceForKMSKeyID(
 		}
 		referencedValue := string(*obj.Status.ACKResourceMetadata.ARN)
 		ko.Spec.KMSKeyID = &referencedValue
+	}
+	return nil
+}
+
+// resolveReferenceForVPCSecurityGroupIDs reads the resource referenced
+// from VPCSecurityGroupRefs field and sets the VPCSecurityGroupIDs
+// from referenced resource
+func resolveReferenceForVPCSecurityGroupIDs(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.DBInstance,
+) error {
+	if ko.Spec.VPCSecurityGroupRefs != nil &&
+		len(ko.Spec.VPCSecurityGroupRefs) > 0 {
+		resolvedReferences := []*string{}
+		for _, arrw := range ko.Spec.VPCSecurityGroupRefs {
+			arr := arrw.From
+			if arr == nil || arr.Name == nil || *arr.Name == "" {
+				return fmt.Errorf("provided resource reference is nil or empty")
+			}
+			namespacedName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      *arr.Name,
+			}
+			obj := ec2apitypes.SecurityGroup{}
+			err := apiReader.Get(ctx, namespacedName, &obj)
+			if err != nil {
+				return err
+			}
+			var refResourceSynced, refResourceTerminal bool
+			for _, cond := range obj.Status.Conditions {
+				if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+					cond.Status == corev1.ConditionTrue {
+					refResourceSynced = true
+				}
+				if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+					cond.Status == corev1.ConditionTrue {
+					refResourceTerminal = true
+				}
+			}
+			if refResourceTerminal {
+				return ackerr.ResourceReferenceTerminalFor(
+					"SecurityGroup",
+					namespace, *arr.Name)
+			}
+			if !refResourceSynced {
+				return ackerr.ResourceReferenceNotSyncedFor(
+					"SecurityGroup",
+					namespace, *arr.Name)
+			}
+			if obj.Status.ID == nil {
+				return ackerr.ResourceReferenceMissingTargetFieldFor(
+					"SecurityGroup",
+					namespace, *arr.Name,
+					"Status.ID")
+			}
+			referencedValue := string(*obj.Status.ID)
+			resolvedReferences = append(resolvedReferences, &referencedValue)
+		}
+		ko.Spec.VPCSecurityGroupIDs = resolvedReferences
 	}
 	return nil
 }


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/1378

Description of changes:
Add reference for DBInstance/Cluster ParameterGroup/SubnetGroup/vpcSecurityGroup. 

Here is my testing process, it should apply to param group and vpc security group too. 

1. Try create a rds instance `brucegu-test-ref-4` and specify 
```  
dbSubnetGroupRef:
    from:
      name: "brucegu-test-subnet-11""
```
 but no `brucegu-test-subnet-11` is available yet. 
2. Verify db instance state has 
```
   Message:               dbsubnetgroups.rds.services.k8s.aws "brucegu-test-subnet-11" not found
    Status:                Unknown
    Type:                  ACK.ReferencesResolved
```
3. Create db SubnetGroup  `brucegu-test-subnet-11` from SubnetGroup CRD 
4. Verify db instance `brucegu-test-ref-4` is created successfully and Resource synced successfully.
```
  Conditions:
    Last Transition Time:     2022-07-07T22:09:25Z
    Status:                   True
    Type:                     ACK.ReferencesResolved
    Last Transition Time:     2022-07-07T22:09:26Z
    Message:                  Late initialization successful
    Reason:                   Late initialization successful
    Status:                   True
    Type:                     ACK.LateInitialized
    Last Transition Time:     2022-07-07T22:09:26Z
    Message:                  Resource synced successfully
    Reason:
    Status:                   True
    Type:                     ACK.ResourceSynced
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
