### PR TITLE
Update `computeTagsDelta` function

### DIFF
--- a/pkg/resource/db_cluster/hooks.go
+++ b/pkg/resource/db_cluster/hooks.go
@@ -25,6 +25,8 @@ import (
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go/service/rds"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/aws-controllers-k8s/rds-controller/pkg/util"
 )
 
 // NOTE(jaypipes): The below list is derived from looking at the RDS control
@@ -182,7 +184,7 @@ func (rm *resourceManager) syncTags(
 
 	arn := (*string)(latest.ko.Status.ACKResourceMetadata.ARN)
 
-	toAdd, toDelete := computeTagsDelta(
+	toAdd, toDelete := util.ComputeTagsDelta(
 		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
 	)
 
@@ -257,46 +259,10 @@ func compareTags(
 	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	} else if len(a.ko.Spec.Tags) > 0 {
-		if !equalTags(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+		if !util.EqualTags(a.ko.Spec.Tags, b.ko.Spec.Tags) {
 			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 		}
 	}
-}
-
-// equalTags returns true if two Tag arrays are equal regardless of the order
-// of their elements.
-func equalTags(
-	a []*svcapitypes.Tag,
-	b []*svcapitypes.Tag,
-) bool {
-	added, removed := computeTagsDelta(a, b)
-	return len(added) == 0 && len(removed) == 0
-}
-
-// computeTagsDelta compares two Tag arrays and returns the tags to add and the
-// tag keys to delete
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (added []*svcapitypes.Tag, removed []*string) {
-	toDelete := []*string{}
-	toAdd := []*svcapitypes.Tag{}
-
-	desiredTags := map[string]string{}
-	for _, tag := range desired {
-		desiredTags[*tag.Key] = *tag.Value
-	}
-
-	for _, tag := range desired {
-		toAdd = append(toAdd, tag)
-	}
-	for _, tag := range latest {
-		_, ok := desiredTags[*tag.Key]
-		if !ok {
-			toDelete = append(toDelete, tag.Key)
-		}
-	}
-	return toAdd, toDelete
 }
 
 // sdkTagsFromResourceTags transforms a *svcapitypes.Tag array to a *svcsdk.Tag
@@ -312,13 +278,6 @@ func sdkTagsFromResourceTags(
 		}
 	}
 	return tags
-}
-
-func equalStrings(a, b *string) bool {
-	if a == nil {
-		return b == nil || *b == ""
-	}
-	return (*a == "" && b == nil) || *a == *b
 }
 
 // function to create restoreDbClusterFromSnapshot payload and call restoreDbClusterFromSnapshot API

--- a/pkg/resource/db_instance/hooks.go
+++ b/pkg/resource/db_instance/hooks.go
@@ -26,6 +26,8 @@ import (
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go/service/rds"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/aws-controllers-k8s/rds-controller/pkg/util"
 )
 
 // NOTE(jaypipes): The below list is derived from looking at the RDS control
@@ -426,7 +428,7 @@ func (rm *resourceManager) syncTags(
 
 	arn := (*string)(latest.ko.Status.ACKResourceMetadata.ARN)
 
-	toAdd, toDelete := computeTagsDelta(
+	toAdd, toDelete := util.ComputeTagsDelta(
 		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
 	)
 
@@ -501,54 +503,10 @@ func compareTags(
 	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	} else if len(a.ko.Spec.Tags) > 0 {
-		if !equalTags(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+		if !util.EqualTags(a.ko.Spec.Tags, b.ko.Spec.Tags) {
 			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 		}
 	}
-}
-
-// equalTags returns true if two Tag arrays are equal regardless of the order
-// of their elements.
-func equalTags(
-	a []*svcapitypes.Tag,
-	b []*svcapitypes.Tag,
-) bool {
-	added, removed := computeTagsDelta(a, b)
-	return len(added) == 0 && len(removed) == 0
-}
-
-// computeTagsDelta compares two Tag arrays and returns the tags to add and the
-// tag keys to delete
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (added []*svcapitypes.Tag, removed []*string) {
-	toDelete := []*string{}
-	toAdd := []*svcapitypes.Tag{}
-
-	desiredTags := map[string]string{}
-	for _, tag := range desired {
-		desiredTags[*tag.Key] = *tag.Value
-	}
-
-	latestTags := map[string]string{}
-	for _, tag := range latest {
-		latestTags[*tag.Key] = *tag.Value
-	}
-
-	for _, tag := range desired {
-		val, ok := latestTags[*tag.Key]
-		if !ok || val != *tag.Value {
-			toAdd = append(toAdd, tag)
-		}
-	}
-	for _, tag := range latest {
-		_, ok := desiredTags[*tag.Key]
-		if !ok {
-			toDelete = append(toDelete, tag.Key)
-		}
-	}
-	return toAdd, toDelete
 }
 
 // sdkTagsFromResourceTags transforms a *svcapitypes.Tag array to a *svcsdk.Tag
@@ -564,11 +522,4 @@ func sdkTagsFromResourceTags(
 		}
 	}
 	return tags
-}
-
-func equalStrings(a, b *string) bool {
-	if a == nil {
-		return b == nil || *b == ""
-	}
-	return (*a == "" && b == nil) || *a == *b
 }

