### PR TITLE
Fix issue of adopted resource for both DBClusterParameterGroup and DBSubnetGroup

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-07-12T23:15:01Z"
+  build_date: "2022-07-12T23:19:21Z"
   build_hash: d09bac5fa87cffd0028014833a5e7e786c0187dd
   go_version: go1.18.2
   version: v0.19.2-6-gd09bac5
@@ -7,7 +7,7 @@ api_directory_checksum: a60467e94dc7e76bf34ff50f21691507d576fefc
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.27
 generator_config_info:
-  file_checksum: 7c97381f2505016d3d383ddabd3a54042822914d
+  file_checksum: 0b31df47b2d4db92ee4536c1713f64c60d266c72
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-07-11T21:43:34Z"
+  build_date: "2022-07-12T23:15:01Z"
   build_hash: d09bac5fa87cffd0028014833a5e7e786c0187dd
   go_version: go1.18.2
   version: v0.19.2-6-gd09bac5
@@ -7,7 +7,7 @@ api_directory_checksum: a60467e94dc7e76bf34ff50f21691507d576fefc
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.27
 generator_config_info:
-  file_checksum: bb74db41177efd5c2c2dee2b106ff4ad8e9adcdb
+  file_checksum: 7c97381f2505016d3d383ddabd3a54042822914d
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -134,6 +134,7 @@ resources:
         DescribeDBClusterParameterGroups:
           input_fields:
             DBClusterParameterGroupName: Name
+            DBParameterGroupFamily: Family
         CreateDBClusterParameterGroup:
           input_fields:
             DBClusterParameterGroupName: Name
@@ -141,6 +142,10 @@ resources:
         DeleteDBClusterParameterGroup:
           input_fields:
             DBClusterParameterGroupName: Name
+        ModifyDBClusterParameterGroup:
+          input_fields:
+            DBClusterParameterGroupName: Name
+            DBParameterGroupFamily: Family
     update_operation:
       # We need a custom update implementation until the issue behind
       # https://github.com/aws-controllers-k8s/community/issues/869 is
@@ -306,14 +311,17 @@ resources:
           input_fields:
             DBSubnetGroupName: Name
             DBSubnetGroupDescription: Description
+            Subnet.SubnetIdentifier: SubnetIDs
         CreateDBSubnetGroup:
           input_fields:
             DBSubnetGroupName: Name
             DBSubnetGroupDescription: Description
+            Subnet.SubnetIdentifier: SubnetIDs
         ModifyDBSubnetGroup:
           input_fields:
             DBSubnetGroupName: Name
             DBSubnetGroupDescription: Description
+            Subnet.SubnetIdentifier: SubnetIDs
         DeleteDBSubnetGroup:
           input_fields:
             DBSubnetGroupName: Name

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -311,17 +311,14 @@ resources:
           input_fields:
             DBSubnetGroupName: Name
             DBSubnetGroupDescription: Description
-            Subnet.SubnetIdentifier: SubnetIDs
         CreateDBSubnetGroup:
           input_fields:
             DBSubnetGroupName: Name
             DBSubnetGroupDescription: Description
-            Subnet.SubnetIdentifier: SubnetIDs
         ModifyDBSubnetGroup:
           input_fields:
             DBSubnetGroupName: Name
             DBSubnetGroupDescription: Description
-            Subnet.SubnetIdentifier: SubnetIDs
         DeleteDBSubnetGroup:
           input_fields:
             DBSubnetGroupName: Name

--- a/generator.yaml
+++ b/generator.yaml
@@ -134,6 +134,7 @@ resources:
         DescribeDBClusterParameterGroups:
           input_fields:
             DBClusterParameterGroupName: Name
+            DBParameterGroupFamily: Family
         CreateDBClusterParameterGroup:
           input_fields:
             DBClusterParameterGroupName: Name
@@ -141,6 +142,10 @@ resources:
         DeleteDBClusterParameterGroup:
           input_fields:
             DBClusterParameterGroupName: Name
+        ModifyDBClusterParameterGroup:
+          input_fields:
+            DBClusterParameterGroupName: Name
+            DBParameterGroupFamily: Family
     update_operation:
       # We need a custom update implementation until the issue behind
       # https://github.com/aws-controllers-k8s/community/issues/869 is
@@ -306,14 +311,17 @@ resources:
           input_fields:
             DBSubnetGroupName: Name
             DBSubnetGroupDescription: Description
+            Subnet.SubnetIdentifier: SubnetIDs
         CreateDBSubnetGroup:
           input_fields:
             DBSubnetGroupName: Name
             DBSubnetGroupDescription: Description
+            Subnet.SubnetIdentifier: SubnetIDs
         ModifyDBSubnetGroup:
           input_fields:
             DBSubnetGroupName: Name
             DBSubnetGroupDescription: Description
+            Subnet.SubnetIdentifier: SubnetIDs
         DeleteDBSubnetGroup:
           input_fields:
             DBSubnetGroupName: Name

--- a/generator.yaml
+++ b/generator.yaml
@@ -311,17 +311,14 @@ resources:
           input_fields:
             DBSubnetGroupName: Name
             DBSubnetGroupDescription: Description
