### PR TITLE
support overriding parameter values on param group

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -3,11 +3,11 @@ ack_generate_info:
   build_hash: fe61d04673fd4d9848d5f726b01e0689a16d3733
   go_version: go1.18.2
   version: v0.19.3-1-gfe61d04
-api_directory_checksum: 6a967cc8a62d521d4f4816dbccc48f81d0cb271d
+api_directory_checksum: 420612ef2bc7cf0b19ebe41c44626560e060c4a1
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.27
 generator_config_info:
-  file_checksum: 48d8a87d42545d99ddabf9bea4ab180e08ab79b7
+  file_checksum: 90a2d0d868a32e6474738ad70a557035f490780a
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-08-22T20:21:30Z"
-  build_hash: fe61d04673fd4d9848d5f726b01e0689a16d3733
-  go_version: go1.18.2
-  version: v0.19.3-1-gfe61d04
+  build_date: "2022-09-02T16:27:09Z"
+  build_hash: cdb0d99c7c1d3d00e71623eb56e650960dcef0d5
+  go_version: go1.18.3
+  version: v0.19.3-2-gcdb0d99
 api_directory_checksum: 83bde1f77a49ebd8acd36a1c5e231138b67aa883
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.27
 generator_config_info:
-  file_checksum: 5d126ead4715f729c2fda976c422eb14a948f3da
+  file_checksum: 868688590b240be6d557dd31f0583bad2d309cb8
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -3,11 +3,11 @@ ack_generate_info:
   build_hash: fe61d04673fd4d9848d5f726b01e0689a16d3733
   go_version: go1.18.2
   version: v0.19.3-1-gfe61d04
-api_directory_checksum: 420612ef2bc7cf0b19ebe41c44626560e060c4a1
+api_directory_checksum: 83bde1f77a49ebd8acd36a1c5e231138b67aa883
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.27
 generator_config_info:
-  file_checksum: 90a2d0d868a32e6474738ad70a557035f490780a
+  file_checksum: 5d126ead4715f729c2fda976c422eb14a948f3da
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/db_parameter_group.go
+++ b/apis/v1alpha1/db_parameter_group.go
@@ -93,30 +93,8 @@ type DBParameterGroupSpec struct {
 	// This value is stored as a lowercase string.
 	// +kubebuilder:validation:Required
 	Name *string `json:"name"`
-	// An array of parameter names, values, and the application methods for the
-	// parameter update. At least one parameter name, value, and application method
-	// must be supplied; later arguments are optional. A maximum of 20 parameters
-	// can be modified in a single request.
-	//
-	// Valid Values (for the application method): immediate | pending-reboot
-	//
-	// You can use the immediate value with dynamic parameters only. You can use
-	// the pending-reboot value for both dynamic and static parameters.
-	//
-	// When the application method is immediate, changes to dynamic parameters are
-	// applied immediately to the DB instances associated with the parameter group.
-	//
-	// When the application method is pending-reboot, changes to dynamic and static
-	// parameters are applied after a reboot without failover to the DB instances
-	// associated with the parameter group.
-	//
-	// You can't use pending-reboot with dynamic parameters on RDS for SQL Server
-	// DB instances. Use immediate.
-	//
-	// For more information on modifying DB parameters, see Working with DB parameter
-	// groups (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html)
-	// in the Amazon RDS User Guide.
-	Parameters []*Parameter `json:"parameters,omitempty"`
+
+	ParameterOverrides map[string]*string `json:"parameterOverrides,omitempty"`
 	// Tags to assign to the DB parameter group.
 	Tags []*Tag `json:"tags,omitempty"`
 }
@@ -134,6 +112,9 @@ type DBParameterGroupStatus struct {
 	// resource
 	// +kubebuilder:validation:Optional
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
+	// A list of Parameter values.
+	// +kubebuilder:validation:Optional
+	ParameterOverrideStatuses []*Parameter `json:"parameterOverrideStatuses,omitempty"`
 }
 
 // DBParameterGroup is the Schema for the DBParameterGroups API

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -322,14 +322,27 @@ resources:
     fields:
       Name:
         is_primary_key: true
