### PR TITLE
Copy the security groups from status into spec

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2023-02-03T21:00:52Z"
-  build_hash: ef775017fc8021baf85ad3ff2ec115df7a543568
+  build_date: "2023-03-08T11:01:31Z"
+  build_hash: b55ae8752ece381c383ffe5b388ed2147c6b30d8
   go_version: go1.19.1
-  version: v0.23.1-1-gef77501
+  version: v0.23.1
 api_directory_checksum: 17386cedbca91cf13d88bc733393624a51c214ae
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93

--- a/pkg/resource/db_cluster/sdk.go
+++ b/pkg/resource/db_cluster/sdk.go
@@ -600,6 +600,18 @@ func (rm *resourceManager) sdkFind(
 	} else {
 		ackcondition.SetSynced(&resource{ko}, corev1.ConditionTrue, nil, nil)
 	}
+	if len(r.ko.Spec.VPCSecurityGroupIDs) > 0 {
+		// If the desired resource has security groups specified then update the spec of the latest resource with the
+		// value from the status. This is done so that when a cluster is created without security groups and gets a
+		// default security group attached to it, it is not overwritten with empty security groups from the
+		// desired resource.
+		sgIDs := make([]*string, len(ko.Status.VPCSecurityGroups))
+		for i, sg := range ko.Status.VPCSecurityGroups {
+			id := *sg.VPCSecurityGroupID
+			sgIDs[i] = &id
+		}
+		ko.Spec.VPCSecurityGroupIDs = sgIDs
+	}
 
 	return &resource{ko}, nil
 }

--- a/pkg/resource/db_instance/sdk.go
+++ b/pkg/resource/db_instance/sdk.go
@@ -757,6 +757,18 @@ func (rm *resourceManager) sdkFind(
 		// the resource. No need to return a requeue error here.
 		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
 	}
+	if len(r.ko.Spec.VPCSecurityGroupIDs) > 0 {
+		// If the desired resource has security groups specified then update the spec of the latest resource with the
+		// security groups from the status. This is done so that when an instance is created without security groups
+		// and gets a default security group attached to it, it is not overwritten with no security groups from the
+		// desired resource.
+		sgIDs := make([]*string, len(ko.Status.VPCSecurityGroups))
+		for i, sg := range ko.Status.VPCSecurityGroups {
+			id := *sg.VPCSecurityGroupID
+			sgIDs[i] = &id
+		}
+		ko.Spec.VPCSecurityGroupIDs = sgIDs
+	}
 
 	return &resource{ko}, nil
 }

--- a/templates/hooks/db_cluster/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/db_cluster/sdk_read_many_post_set_output.go.tpl
@@ -13,4 +13,15 @@
 	} else {
 		ackcondition.SetSynced(&resource{ko}, corev1.ConditionTrue, nil, nil)
 	}
-
+	if len(r.ko.Spec.VPCSecurityGroupIDs) > 0 {
+		// If the desired resource has security groups specified then update the spec of the latest resource with the
+		// value from the status. This is done so that when a cluster is created without security groups and gets a
+		// default security group attached to it, it is not overwritten with empty security groups from the
+		// desired resource.
+		sgIDs := make([]*string, len(ko.Status.VPCSecurityGroups))
+		for i, sg := range ko.Status.VPCSecurityGroups {
+			id := *sg.VPCSecurityGroupID
+			sgIDs[i] = &id
+		}
+		ko.Spec.VPCSecurityGroupIDs = sgIDs
+	}

--- a/templates/hooks/db_instance/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/db_instance/sdk_read_many_post_set_output.go.tpl
@@ -11,4 +11,15 @@
 		// the resource. No need to return a requeue error here.
 		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
 	}
-
+	if len(r.ko.Spec.VPCSecurityGroupIDs) > 0 {
+		// If the desired resource has security groups specified then update the spec of the latest resource with the
+		// security groups from the status. This is done so that when an instance is created without security groups
+		// and gets a default security group attached to it, it is not overwritten with no security groups from the
+		// desired resource.
+		sgIDs := make([]*string, len(ko.Status.VPCSecurityGroups))
+		for i, sg := range ko.Status.VPCSecurityGroups {
+			id := *sg.VPCSecurityGroupID
+			sgIDs[i] = &id
+		}
+		ko.Spec.VPCSecurityGroupIDs = sgIDs
+	}


### PR DESCRIPTION
Issue #, if available: aws-controllers-k8s/community/issues/1712

Description of changes:
Because the names of the security group fields returned by the API differ the `VPCSecurityGroupsIDs` is not read from the API response into the _latest_. Instead the values of the _desired_ is copied. This means that the controller determines that there is not need for an update. Instead by copying the the VPCSecurityGroups field from the status into the spec the controller can correctly determine that there is a difference between the latest and desired. This affects both type __DBCluster__ and __DBInstance__.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
