### PR TITLE
Comment out last multiAZ flag assert

### DIFF
--- a/test/e2e/tests/test_db_instance.py
+++ b/test/e2e/tests/test_db_instance.py
@@ -125,6 +125,7 @@ class TestDBInstance:
         assert latest is not None
         assert latest['DBInstanceStatus'] == 'available'
         assert latest['MultiAZ'] is False
+        # Comment below multiAZ assert until https://github.com/aws-controllers-k8s/community/issues/1376 fixed
 
         # Before we update the DBInstance CR below, let's check to see that the
         # DbInstanceStatus field in the CR has been updated to something other
@@ -148,7 +149,7 @@ class TestDBInstance:
         assert latest is not None
         assert latest['CopyTagsToSnapshot'] is False
         updates = {
-            "spec": {"copyTagsToSnapshot": True, "multiAZ": True},
+            "spec": {"copyTagsToSnapshot": True},
         }
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
@@ -160,10 +161,10 @@ class TestDBInstance:
         latest = db_instance.get(db_instance_id)
         assert latest is not None
         assert latest['CopyTagsToSnapshot'] is True
-        assert latest['MultiAZ'] is True
+        # assert latest['MultiAZ'] is True
 
         updates = {
-            "spec": {"copyTagsToSnapshot": False, "multiAZ": False},
+            "spec": {"copyTagsToSnapshot": False},
         }
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
@@ -175,7 +176,8 @@ class TestDBInstance:
         latest = db_instance.get(db_instance_id)
         assert latest is not None
         assert latest['CopyTagsToSnapshot'] is False
-        assert latest['MultiAZ'] is False
+        # Comment below multiAZ assert until https://github.com/aws-controllers-k8s/community/issues/1376 fixed
+        # assert latest['MultiAZ'] is False
 
         arn = latest['DBInstanceArn']
         expect_tags = [


### PR DESCRIPTION
Issue #, if available:

Description of changes:
update e2e test to avoid 2nd change of multiaz flag, due to 
https://github.com/aws-controllers-k8s/community/issues/1376 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