-      Parameters:
-        from:
-          operation: ModifyDBParameterGroup
-          path: Parameters
+      # These are ONLY user-defined parameter overrides for the DB parameter
+      # group. This does not contain default or system parameters.
+      ParameterOverrides:
+        custom_field:
+          # The type is a map[string]string where the map keys are the
+          # parameter name and the values are the parameter value. We
+          # automatically determine the "apply method" for parameters so all
+          # the user needs to do is specify the parameter name and value they
+          # want to override...
+          map_of: String
       Tags:
         compare:
           # We have a custom comparison function...
           is_ignored: true
+      # These are the "statuses" for the user-defined parameter overrides in
+      # Spec.ParameterOverrides
+      ParameterOverrideStatuses:
+        from:
+          operation: DescribeDBParameters
+          path: Parameters
+        is_read_only: true
   DBSubnetGroup:
     renames:
       operations:

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -319,6 +319,8 @@ resources:
         template_path: hooks/db_parameter_group/sdk_read_many_post_set_output.go.tpl
       delta_pre_compare:
         template_path: hooks/db_parameter_group/delta_pre_compare.go.tpl
+      sdk_create_post_set_output:
+        template_path: hooks/db_parameter_group/sdk_create_post_set_output.go.tpl
     fields:
       Name:
         is_primary_key: true

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -3451,15 +3451,19 @@ func (in *DBParameterGroupSpec) DeepCopyInto(out *DBParameterGroupSpec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.Parameters != nil {
-		in, out := &in.Parameters, &out.Parameters
-		*out = make([]*Parameter, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(Parameter)
-				(*in).DeepCopyInto(*out)
+	if in.ParameterOverrides != nil {
+		in, out := &in.ParameterOverrides, &out.ParameterOverrides
+		*out = make(map[string]*string, len(*in))
+		for key, val := range *in {
+			var outVal *string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = new(string)
+				**out = **in
 			}
+			(*out)[key] = outVal
 		}
 	}
 	if in.Tags != nil {
@@ -3500,6 +3504,17 @@ func (in *DBParameterGroupStatus) DeepCopyInto(out *DBParameterGroupStatus) {
 			if (*in)[i] != nil {
 				in, out := &(*in)[i], &(*out)[i]
 				*out = new(corev1alpha1.Condition)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
+	if in.ParameterOverrideStatuses != nil {
+		in, out := &in.ParameterOverrideStatuses, &out.ParameterOverrideStatuses
+		*out = make([]*Parameter, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(Parameter)
 				(*in).DeepCopyInto(*out)
 			}
 		}

--- a/config/crd/bases/rds.services.k8s.aws_dbparametergroups.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbparametergroups.yaml
@@ -67,56 +67,10 @@ spec:
                   character must be a letter \n    * Can't end with a hyphen or contain
                   two consecutive hyphens \n This value is stored as a lowercase string."
                 type: string
-              parameters:
-                description: "An array of parameter names, values, and the application
-                  methods for the parameter update. At least one parameter name, value,
-                  and application method must be supplied; later arguments are optional.
-                  A maximum of 20 parameters can be modified in a single request.
-                  \n Valid Values (for the application method): immediate | pending-reboot
-                  \n You can use the immediate value with dynamic parameters only.
-                  You can use the pending-reboot value for both dynamic and static
-                  parameters. \n When the application method is immediate, changes
-                  to dynamic parameters are applied immediately to the DB instances
-                  associated with the parameter group. \n When the application method
-                  is pending-reboot, changes to dynamic and static parameters are
-                  applied after a reboot without failover to the DB instances associated
-                  with the parameter group. \n You can't use pending-reboot with dynamic
-                  parameters on RDS for SQL Server DB instances. Use immediate. \n
-                  For more information on modifying DB parameters, see Working with
-                  DB parameter groups (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html)
-                  in the Amazon RDS User Guide."
-                items:
-                  description: "This data type is used as a request parameter in the
-                    ModifyDBParameterGroup and ResetDBParameterGroup actions. \n This
-                    data type is used as a response element in the DescribeEngineDefaultParameters
-                    and DescribeDBParameters actions."
-                  properties:
-                    allowedValues:
-                      type: string
-                    applyMethod:
-                      type: string
-                    applyType:
-                      type: string
-                    dataType:
-                      type: string
-                    description:
-                      type: string
-                    isModifiable:
-                      type: boolean
-                    minimumEngineVersion:
-                      type: string
-                    parameterName:
-                      type: string
-                    parameterValue:
-                      type: string
-                    source:
-                      type: string
-                    supportedEngineModes:
-                      items:
-                        type: string
-                      type: array
-                  type: object
-                type: array
+              parameterOverrides:
+                additionalProperties:
+                  type: string
+                type: object
               tags:
                 description: Tags to assign to the DB parameter group.
                 items:
@@ -196,6 +150,40 @@ spec:
                   required:
                   - status
                   - type
+                  type: object
+                type: array
+              parameterOverrideStatuses:
+                description: A list of Parameter values.
+                items:
+                  description: "This data type is used as a request parameter in the
+                    ModifyDBParameterGroup and ResetDBParameterGroup actions. \n This
+                    data type is used as a response element in the DescribeEngineDefaultParameters
+                    and DescribeDBParameters actions."
+                  properties:
+                    allowedValues:
+                      type: string
+                    applyMethod:
+                      type: string
+                    applyType:
+                      type: string
+                    dataType:
+                      type: string
+                    description:
+                      type: string
+                    isModifiable:
+                      type: boolean
+                    minimumEngineVersion:
+                      type: string
+                    parameterName:
+                      type: string
+                    parameterValue:
+                      type: string
+                    source:
+                      type: string
+                    supportedEngineModes:
+                      items:
+                        type: string
+                      type: array
                   type: object
                 type: array
             type: object

--- a/generator.yaml
+++ b/generator.yaml
@@ -322,14 +322,27 @@ resources:
     fields:
       Name:
         is_primary_key: true
-      Parameters:
-        from:
-          operation: ModifyDBParameterGroup
-          path: Parameters
+      # These are ONLY user-defined parameter overrides for the DB parameter
+      # group. This does not contain default or system parameters.
+      ParameterOverrides:
+        custom_field:
+          # The type is a map[string]string where the map keys are the
+          # parameter name and the values are the parameter value. We
+          # automatically determine the "apply method" for parameters so all
+          # the user needs to do is specify the parameter name and value they
+          # want to override...
+          map_of: String
       Tags:
         compare:
           # We have a custom comparison function...
           is_ignored: true
+      # These are the "statuses" for the user-defined parameter overrides in
+      # Spec.ParameterOverrides
+      ParameterOverrideStatuses:
+        from:
+          operation: DescribeDBParameters
+          path: Parameters
+        is_read_only: true
   DBSubnetGroup:
     renames:
       operations:

--- a/generator.yaml
+++ b/generator.yaml
@@ -319,6 +319,8 @@ resources:
         template_path: hooks/db_parameter_group/sdk_read_many_post_set_output.go.tpl
       delta_pre_compare:
         template_path: hooks/db_parameter_group/delta_pre_compare.go.tpl
+      sdk_create_post_set_output:
+        template_path: hooks/db_parameter_group/sdk_create_post_set_output.go.tpl
     fields:
       Name:
         is_primary_key: true

--- a/helm/crds/rds.services.k8s.aws_dbparametergroups.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbparametergroups.yaml
@@ -67,56 +67,10 @@ spec:
                   character must be a letter \n    * Can't end with a hyphen or contain
                   two consecutive hyphens \n This value is stored as a lowercase string."
                 type: string
-              parameters:
-                description: "An array of parameter names, values, and the application
-                  methods for the parameter update. At least one parameter name, value,
-                  and application method must be supplied; later arguments are optional.
-                  A maximum of 20 parameters can be modified in a single request.
-                  \n Valid Values (for the application method): immediate | pending-reboot
-                  \n You can use the immediate value with dynamic parameters only.
-                  You can use the pending-reboot value for both dynamic and static
-                  parameters. \n When the application method is immediate, changes
-                  to dynamic parameters are applied immediately to the DB instances
-                  associated with the parameter group. \n When the application method
-                  is pending-reboot, changes to dynamic and static parameters are
-                  applied after a reboot without failover to the DB instances associated
-                  with the parameter group. \n You can't use pending-reboot with dynamic
-                  parameters on RDS for SQL Server DB instances. Use immediate. \n
-                  For more information on modifying DB parameters, see Working with
-                  DB parameter groups (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html)
-                  in the Amazon RDS User Guide."
-                items:
-                  description: "This data type is used as a request parameter in the
-                    ModifyDBParameterGroup and ResetDBParameterGroup actions. \n This
-                    data type is used as a response element in the DescribeEngineDefaultParameters
-                    and DescribeDBParameters actions."
-                  properties:
-                    allowedValues:
-                      type: string
-                    applyMethod:
-                      type: string
-                    applyType:
-                      type: string
-                    dataType:
-                      type: string
-                    description:
-                      type: string
-                    isModifiable:
-                      type: boolean
-                    minimumEngineVersion:
-                      type: string
-                    parameterName:
-                      type: string
-                    parameterValue:
-                      type: string
-                    source:
-                      type: string
-                    supportedEngineModes:
-                      items:
-                        type: string
-                      type: array
-                  type: object
-                type: array
+              parameterOverrides:
+                additionalProperties:
+                  type: string
+                type: object
               tags:
                 description: Tags to assign to the DB parameter group.
                 items:
@@ -196,6 +150,40 @@ spec:
                   required:
                   - status
                   - type
+                  type: object
+                type: array
+              parameterOverrideStatuses:
+                description: A list of Parameter values.
+                items:
+                  description: "This data type is used as a request parameter in the
+                    ModifyDBParameterGroup and ResetDBParameterGroup actions. \n This
+                    data type is used as a response element in the DescribeEngineDefaultParameters
+                    and DescribeDBParameters actions."
+                  properties:
+                    allowedValues:
+                      type: string
+                    applyMethod:
+                      type: string
+                    applyType:
+                      type: string
+                    dataType:
+                      type: string
+                    description:
+                      type: string
+                    isModifiable:
+                      type: boolean
+                    minimumEngineVersion:
+                      type: string
+                    parameterName:
+                      type: string
+                    parameterValue:
+                      type: string
+                    source:
+                      type: string
+                    supportedEngineModes:
+                      items:
+                        type: string
+                      type: array
                   type: object
                 type: array
             type: object

--- a/pkg/resource/db_parameter_group/delta.go
+++ b/pkg/resource/db_parameter_group/delta.go
@@ -63,8 +63,12 @@ func newResourceDelta(
 			delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
 		}
 	}
-	if !reflect.DeepEqual(a.ko.Spec.Parameters, b.ko.Spec.Parameters) {
-		delta.Add("Spec.Parameters", a.ko.Spec.Parameters, b.ko.Spec.Parameters)
+	if ackcompare.HasNilDifference(a.ko.Spec.ParameterOverrides, b.ko.Spec.ParameterOverrides) {
+		delta.Add("Spec.ParameterOverrides", a.ko.Spec.ParameterOverrides, b.ko.Spec.ParameterOverrides)
+	} else if a.ko.Spec.ParameterOverrides != nil && b.ko.Spec.ParameterOverrides != nil {
+		if !ackcompare.MapStringStringPEqual(a.ko.Spec.ParameterOverrides, b.ko.Spec.ParameterOverrides) {
+			delta.Add("Spec.ParameterOverrides", a.ko.Spec.ParameterOverrides, b.ko.Spec.ParameterOverrides)
+		}
 	}
 
 	return delta

--- a/pkg/resource/db_parameter_group/sdk.go
+++ b/pkg/resource/db_parameter_group/sdk.go
@@ -126,6 +126,15 @@ func (rm *resourceManager) sdkFind(
 		}
 		ko.Spec.Tags = tags
 	}
+	if ko.Spec.Name != nil {
+		groupName := ko.Spec.Name
+		params, paramStatuses, err := rm.getParameters(ctx, groupName)
+		if err != nil {
+			return nil, err
+		}
+		ko.Spec.ParameterOverrides = params
+		ko.Status.ParameterOverrideStatuses = paramStatuses
+	}
 
 	return &resource{ko}, nil
 }

--- a/pkg/resource/db_parameter_group/sdk.go
+++ b/pkg/resource/db_parameter_group/sdk.go
@@ -215,6 +215,10 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
+	// We need to instantly requeue after a create operation, otherwise the controller
+	// will override the latest resource with the desired resource overrideParameters
+	// and cause the controller to not properly compare latest and desired resources.
+	return &resource{ko}, requeueWaitWhileCreating
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/db_parameter_group/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/db_parameter_group/sdk_create_post_set_output.go.tpl
@@ -1,0 +1,4 @@
+    // We need to instantly requeue after a create operation, otherwise the controller
+    // will override the latest resource with the desired resource overrideParameters
+    // and cause the controller to not properly compare latest and desired resources.
+    return &resource{ko}, requeueWaitWhileCreating

--- a/templates/hooks/db_parameter_group/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/db_parameter_group/sdk_read_many_post_set_output.go.tpl
@@ -1,8 +1,17 @@
 	if ko.Status.ACKResourceMetadata != nil && ko.Status.ACKResourceMetadata.ARN != nil {
-        resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
-        tags, err := rm.getTags(ctx, *resourceARN)
-        if err != nil {
-            return nil, err
-        }
-        ko.Spec.Tags = tags
+		resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
+		tags, err := rm.getTags(ctx, *resourceARN)
+		if err != nil {
+			return nil, err
+		}
+		ko.Spec.Tags = tags
+	}
+	if ko.Spec.Name != nil {
+		groupName := ko.Spec.Name
+		params, paramStatuses, err := rm.getParameters(ctx, groupName)
+		if err != nil {
+			return nil, err
+		}
+		ko.Spec.ParameterOverrides = params
+		ko.Status.ParameterOverrideStatuses = paramStatuses
 	}

--- a/test/e2e/db_parameter_group.py
+++ b/test/e2e/db_parameter_group.py
@@ -32,6 +32,19 @@ def get(db_parameter_group_name):
     except c.exceptions.DBParameterGroupNotFoundFault:
         return None
 
+def get_parameters(db_parameter_group_name):
+    """Returns a dict containing the paramters of a given parameter group
+
+    If no such DB parameter group exists, returns None.
+    """
+    c = boto3.client('rds')
+    try:
+        resp = c.describe_db_parameters(
+            DBParameterGroupName=db_parameter_group_name,
+        )
+        return resp['Parameters']
+    except c.exceptions.DBParameterGroupNotFoundFault:
+        return None
 
 def get_tags(db_parameter_group_arn):
     """Returns a dict containing the DB parameter group's tag records from the

--- a/test/e2e/resources/db_parameter_group_postgres13_standard.yaml
+++ b/test/e2e/resources/db_parameter_group_postgres13_standard.yaml
@@ -6,6 +6,9 @@ spec:
   name: $DB_PARAMETER_GROUP_NAME
   description: $DB_PARAMETER_GROUP_DESC
   family: postgres13
+  parameterOverrides:
+    array_nulls: "1"
+    authentication_timeout: "50"
   tags:
     - key: environment
       value: dev


### PR DESCRIPTION
Adds code to allow a user to specify a set of parameter override values
for a DB parameter group.

The `Spec.ParameterOverrides` is a `map[string]*string` containing the
parameter names and values for parameters in a DB parameter group that
the user wishes to override from their defaults.

The `Status.ParameterOverrideStatuses` field is a slice of `Parameter`
structs that contains more "status-y" information about those overridden
parameters.

Still yet to work out is how I'm going to keep track of which parameters
for which DB engine family can have ApplyMethod=intermediate and which
ones must have ApplyMethod=pending-reboot.

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