-            Subnet.SubnetIdentifier: SubnetIDs
         CreateDBSubnetGroup:
           input_fields:
             DBSubnetGroupName: Name
             DBSubnetGroupDescription: Description
-            Subnet.SubnetIdentifier: SubnetIDs
         ModifyDBSubnetGroup:
           input_fields:
             DBSubnetGroupName: Name
             DBSubnetGroupDescription: Description
-            Subnet.SubnetIdentifier: SubnetIDs
         DeleteDBSubnetGroup:
           input_fields:
             DBSubnetGroupName: Name

--- a/pkg/resource/db_cluster_parameter_group/sdk.go
+++ b/pkg/resource/db_cluster_parameter_group/sdk.go
@@ -100,6 +100,11 @@ func (rm *resourceManager) sdkFind(
 		} else {
 			ko.Spec.Name = nil
 		}
+		if elem.DBParameterGroupFamily != nil {
+			ko.Spec.Family = elem.DBParameterGroupFamily
+		} else {
+			ko.Spec.Family = nil
+		}
 		if elem.Description != nil {
 			ko.Spec.Description = elem.Description
 		} else {

--- a/pkg/resource/db_instance/sdk.go
+++ b/pkg/resource/db_instance/sdk.go
@@ -1775,7 +1775,6 @@ func (rm *resourceManager) sdkUpdate(
 	// For dbInstance inside dbCluster, it's either aurora or
 	// multi-az cluster case, in either case, the below params
 	// are not controlled in instance level.
-	// multi-az cluster control it on cluster leve, aurora doesn't need it
 	// hence when DBClusterIdentifier appear, set them to nil
 	// Please refer to doc : https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DeleteDBInstance.html
 	if desired.ko.Spec.DBClusterIdentifier != nil {

--- a/pkg/resource/db_subnet_group/sdk.go
+++ b/pkg/resource/db_subnet_group/sdk.go
@@ -173,6 +173,14 @@ func (rm *resourceManager) sdkFind(
 		ko.Spec.Tags = tags
 	}
 
+	if ko.Status.Subnets != nil {
+		for _, subnetIdIter := range ko.Status.Subnets {
+			if subnetIdIter.SubnetIdentifier != nil {
+				ko.Spec.SubnetIDs = append(ko.Spec.SubnetIDs, subnetIdIter.SubnetIdentifier)
+			}
+		}
+	}
+
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/db_subnet_group/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/db_subnet_group/sdk_read_many_post_set_output.go.tpl
@@ -6,3 +6,11 @@
         }
         ko.Spec.Tags = tags
 	}
+
+        if ko.Status.Subnets != nil {
+            for _, subnetIdIter := range ko.Status.Subnets {
+                if subnetIdIter.SubnetIdentifier != nil {
+                    ko.Spec.SubnetIDs = append(ko.Spec.SubnetIDs, subnetIdIter.SubnetIdentifier)
+                }
+            }
+        }

--- a/templates/hooks/db_subnet_group/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/db_subnet_group/sdk_read_many_post_set_output.go.tpl
@@ -9,8 +9,8 @@
 
         if ko.Status.Subnets != nil {
                 for _, subnetIdIter := range ko.Status.Subnets {
-                    if subnetIdIter.SubnetIdentifier != nil {
-                        ko.Spec.SubnetIDs = append(ko.Spec.SubnetIDs, subnetIdIter.SubnetIdentifier)
-                    }
+                        if subnetIdIter.SubnetIdentifier != nil {
+                                ko.Spec.SubnetIDs = append(ko.Spec.SubnetIDs, subnetIdIter.SubnetIdentifier)
+                        }
                 }
         }

--- a/templates/hooks/db_subnet_group/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/db_subnet_group/sdk_read_many_post_set_output.go.tpl
@@ -8,9 +8,9 @@
 	}
 
         if ko.Status.Subnets != nil {
-            for _, subnetIdIter := range ko.Status.Subnets {
-                if subnetIdIter.SubnetIdentifier != nil {
-                    ko.Spec.SubnetIDs = append(ko.Spec.SubnetIDs, subnetIdIter.SubnetIdentifier)
+                for _, subnetIdIter := range ko.Status.Subnets {
+                    if subnetIdIter.SubnetIdentifier != nil {
+                        ko.Spec.SubnetIDs = append(ko.Spec.SubnetIDs, subnetIdIter.SubnetIdentifier)
+                    }
                 }
-            }
         }


### PR DESCRIPTION
Issue #, if available:

https://github.com/aws-controllers-k8s/community/issues/1389

Description of changes:
Fix issue of adopted resource for both DBClusterParameterGroup and DBSubnetGroup
1. for DBClusterParameterGroup, it's due to the rename issue that `DBParameterGroupFamily` need be called `Family` and `DBClusterParameterGroupName` need be called `Name`
2. for DBSubnetGroup, synced with @RedbackThomson , it's due to rds output status of `DBSubnetGroup` doesn't have `SubnetIDs`, and it only has `Subnets. SubnetIdentifier`, so we need to use hook to append each of them. 


With these above fixed, adopted resource should work for all available RDS CRDs now. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
