### PR TITLE
Add asynchronous status checks for `DBProxy`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-03-10T22:44:13Z"
+  build_date: "2023-03-13T17:16:37Z"
   build_hash: 338374e45678067e238b3991b8c15a4dd0b65c8e
-  go_version: go1.19.2
+  go_version: go1.19.1
   version: v0.24.3-2-g338374e
 api_directory_checksum: 17386cedbca91cf13d88bc733393624a51c214ae
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 0fb61f01b3715995f51dfc33124c45670c87a257
+  file_checksum: fff3f61faf773d9fc572f9ba2aabe69805b0f642
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -409,3 +409,14 @@ resources:
         ModifyDBProxy:
           input_fields:
             DBProxyName: Name
+    hooks:
+      sdk_create_post_set_output:
+        template_path: hooks/db_proxy/sdk_create_post_set_output.go.tpl
+      sdk_read_many_post_set_output:
+        template_path: hooks/db_proxy/sdk_read_many_post_set_output.go.tpl
+      sdk_update_pre_build_request:
+        template_path: hooks/db_proxy/sdk_update_pre_build_request.go.tpl
+      sdk_update_post_set_output:
+        template_path: hooks/db_proxy/sdk_update_post_set_output.go.tpl
+      sdk_delete_pre_build_request:
+        template_path: hooks/db_proxy/sdk_delete_pre_build_request.go.tpl

--- a/generator.yaml
+++ b/generator.yaml
@@ -409,3 +409,14 @@ resources:
         ModifyDBProxy:
           input_fields:
             DBProxyName: Name
+    hooks:
+      sdk_create_post_set_output:
+        template_path: hooks/db_proxy/sdk_create_post_set_output.go.tpl
+      sdk_read_many_post_set_output:
+        template_path: hooks/db_proxy/sdk_read_many_post_set_output.go.tpl
+      sdk_update_pre_build_request:
+        template_path: hooks/db_proxy/sdk_update_pre_build_request.go.tpl
+      sdk_update_post_set_output:
+        template_path: hooks/db_proxy/sdk_update_post_set_output.go.tpl
+      sdk_delete_pre_build_request:
+        template_path: hooks/db_proxy/sdk_delete_pre_build_request.go.tpl

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -145,10 +145,7 @@ spec:
                             blockOwnerDeletion:
                               description: If true, AND if the owner has the "foregroundDeletion"
                                 finalizer, then the owner cannot be deleted from the
-                                key-value store until this reference is removed. See
-                                https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
-                                for how the garbage collector interacts with this
-                                field and enforces the foreground deletion. Defaults
+                                key-value store until this reference is removed. Defaults
                                 to false. To set this field, a user needs "delete"
                                 permission of the owner, otherwise 422 (Unprocessable
                                 Entity) will be returned.

--- a/templates/hooks/db_proxy/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/db_proxy/sdk_create_post_set_output.go.tpl
@@ -1,0 +1,9 @@
+	// We expect the DB proxy to be in 'creating' status since we just
+	// issued the call to create it, but I suppose it doesn't hurt to check
+	// here.
+	if proxyCreating(&resource{ko}) {
+		// Setting resource synced condition to false will trigger a requeue of
+		// the resource. No need to return a requeue error here.
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
+		return &resource{ko}, nil
+	}

--- a/templates/hooks/db_proxy/sdk_delete_pre_build_request.go.tpl
+++ b/templates/hooks/db_proxy/sdk_delete_pre_build_request.go.tpl
@@ -1,0 +1,3 @@
+	if proxyDeleting(r) {
+		return r, requeueWaitWhileDeleting
+	}

--- a/templates/hooks/db_proxy/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/db_proxy/sdk_read_many_post_set_output.go.tpl
@@ -1,0 +1,5 @@
+	if !proxyAvailable(&resource{ko}) {
+		// Setting resource synced condition to false will trigger a requeue of
+		// the resource. No need to return a requeue error here.
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
+	}

--- a/templates/hooks/db_proxy/sdk_update_post_set_output.go.tpl
+++ b/templates/hooks/db_proxy/sdk_update_post_set_output.go.tpl
@@ -1,0 +1,8 @@
+    // When ModifyDBProxy API is successful, it asynchronously
+	// updates the DBProxyStatus. Requeue to find the current
+	// DBProxy status and set Synced condition accordingly
+	if err == nil {
+		// Setting resource synced condition to false will trigger a requeue of
+		// the resource. No need to return a requeue error here.
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
+	}

--- a/templates/hooks/db_proxy/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/db_proxy/sdk_update_pre_build_request.go.tpl
@@ -1,0 +1,21 @@
+	if proxyDeleting(latest) {
+		msg := "DB proxy is currently being deleted"
+		ackcondition.SetSynced(desired, corev1.ConditionFalse, &msg, nil)
+		return desired, requeueWaitWhileDeleting
+	}
+	if proxyCreating(latest) {
+		msg := "DB proxy is currently being created"
+		ackcondition.SetSynced(desired, corev1.ConditionFalse, &msg, nil)
+		return desired, requeueWaitUntilCanModify(latest)
+	}
+	if proxyHasTerminalStatus(latest) {
+		msg := "DB proxy is in '"+*latest.ko.Status.Status+"' status"
+		ackcondition.SetTerminal(desired, corev1.ConditionTrue, &msg, nil)
+		ackcondition.SetSynced(desired, corev1.ConditionTrue, nil, nil)
+		return desired, nil
+	}
+	if !proxyAvailable(latest) {
+		msg := "DB proxy cannot be modifed while in '" + *latest.ko.Status.Status + "' status"
+		ackcondition.SetSynced(desired, corev1.ConditionFalse, &msg, nil)
+		return desired, requeueWaitUntilCanModify(latest)
+	}