--- a/pkg/resource/db_subnet_group/hooks.go
+++ b/pkg/resource/db_subnet_group/hooks.go
@@ -21,6 +21,8 @@ import (
 
 	svcapitypes "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
 	svcsdk "github.com/aws/aws-sdk-go/service/rds"
+
+	"github.com/aws-controllers-k8s/rds-controller/pkg/util"
 )
 
 // syncTags keeps the resource's tags in sync
@@ -52,7 +54,7 @@ func (rm *resourceManager) syncTags(
 
 	arn := (*string)(latest.ko.Status.ACKResourceMetadata.ARN)
 
-	toAdd, toDelete := computeTagsDelta(
+	toAdd, toDelete := util.ComputeTagsDelta(
 		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
 	)
 
@@ -127,46 +129,10 @@ func compareTags(
 	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	} else if len(a.ko.Spec.Tags) > 0 {
-		if !equalTags(a.ko.Spec.Tags, b.ko.Spec.Tags) {
+		if !util.EqualTags(a.ko.Spec.Tags, b.ko.Spec.Tags) {
 			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 		}
 	}
-}
-
-// equalTags returns true if two Tag arrays are equal regardless of the order
-// of their elements.
-func equalTags(
-	a []*svcapitypes.Tag,
-	b []*svcapitypes.Tag,
-) bool {
-	added, removed := computeTagsDelta(a, b)
-	return len(added) == 0 && len(removed) == 0
-}
-
-// computeTagsDelta compares two Tag arrays and returns the tags to add and the
-// tag keys to delete
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) ([]*svcapitypes.Tag, []*string) {
-	toDelete := []*string{}
-	toAdd := []*svcapitypes.Tag{}
-
-	desiredTags := map[string]string{}
-	for _, tag := range desired {
-		desiredTags[*tag.Key] = *tag.Value
-	}
-
-	for _, tag := range desired {
-		toAdd = append(toAdd, tag)
-	}
-	for _, tag := range latest {
-		_, ok := desiredTags[*tag.Key]
-		if !ok {
-			toDelete = append(toDelete, tag.Key)
-		}
-	}
-	return toAdd, toDelete
 }
 
 // sdkTagsFromResourceTags transforms a *svcapitypes.Tag array to a *svcsdk.Tag
@@ -182,11 +148,4 @@ func sdkTagsFromResourceTags(
 		}
 	}
 	return tags
-}
-
-func equalStrings(a, b *string) bool {
-	if a == nil {
-		return b == nil || *b == ""
-	}
-	return (*a == "" && b == nil) || *a == *b
 }

--- a/pkg/util/tags.go
+++ b/pkg/util/tags.go
@@ -1,0 +1,69 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package util
+
+import (
+	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
+
+	svcapitypes "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
+)
+
+// TODO(a-hilaly) most of the utility in this package should ideally go to
+// ack runtime or pkg repository.
+
+// computeTagsDelta compares two Tag arrays and return two different list
+// containing the addedOrupdated and removed tags. The removed tags array
+// only contains the tags Keys.
+func ComputeTagsDelta(
+	a []*svcapitypes.Tag,
+	b []*svcapitypes.Tag,
+) (addedOrUpdated []*svcapitypes.Tag, removed []*string) {
+	var visitedIndexes []string
+mainLoop:
+	for _, aElement := range b {
+		visitedIndexes = append(visitedIndexes, *aElement.Key)
+		for _, bElement := range a {
+			if equalStrings(aElement.Key, bElement.Key) {
+				if !equalStrings(aElement.Value, bElement.Value) {
+					addedOrUpdated = append(addedOrUpdated, bElement)
+				}
+				continue mainLoop
+			}
+		}
+		removed = append(removed, aElement.Key)
+	}
+	for _, bElement := range a {
+		if !ackutil.InStrings(*bElement.Key, visitedIndexes) {
+			addedOrUpdated = append(addedOrUpdated, bElement)
+		}
+	}
+	return addedOrUpdated, removed
+}
+
+// equalTags returns true if two Tag arrays are equal regardless of the order
+// of their elements.
+func EqualTags(
+	a []*svcapitypes.Tag,
+	b []*svcapitypes.Tag,
+) bool {
+	addedOrUpdated, removed := ComputeTagsDelta(a, b)
+	return len(addedOrUpdated) == 0 && len(removed) == 0
+}
+
+func equalStrings(a, b *string) bool {
+	if a == nil {
+		return b == nil || *b == ""
+	}
+	return (*a == "" && b == nil) || *a == *b
+}

