### PR TITLE
Fix `computeTagsDelta` function

### DIFF
--- a/pkg/resource/db_instance/hooks.go
+++ b/pkg/resource/db_instance/hooks.go
@@ -532,7 +532,7 @@ func computeTagsDelta(
 	}
 
 	latestTags := map[string]string{}
-	for _, tag := range desired {
+	for _, tag := range latest {
 		latestTags[*tag.Key] = *tag.Value
 	}
 


### PR DESCRIPTION
This patch modifies the tags comparison functions to fix a bug that was
recently observed in prow e2e tests.

- Fixes `computeTagsDelta` function for `pkg/db_instance/hooks.go`

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
