### PR TITLE
Fix db_proxy test assertion

### DIFF
--- a/test/e2e/tests/test_db_proxy.py
+++ b/test/e2e/tests/test_db_proxy.py
@@ -74,6 +74,7 @@ class TestDBProxy:
         cr = k8s.wait_resource_consumed_by_controller(ref)
 
         assert cr is not None
+        assert k8s.get_resource_exists(ref)
         assert 'status' in cr
         assert 'status' in cr['status']
         assert cr['status']['status'] in ['creating', 'available']
@@ -82,6 +83,14 @@ class TestDBProxy:
             db_proxy_id,
             db_proxy.status_matches('available'),
         )
+
+        assert k8s.wait_on_condition(
+            ref,
+            condition.CONDITION_TYPE_RESOURCE_SYNCED,
+            "True",
+            wait_periods=15,
+            period_length=20
+        ), "DB proxy not synced"
 
         time.sleep(CHECK_STATUS_WAIT_SECONDS)
 

--- a/test/e2e/tests/test_db_proxy.py
+++ b/test/e2e/tests/test_db_proxy.py
@@ -76,7 +76,7 @@ class TestDBProxy:
         assert cr is not None
         assert 'status' in cr
         assert 'status' in cr['status']
-        assert cr['status']['status'] == 'creating'
+        assert cr['status']['status'] in ['creating', 'available']
 
         db_proxy.wait_until(
             db_proxy_id,


### PR DESCRIPTION
Following `create_custom_resource`, assert that the status is either `creating` or `available`

Issue #, if available:

Description of changes:
While working on https://github.com/aws-controllers-k8s/rds-controller/pull/133 it became clear that an existing e2e test unrelated to that change was now [failing](https://prow.ack.aws.dev/view/s3/ack-prow-logs/pr-logs/pull/aws-controllers-k8s_rds-controller/133/rds-kind-e2e/1633544817986244608):

```
=================================== FAILURES ===================================
____________________ TestDBProxy.test_crud_postgresql_proxy ____________________
[gw2] linux -- Python 3.8.16 /usr/local/bin/python

self = <e2e.tests.test_db_proxy.TestDBProxy object at 0x7f64420527f0>

    def test_crud_postgresql_proxy(
            self,
    ):
        db_proxy_id = "my-test-proxy"
        db_proxy_engine_family = "POSTGRESQL"
        # The IAM role and secrect below has a complext dependency chain and we can hard code it for now
        # It needs create one rds instance -> create aws secret manager service's secret based on it -> create IAM role based on this secret
        # I don't have a better way to fit this dependency chain in current rds controller yet, hence hard code it for now
        secret_arn = "arn:aws:secretsmanager:us-west-2:274006911594:secret:prod/ack/persistent/secret-hGHdOK"
        description = "proxy created by ack"
    
        replacements = REPLACEMENT_VALUES.copy()
        replacements["DB_PROXY_NAME"] = db_proxy_id
        replacements["DB_PROXY_ENGINE_FAMILY"] = db_proxy_engine_family
        replacements["IAM_ROLE_ARN"] = get_bootstrap_resources().RDSProxyRole.arn
        replacements["SECRET_ARN"] = secret_arn
        replacements["DESCRIPTION"] = description
    
        resource_data = load_rds_resource(
            "db_proxy",
            additional_replacements=replacements,
        )
    
        ref = k8s.CustomResourceReference(
            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
            db_proxy_id, namespace="default",
        )
        # First try create db proxy
        k8s.create_custom_resource(ref, resource_data)
        cr = k8s.wait_resource_consumed_by_controller(ref)
    
        assert cr is not None
        assert 'status' in cr
        assert 'status' in cr['status']
>       assert cr['status']['status'] == 'creating'
E       AssertionError: assert 'available' == 'creating'
E         - creating
E         + available

tests/test_db_proxy.py:79: AssertionError
```

This change addresses this failure by relaxing the assertion on the status of the CR immediately following its creation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
