### PR TITLE
Add `GlobalCluster` e2e tests for CRUD operations

### DIFF
--- a/test/e2e/db_global_cluster.py
+++ b/test/e2e/db_global_cluster.py
@@ -1,0 +1,74 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Utilities for working with DB global cluster resources"""
+
+import datetime
+import time
+
+import boto3
+import pytest
+
+DEFAULT_WAIT_UNTIL_DELETED_TIMEOUT_SECONDS = 60*10
+DEFAULT_WAIT_UNTIL_DELETED_INTERVAL_SECONDS = 15
+
+def wait_until_deleted(
+        global_cluster_id: str,
+        timeout_seconds: int = DEFAULT_WAIT_UNTIL_DELETED_TIMEOUT_SECONDS,
+        interval_seconds: int = DEFAULT_WAIT_UNTIL_DELETED_INTERVAL_SECONDS,
+    ) -> None:
+    """Waits until a DB global_cluster with a supplied ID is no longer returned from
+    the RDS API.
+
+    Usage:
+        from e2e.db_global_cluster import wait_until_deleted
+
+        wait_until_deleted(global_cluster_id)
+
+    Raises:
+        pytest.fail upon timeout or if the DB global_cluster goes to any other status
+        other than 'deleting'
+    """
+    now = datetime.datetime.now()
+    timeout = now + datetime.timedelta(seconds=timeout_seconds)
+
+    while True:
+        if datetime.datetime.now() >= timeout:
+            pytest.fail(
+                "Timed out waiting for DB global_cluster to be "
+                "deleted in RDS API"
+            )
+        time.sleep(interval_seconds)
+
+        latest = get(global_cluster_id)
+        if latest is None:
+            break
+
+        if latest['Status'] != "deleting":
+            pytest.fail(
+                "Status is not 'deleting' for DB global_cluster that was "
+                "deleted. Status is " + latest['Status']
+            )
+
+def get(global_cluster_id):
+    """Returns a dict containing the DB global cluster record from the RDS API.
+
+    If no such DB global cluster exists, returns None.
+    """
+    c = boto3.client('rds')
+    try:
+        resp = c.describe_global_clusters(GlobalClusterIdentifier=global_cluster_id)
+        assert len(resp['GlobalClusters']) == 1
+        return resp['GlobalClusters'][0]
+    except c.exceptions.GlobalClusterNotFoundFault:
+        return None

--- a/test/e2e/resources/db_global_cluster.yaml
+++ b/test/e2e/resources/db_global_cluster.yaml
@@ -1,0 +1,11 @@
+apiVersion: rds.services.k8s.aws/v1alpha1
+kind: GlobalCluster
+metadata:
+  name: $DB_GLOBAL_CLUSTER_ID
+spec:
+  databaseName: test
+  deletionProtection: true
+  engine: aurora-mysql
+  engineVersion: 5.7.mysql_aurora.2.07.2
+  globalClusterIdentifier: $DB_GLOBAL_CLUSTER_ID
+  storageEncrypted: false

--- a/test/e2e/tests/test_db_global_cluster.py
+++ b/test/e2e/tests/test_db_global_cluster.py
@@ -1,0 +1,83 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Integration tests for the RDS API DBGlobalCluster resource
+"""
+
+import logging
+import time
+
+import pytest
+
+from acktest.k8s import resource as k8s
+from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_rds_resource
+from e2e.replacement_values import REPLACEMENT_VALUES
+from e2e.bootstrap_resources import get_bootstrap_resources
+from e2e import condition
+from e2e import db_global_cluster
+
+RESOURCE_PLURAL = 'globalclusters'
+
+DELETE_WAIT_AFTER_SECONDS = 10
+MODIFY_WAIT_AFTER_SECONDS = 10
+
+@service_marker
+@pytest.mark.canary
+class TestDBGlobalCluster:
+    def test_crud(self):
+        resource_name = "mygc-mysql"
+
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements["DB_GLOBAL_CLUSTER_ID"] = resource_name
+
+        resource_data = load_rds_resource(
+            "db_global_cluster",
+            additional_replacements=replacements,
+        )
+        logging.debug(resource_data)
+
+        # Create the k8s resource
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            resource_name, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        time.sleep(90)
+        
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+
+        assert cr is not None
+        assert k8s.get_resource_exists(ref)
+        condition.assert_synced(ref)
+
+        # Let's check that the DB global cluster appears in RDS
+        latest = db_global_cluster.get(resource_name)
+        assert latest is not None
+
+        updates = {
+            "spec": {"deletionProtection": False},
+        }
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+
+        latest = db_global_cluster.get(resource_name)
+        assert latest["DeletionProtection"]
+
+        # Delete the k8s resource on teardown of the module
+        k8s.delete_custom_resource(ref)
+
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+        # DB global cluster should no longer appear in RDS
+        latest = db_global_cluster.get(resource_name)
+        assert latest is None


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Add `GlobalCluster` e2e tests for CRUD operations

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