--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -1,3 +1,3 @@
 __pycache__/
 *.py[cod]
-**/bootstrap.yaml
+**/bootstrap.pkl

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -13,6 +13,7 @@
 
 import os
 import pytest
+import boto3
 
 from acktest import k8s
 
@@ -44,3 +45,15 @@ def pytest_collection_modifyitems(config, items):
 @pytest.fixture(scope='class')
 def k8s_client():
     return k8s._get_k8s_api_client()
+
+@pytest.fixture(scope='module')
+def rds_client():
+    return boto3.client('rds')
+
+@pytest.fixture(scope='module')
+def rds_resource():
+    return boto3.resource('rds') 
+
+@pytest.fixture(scope='module')
+def sts_client():
+    return boto3.client('sts')

--- a/test/e2e/tests/test_db_proxy.py
+++ b/test/e2e/tests/test_db_proxy.py
@@ -19,6 +19,7 @@ import time
 import pytest
 
 from acktest.k8s import resource as k8s
+from acktest.resources import random_suffix_name
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_rds_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
 from e2e import condition
@@ -37,46 +38,65 @@ CHECK_STATUS_WAIT_SECONDS = 60*4
 
 MODIFY_WAIT_AFTER_SECONDS = 20
 
+@pytest.fixture
+def postgres_proxy(sts_client):
+    db_proxy_id = random_suffix_name("my-test-proxy", 20)
+    db_proxy_engine_family = "POSTGRESQL"
+    # The IAM role and secrect below has a complext dependency chain and we can hard code it for now
+    # It needs create one rds instance -> create aws secret manager service's secret based on it -> create IAM role based on this secret
+    # I don't have a better way to fit this dependency chain in current rds controller yet, hence hard code it for now
+    account_id = sts_client.get_caller_identity().get("Account")
+    secret_arn = f"arn:aws:secretsmanager:us-west-2:{account_id}:secret:prod/ack/persistent/secret-hGHdOK"
+    description = "proxy created by ack"
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["DB_PROXY_NAME"] = db_proxy_id
+    replacements["DB_PROXY_ENGINE_FAMILY"] = db_proxy_engine_family
+    replacements["IAM_ROLE_ARN"] = get_bootstrap_resources().RDSProxyRole.arn
+    replacements["SECRET_ARN"] = secret_arn
+    replacements["DESCRIPTION"] = description
+
+    resource_data = load_rds_resource(
+        "db_proxy",
+        additional_replacements=replacements,
+    )
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+        db_proxy_id, namespace="default",
+    )
+
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    yield (ref, cr)
+
+    # Try to delete, if doesn't already exist
+    try:
+        _, deleted = k8s.delete_custom_resource(ref, 3, 10)
+        assert deleted
+        db_proxy.wait_until_deleted(db_proxy_id)
+    except:
+        pass
 
 @service_marker
 @pytest.mark.canary
 class TestDBProxy:
-
     def test_crud_postgresql_proxy(
-            self,
+        self,
+        postgres_proxy
     ):
-        db_proxy_id = "my-test-proxy"
-        db_proxy_engine_family = "POSTGRESQL"
-        # The IAM role and secrect below has a complext dependency chain and we can hard code it for now
-        # It needs create one rds instance -> create aws secret manager service's secret based on it -> create IAM role based on this secret
-        # I don't have a better way to fit this dependency chain in current rds controller yet, hence hard code it for now
-        secret_arn = "arn:aws:secretsmanager:us-west-2:274006911594:secret:prod/ack/persistent/secret-hGHdOK"
-        description = "proxy created by ack"
-
-        replacements = REPLACEMENT_VALUES.copy()
-        replacements["DB_PROXY_NAME"] = db_proxy_id
-        replacements["DB_PROXY_ENGINE_FAMILY"] = db_proxy_engine_family
-        replacements["IAM_ROLE_ARN"] = get_bootstrap_resources().RDSProxyRole.arn
-        replacements["SECRET_ARN"] = secret_arn
-        replacements["DESCRIPTION"] = description
-
-        resource_data = load_rds_resource(
-            "db_proxy",
-            additional_replacements=replacements,
-        )
-
-        ref = k8s.CustomResourceReference(
-            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
-            db_proxy_id, namespace="default",
-        )
-        # First try create db proxy 
-        k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
+        (ref, cr) = postgres_proxy
+        db_proxy_id = cr["spec"]["name"]
 
         assert cr is not None
+        assert k8s.get_resource_exists(ref)
         assert 'status' in cr
         assert 'status' in cr['status']
-        assert cr['status']['status'] == 'creating'
+        assert cr['status']['status'] in ['creating', 'available']
 
         db_proxy.wait_until(
             db_proxy_id,
@@ -85,12 +105,13 @@ class TestDBProxy:
 
         time.sleep(CHECK_STATUS_WAIT_SECONDS)
 
-        # assert db proxy is synced
-        cr = k8s.get_resource(ref)
-        assert cr is not None
-        assert 'status' in cr
-        assert 'status' in cr['status']
-        condition.assert_synced(ref)
+        assert k8s.wait_on_condition(
+            ref,
+            condition.CONDITION_TYPE_RESOURCE_SYNCED,
+            "True",
+            wait_periods=5,
+            period_length=3
+        ), "DB proxy not synced"
 
         # Start testing tag for proxy
         latest = db_proxy.get(db_proxy_id)


### PR DESCRIPTION
Description of changes:
The DBProxy APIs put the resource into `creating` state for ~10 minutes before becoming `available`, as well as `deleting` before it is gone. This PR copies the systems we use for `DBInstance`, which has the same properties, into custom hooks for `DBProxy`. It also updates the tests for `DBProxy` to use proper fixturing and to use a autogenerated resource name suffix (so tests don't collide).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
