### PR TITLE
Use new bootstrap logic for shared resource like VPC for rds controller tests

### DIFF
--- a/test/e2e/bootstrap_resources.py
+++ b/test/e2e/bootstrap_resources.py
@@ -16,26 +16,20 @@ for them.
 """
 
 from dataclasses import dataclass
-from acktest.resources import read_bootstrap_config
+from acktest.bootstrapping.vpc import VPC
+from acktest.bootstrapping import Resources
 from e2e import bootstrap_directory
 
-VPC_CIDR = "10.0.81.0/27"
-SUBNET_AZ1_CIDR = "10.0.81.0/28"
-SUBNET_AZ2_CIDR = "10.0.81.16/28"
 
 @dataclass
-class TestBootstrapResources:
-    VPCID: str
-    SubnetAZ1: str
-    SubnetAZ2: str
-    DBSubnetGroupName: str
+class BootstrapResources(Resources):
+    ClusterVPC: VPC
 
 _bootstrap_resources = None
 
-def get_bootstrap_resources(bootstrap_file_name: str = "bootstrap.yaml"):
+
+def get_bootstrap_resources(bootstrap_file_name: str = "bootstrap.pkl") -> BootstrapResources:
     global _bootstrap_resources
     if _bootstrap_resources is None:
-        _bootstrap_resources = TestBootstrapResources(
-            **read_bootstrap_config(bootstrap_directory, bootstrap_file_name=bootstrap_file_name),
-        )
+        _bootstrap_resources = BootstrapResources.deserialize(bootstrap_directory, bootstrap_file_name=bootstrap_file_name)
     return _bootstrap_resources

--- a/test/e2e/replacement_values.py
+++ b/test/e2e/replacement_values.py
@@ -13,6 +13,9 @@
 """Stores the values used by each of the integration tests for replacing the
 RDS-specific test variables.
 """
+from e2e.bootstrap_resources import get_bootstrap_resources
 
 REPLACEMENT_VALUES = {
+    "PUBLIC_SUBNET_1": get_bootstrap_resources().ClusterVPC.public_subnets.subnet_ids[0],
+    "PUBLIC_SUBNET_2": get_bootstrap_resources().ClusterVPC.public_subnets.subnet_ids[1]
 }

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@955d7831ee374a212250179e95a5f3b75e555fd9
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@f3fa264ef08d93a57b515213ac044c0c0392ffa2

--- a/test/e2e/resources/db_instance_postgres14_t3_micro.yaml
+++ b/test/e2e/resources/db_instance_postgres14_t3_micro.yaml
@@ -7,7 +7,6 @@ spec:
   copyTagsToSnapshot: $COPY_TAGS_TO_SNAPSHOT
   dbInstanceClass: db.t3.micro
   dbInstanceIdentifier: $DB_INSTANCE_ID
-  dbSubnetGroupName: $DB_SUBNET_GROUP_NAME
   engine: postgres
   engineVersion: "14.1"
   masterUsername: root

--- a/test/e2e/resources/db_subnet_group_2az.yaml
+++ b/test/e2e/resources/db_subnet_group_2az.yaml
@@ -6,8 +6,8 @@ spec:
   name: $DB_SUBNET_GROUP_NAME
   description: $DB_SUBNET_GROUP_DESC
   subnetIDs:
-    - $SUBNET_AZ1
-    - $SUBNET_AZ2
+    - $PUBLIC_SUBNET_1
+    - $PUBLIC_SUBNET_2
   tags:
     - key: environment
       value: dev

--- a/test/e2e/service_bootstrap.py
+++ b/test/e2e/service_bootstrap.py
@@ -13,124 +13,29 @@
 """Bootstraps the resources required to run the RDS integration tests.
 """
 
-import boto3
 import logging
-import time
 
-from acktest import resources
-from acktest.resources import random_suffix_name
-from acktest.aws.identity import get_region
 from e2e import bootstrap_directory
-from e2e.bootstrap_resources import (
-    TestBootstrapResources,
-    VPC_CIDR,
-    SUBNET_AZ1_CIDR,
-    SUBNET_AZ2_CIDR,
-)
+from acktest.bootstrapping import Resources, BootstrapFailureException
+from acktest.bootstrapping.vpc import VPC
+from e2e.bootstrap_resources import BootstrapResources
 
 
-def create_vpc() -> str:
-    region = get_region()
-    ec2 = boto3.client("ec2", region_name=region)
-
-    logging.debug(f"Creating VPC with CIDR {VPC_CIDR}")
-
-    resp = ec2.create_vpc(
-        CidrBlock=VPC_CIDR,
-    )
-    vpc_id = resp['Vpc']['VpcId']
-
-    # TODO(jaypipes): Put a proper waiter here...
-    time.sleep(3)
-
-    vpcs = ec2.describe_vpcs(VpcIds=[vpc_id])
-    if len(vpcs['Vpcs']) != 1:
-        raise RuntimeError(
-            f"failed to describe VPC we just created '{vpc_id}'",
-        )
-
-    vpc = vpcs['Vpcs'][0]
-    vpc_state = vpc['State']
-    if vpc_state != "available":
-        raise RuntimeError(
-            f"VPC we just created '{vpc_id}' is not available. current state: {vpc_state}",
-        )
-
-    logging.info(f"Created VPC {vpc_id}")
-
-    return vpc_id
-
-
-def create_subnet(vpc_id: str, az_id: str, cidr: str) -> str:
-    region = get_region()
-    ec2 = boto3.client("ec2", region_name=region)
-
-    logging.debug(f"Creating subnet with CIDR {cidr} in AZ {az_id}")
-
-    resp = ec2.create_subnet(
-        VpcId=vpc_id,
-        AvailabilityZone=az_id,
-        CidrBlock=cidr,
-    )
-    subnet_id = resp['Subnet']['SubnetId']
-
-    # TODO(jaypipes): Put a proper waiter here...
-    time.sleep(3)
-
-    subnets  = ec2.describe_subnets(SubnetIds=[subnet_id])
-    if len(subnets['Subnets']) != 1:
-        raise RuntimeError(
-            f"failed to describe subnet we just created '{subnet_id}'",
-        )
-
-    subnet = subnets['Subnets'][0]
-    subnet_state = subnet['State']
-    if subnet_state != "available":
-        raise RuntimeError(
-            f"Subnet we just created '{subnet_id}' is not available. current state: {subnet_state}",
-        )
-
-    logging.info(f"Created VPC Subnet {subnet_id} in AZ {az_id}")
-
-    return subnet_id
-
-
-def create_db_subnet_group(db_subnet_group_name: str, subnet_az1_id: str, subnet_az2_id:str):
-    region = get_region()
-    rds = boto3.client("rds", region_name=region)
-
-    logging.debug(f"Creating DBSubnetGroup with name {db_subnet_group_name}")
-
-    rds.create_db_subnet_group(
-        DBSubnetGroupName=db_subnet_group_name,
-        DBSubnetGroupDescription='DBSubnetGroup for e2e testing of ACK rds-controller',
-        SubnetIds=[subnet_az1_id, subnet_az2_id],
-    )
-
-    logging.info(f"Created DBSubnetGroup {db_subnet_group_name}")
-
-
-def service_bootstrap() -> dict:
+def service_bootstrap() -> Resources:
     logging.getLogger().setLevel(logging.INFO)
-    region = get_region()
 
-    vpc_id = create_vpc()
-    az1 = f"{region}a"
-    subnet_az1_id = create_subnet(vpc_id, az1, SUBNET_AZ1_CIDR)
-    az2 = f"{region}b"
-    subnet_az2_id = create_subnet(vpc_id, az2, SUBNET_AZ2_CIDR)
-    db_subnet_group_name = random_suffix_name("ack-test-subnet-group", 30)
-    create_db_subnet_group(db_subnet_group_name, subnet_az1_id, subnet_az2_id)
+    resources = BootstrapResources(
+        ClusterVPC=VPC(name_prefix="cluster-vpc", num_public_subnet=2, num_private_subnet=2),
+    )
 
-    return TestBootstrapResources(
-        vpc_id,
-        subnet_az1_id,
-        subnet_az2_id,
-        db_subnet_group_name
-    ).__dict__
+    try:
+        resources.bootstrap()
+    except BootstrapFailureException as ex:
+        exit(254)
 
+    return resources
 
 if __name__ == "__main__":
     config = service_bootstrap()
     # Write config to current directory by default
-    resources.write_bootstrap_config(config, bootstrap_directory)
+    config.serialize(bootstrap_directory)

--- a/test/e2e/tests/test_db_cluster.py
+++ b/test/e2e/tests/test_db_cluster.py
@@ -23,6 +23,7 @@ from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_rds_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
 from e2e import condition
 from e2e import db_cluster
+from e2e.fixtures import k8s_secret
 from e2e import tag
 
 RESOURCE_PLURAL = 'dbclusters'

--- a/test/e2e/tests/test_db_cluster.py
+++ b/test/e2e/tests/test_db_cluster.py
@@ -21,10 +21,8 @@ import pytest
 from acktest.k8s import resource as k8s
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_rds_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
-from e2e.bootstrap_resources import get_bootstrap_resources
 from e2e import condition
 from e2e import db_cluster
-from e2e.fixtures import k8s_secret
 from e2e import tag
 
 RESOURCE_PLURAL = 'dbclusters'

--- a/test/e2e/tests/test_db_cluster_parameter_group.py
+++ b/test/e2e/tests/test_db_cluster_parameter_group.py
@@ -24,6 +24,7 @@ from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_rds_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
 from e2e import db_cluster_parameter_group
 from e2e import tag
+from e2e import condition
 
 RESOURCE_PLURAL = 'dbclusterparametergroups'
 

--- a/test/e2e/tests/test_db_cluster_parameter_group.py
+++ b/test/e2e/tests/test_db_cluster_parameter_group.py
@@ -22,8 +22,6 @@ import pytest
 from acktest.k8s import resource as k8s
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_rds_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
-from e2e.bootstrap_resources import get_bootstrap_resources
-from e2e import condition
 from e2e import db_cluster_parameter_group
 from e2e import tag
 

--- a/test/e2e/tests/test_db_instance.py
+++ b/test/e2e/tests/test_db_instance.py
@@ -22,10 +22,8 @@ from acktest.k8s import resource as k8s
 from acktest.resources import random_suffix_name
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_rds_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
-from e2e.bootstrap_resources import get_bootstrap_resources
 from e2e import condition
 from e2e import db_instance
-from e2e.fixtures import k8s_secret
 
 RESOURCE_PLURAL = 'dbinstances'
 
@@ -75,7 +73,6 @@ def postgres14_t3_micro_instance(k8s_secret):
     replacements["MASTER_USER_PASS_SECRET_NAMESPACE"] = secret.ns
     replacements["MASTER_USER_PASS_SECRET_NAME"] = secret.name
     replacements["MASTER_USER_PASS_SECRET_KEY"] = secret.key
-    replacements["DB_SUBNET_GROUP_NAME"] = get_bootstrap_resources().DBSubnetGroupName
 
     resource_data = load_rds_resource(
         "db_instance_postgres14_t3_micro",
@@ -148,7 +145,6 @@ class TestDBInstance:
         latest = db_instance.get(db_instance_id)
         assert latest is not None
         assert latest['CopyTagsToSnapshot'] is False
-        assert latest['DBSubnetGroup']['DBSubnetGroupName'] == get_bootstrap_resources().DBSubnetGroupName
         updates = {
             "spec": {"copyTagsToSnapshot": True, "multiAZ": True},
         }

--- a/test/e2e/tests/test_db_instance.py
+++ b/test/e2e/tests/test_db_instance.py
@@ -24,6 +24,7 @@ from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_rds_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
 from e2e import condition
 from e2e import db_instance
+from e2e.fixtures import k8s_secret
 
 RESOURCE_PLURAL = 'dbinstances'
 

--- a/test/e2e/tests/test_db_parameter_group.py
+++ b/test/e2e/tests/test_db_parameter_group.py
@@ -22,7 +22,6 @@ import pytest
 from acktest.k8s import resource as k8s
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_rds_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
-from e2e.bootstrap_resources import get_bootstrap_resources
 from e2e import condition
 from e2e import db_parameter_group
 from e2e import tag

--- a/test/e2e/tests/test_db_subnet_group.py
+++ b/test/e2e/tests/test_db_subnet_group.py
@@ -21,7 +21,6 @@ import pytest
 
 from acktest.k8s import resource as k8s
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_rds_resource
-from e2e.bootstrap_resources import get_bootstrap_resources
 from e2e.replacement_values import REPLACEMENT_VALUES
 from e2e import condition
 from e2e import db_subnet_group
@@ -42,13 +41,9 @@ class TestDBSubnetGroup:
         resource_name = "my-db-subnet-group"
         resource_desc = "my-db-subnet-group description"
 
-        br_resources = get_bootstrap_resources()
-
         replacements = REPLACEMENT_VALUES.copy()
         replacements["DB_SUBNET_GROUP_NAME"] = resource_name
         replacements["DB_SUBNET_GROUP_DESC"] = resource_desc
-        replacements["SUBNET_AZ1"] = br_resources.SubnetAZ1
-        replacements["SUBNET_AZ2"] = br_resources.SubnetAZ2
 
         resource_data = load_rds_resource(
             "db_subnet_group_2az",


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/1325

Description of changes:
This is the first part of using new bootstrap logic for bootstrap shared source for rds e2e tests, VPC/Subnet here. 
I'm expecting to have a new pr for adding bootstrap for rds specific resource later. 
1. use new bootstrap logic to create VPC and subnet are created within VPC as subResource
2. Remove creation of `dbSubnetGroup` since we can rely on rds api to create default `dbSubnetGroup` if no specified and it's not needed to validate that logic in the controller itself. 
3. Not too much change on the e2e test itself, it's still using `load_rds_resource` call to create resource. We can think of bootstraping rds resource later. 

(I'm not very confident with this pr, but tests seem pass with no issue. )

```
2022-07-27T20:58:53+00:00 [INFO] Running test bootstrap ...
INFO:root:🛠️ Bootstrapping resources ...
INFO:root:Attempting bootstrap VPC
INFO:root:Attempting bootstrap Subnets
INFO:root:Attempting bootstrap RouteTable
INFO:root:Attempting bootstrap InternetGateway
INFO:root:Successfully bootstrapped InternetGateway
INFO:root:Successfully bootstrapped RouteTable
INFO:root:Successfully bootstrapped Subnets
INFO:root:Attempting bootstrap Subnets
INFO:root:Attempting bootstrap RouteTable
INFO:root:Successfully bootstrapped RouteTable
INFO:root:Successfully bootstrapped Subnets
INFO:root:Successfully bootstrapped VPC
INFO:root:Wrote bootstrap to /rds-controller/tests/e2e/bootstrap.pkl
2022-07-27T20:58:58+00:00 [INFO] Running tests ...
scheduling tests via LoadScheduling
tests/test_db_instance.py::TestDBInstance::test_crud_postgres14_t3_micro
tests/test_db_instance.py::TestDBInstance::test_enable_pi_postgres14_t3_micro
tests/test_db_cluster.py::TestDBCluster::test_crud_mysql_serverless
tests/test_db_parameter_group.py::TestDBParameterGroup::test_create_delete_postgres13_standard
tests/test_db_cluster_parameter_group.py::TestDBClusterParameterGroup::test_create_delete_aurora_mysql5_7
tests/test_db_subnet_group.py::TestDBSubnetGroup::test_create_delete_2az
[gw1] [ 16%] PASSED tests/test_db_cluster_parameter_group.py::TestDBClusterParameterGroup::test_create_delete_aurora_mysql5_7
[gw4] [ 33%] PASSED tests/test_db_parameter_group.py::TestDBParameterGroup::test_create_delete_postgres13_standard
[gw5] [ 50%] PASSED tests/test_db_subnet_group.py::TestDBSubnetGroup::test_create_delete_2az
[gw0] [ 66%] PASSED tests/test_db_cluster.py::TestDBCluster::test_crud_mysql_serverless
[gw3] [ 83%] PASSED tests/test_db_instance.py::TestDBInstance::test_enable_pi_postgres14_t3_micro
[gw2] [100%] PASSED tests/test_db_instance.py::TestDBInstance::test_crud_postgres14_t3_micro
==================== 6 passed in 2184.47s (0:36:24) 
2022-07-27T21:35:24+00:00 [INFO] Tests succeeded!
2022-07-27T21:35:24+00:00 [INFO] Running test cleanup ...
INFO:root:🧹 Cleaning up resources ...
INFO:root:Attempting cleanup VPC
INFO:root:Attempting cleanup Subnets
INFO:root:Attempting cleanup RouteTable
INFO:root:Successfully cleaned up RouteTable
INFO:root:Successfully cleaned up Subnets
INFO:root:Attempting cleanup Subnets
INFO:root:Attempting cleanup RouteTable
INFO:root:Attempting cleanup InternetGateway
INFO:root:Successfully cleaned up InternetGateway
INFO:root:Successfully cleaned up RouteTable
INFO:root:Successfully cleaned up Subnets
INFO:root:Successfully cleaned up VPC
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
