### PR TITLE
When db instance is inside db cluster(when DBClusterIdentifier appear), set cluster level params to nil 

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,7 +1,7 @@
 ack_generate_info:
-  build_date: "2022-07-11T19:31:21Z"
+  build_date: "2022-07-11T21:43:34Z"
   build_hash: d09bac5fa87cffd0028014833a5e7e786c0187dd
-  go_version: go1.18.3
+  go_version: go1.18.2
   version: v0.19.2-6-gd09bac5
 api_directory_checksum: a60467e94dc7e76bf34ff50f21691507d576fefc
 api_version: v1alpha1

--- a/pkg/resource/db_instance/sdk.go
+++ b/pkg/resource/db_instance/sdk.go
@@ -1772,6 +1772,19 @@ func (rm *resourceManager) sdkUpdate(
 		input.NetworkType = nil
 	}
 
+	// For dbInstance inside dbCluster, it's either aurora or
+	// multi-az cluster case, in either case, the below params
+	// are not controlled in instance level.
+	// multi-az cluster control it on cluster leve, aurora doesn't need it
+	// hence when DBClusterIdentifier appear, set them to nil
+	// Please refer to doc : https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DeleteDBInstance.html
+	if desired.ko.Spec.DBClusterIdentifier != nil {
+		input.AllocatedStorage = nil
+		input.BackupRetentionPeriod = nil
+		input.PreferredBackupWindow = nil
+		input.DeletionProtection = nil
+	}
+
 	var resp *svcsdk.ModifyDBInstanceOutput
 	_ = resp
 	resp, err = rm.sdkapi.ModifyDBInstanceWithContext(ctx, input)

--- a/templates/hooks/db_instance/sdk_update_post_build_request.go.tpl
+++ b/templates/hooks/db_instance/sdk_update_post_build_request.go.tpl
@@ -28,7 +28,6 @@
         // For dbInstance inside dbCluster, it's either aurora or 
         // multi-az cluster case, in either case, the below params
         // are not controlled in instance level. 
-        // multi-az cluster control it on cluster leve, aurora doesn't need it
         // hence when DBClusterIdentifier appear, set them to nil
         // Please refer to doc : https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DeleteDBInstance.html 
         if desired.ko.Spec.DBClusterIdentifier != nil {

--- a/templates/hooks/db_instance/sdk_update_post_build_request.go.tpl
+++ b/templates/hooks/db_instance/sdk_update_post_build_request.go.tpl
@@ -24,3 +24,16 @@
         if !delta.DifferentAt("Spec.NetworkType") {
                 input.NetworkType = nil
         }
+
+        // For dbInstance inside dbCluster, it's either aurora or 
+        // multi-az cluster case, in either case, the below params
+        // are not controlled in instance level. 
+        // multi-az cluster control it on cluster leve, aurora doesn't need it
+        // hence when DBClusterIdentifier appear, set them to nil
+        // Please refer to doc : https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DeleteDBInstance.html 
+        if desired.ko.Spec.DBClusterIdentifier != nil {
+                input.AllocatedStorage = nil
+                input.BackupRetentionPeriod = nil
+                input.PreferredBackupWindow = nil
+                input.DeletionProtection = nil
+        }


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/1028

Description of changes:
When db instance is inside a db cluster, it's either an aurora case or multi-az cluster case. There are some params that should not be controlled in instance level and should go to cluster level.
So when `DBClusterIdentifier` appear, set those values to nil so runtime won'r try to modify them and get RDS `InvalidParameterCombination`. 

Testing:
1. Create a DBCluster first 
2. Create a dbinstance in it using DBClusterIdentifier param, like below, verify create succeed 
```
apiVersion: rds.services.k8s.aws/v1alpha1
kind: DBInstance
metadata:
  name: "brucegu-manfred-instance-0"
spec:
  dbInstanceClass: db.r5.large
  engine: aurora-postgresql
  dbInstanceIdentifier: "brucegu-manfred-instance-0"
  performanceInsightsEnabled: true
  copyTagsToSnapshot: true
  dbClusterIdentifier: "brucegu-test-cluster-3"
```
3. Try change one of the param, like `copyTagsToSnapshot` and verify rds will throw exception like `The specified DB Instance is a member of a cluster. Modify backup window for the DB Cluster using the ModifyDbCluster API` 
4. With new code, make sure modify can go through and no exception is thrown. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