--- a/pkg/util/tags_test.go
+++ b/pkg/util/tags_test.go
@@ -1,0 +1,99 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package util_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+
+	svcapitypes "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
+	"github.com/aws-controllers-k8s/rds-controller/pkg/util"
+)
+
+var (
+	tagA  = &svcapitypes.Tag{Key: aws.String("A"), Value: aws.String("1")}
+	tagB  = &svcapitypes.Tag{Key: aws.String("B"), Value: aws.String("2")}
+	tagC  = &svcapitypes.Tag{Key: aws.String("C"), Value: aws.String("3")}
+	tagD  = &svcapitypes.Tag{Key: aws.String("D"), Value: aws.String("4")}
+	tagE  = &svcapitypes.Tag{Key: aws.String("E"), Value: aws.String("5")}
+	tagE2 = &svcapitypes.Tag{Key: aws.String("E"), Value: aws.String("6")}
+)
+
+func TestComputeTagsDelta(t *testing.T) {
+	type args struct {
+		a []*svcapitypes.Tag
+		b []*svcapitypes.Tag
+	}
+	tests := []struct {
+		name               string
+		args               args
+		wantAddedOrUpdated []*svcapitypes.Tag
+		wantRemoved        []*string
+	}{
+		{
+			name:               "empty arrays",
+			args:               args{},
+			wantAddedOrUpdated: nil,
+			wantRemoved:        nil,
+		},
+		{
+			name: "only added tags",
+			args: args{
+				a: []*svcapitypes.Tag{tagA, tagB, tagC},
+			},
+			wantAddedOrUpdated: []*svcapitypes.Tag{tagA, tagB, tagC},
+			wantRemoved:        nil,
+		},
+		{
+			name: "only removed tags",
+			args: args{
+				b: []*svcapitypes.Tag{tagA, tagB, tagC},
+			},
+			wantAddedOrUpdated: nil,
+			wantRemoved:        []*string{aws.String("A"), aws.String("B"), aws.String("C")},
+		},
+		{
+			name: "added and removed tags",
+			args: args{
+				a: []*svcapitypes.Tag{tagD, tagE},
+				b: []*svcapitypes.Tag{tagA, tagB, tagC},
+			},
+			wantAddedOrUpdated: []*svcapitypes.Tag{tagD, tagE},
+			wantRemoved:        []*string{aws.String("A"), aws.String("B"), aws.String("C")},
+		},
+		{
+			name: "added, updated and removed tags",
+			args: args{
+				a: []*svcapitypes.Tag{tagD, tagE2},
+				b: []*svcapitypes.Tag{tagA, tagB, tagC, tagE},
+			},
+			// notice the order of b is not the same.
+			wantAddedOrUpdated: []*svcapitypes.Tag{tagE2, tagD},
+			wantRemoved:        []*string{aws.String("A"), aws.String("B"), aws.String("C")},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAddedOrUpdated, gotRemoved := util.ComputeTagsDelta(tt.args.a, tt.args.b)
+			if !reflect.DeepEqual(gotAddedOrUpdated, tt.wantAddedOrUpdated) {
+				t.Errorf("ComputeTagsDelta() gotAddedOrUpdated = %v, want %v", gotAddedOrUpdated, tt.wantAddedOrUpdated)
+			}
+			if !reflect.DeepEqual(gotRemoved, tt.wantRemoved) {
+				t.Errorf("ComputeTagsDelta() gotRemoved = %v, want %v", gotRemoved, tt.wantRemoved)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This patch updates the `computeTagsDelta` function for `db_cluster`,
`db_parameter_group`, `db_subnet_group` and `db_cluster_parameter_group`
The previous implementation always returned a non-empty `toAdd` array
which causes the controller to make unnecessary `TagResource` API Calls.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
