### PR TITLE
ensure all resources sync for RDS

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,7 +1,7 @@
 ack_generate_info:
-  build_date: "2023-03-22T21:52:47Z"
+  build_date: "2023-03-24T19:44:43Z"
   build_hash: fa24753ea8b657d8815ae3eac7accd0958f5f9fb
-  go_version: go1.19
+  go_version: go1.19.4
   version: v0.25.0
 api_directory_checksum: 249bb23477dbb69a88064ea191a078f41f4966d0
 api_version: v1alpha1

--- a/pkg/resource/db_cluster_parameter_group/hooks.go
+++ b/pkg/resource/db_cluster_parameter_group/hooks.go
@@ -216,12 +216,18 @@ func (rm *resourceManager) syncParameters(
 	exit := rlog.Trace("rm.syncParameters")
 	defer func() { exit(err) }()
 
-	groupName := latest.ko.Spec.Name
-	family := latest.ko.Spec.Family
+	groupName := desired.ko.Spec.Name
+	family := desired.ko.Spec.Family
+
+	desiredOverrides := desired.ko.Spec.ParameterOverrides
+	latestOverrides := util.Parameters{}
+	// In the create code paths, we pass a nil latest...
+	if latest != nil {
+		latestOverrides = latest.ko.Spec.ParameterOverrides
+	}
 
 	toModify, _, toDelete := util.GetParametersDifference(
-		desired.ko.Spec.ParameterOverrides,
-		latest.ko.Spec.ParameterOverrides,
+		desiredOverrides, latestOverrides,
 	)
 
 	if len(toDelete) > 0 {

--- a/pkg/resource/db_cluster_parameter_group/sdk.go
+++ b/pkg/resource/db_cluster_parameter_group/sdk.go
@@ -215,10 +215,10 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
-	// We need to instantly requeue after a create operation, otherwise the controller
-	// will override the latest resource with the desired resource overrideParameters
-	// and cause the controller to not properly compare latest and desired resources.
-	return &resource{ko}, requeueWaitWhileCreating
+	if err = rm.syncParameters(ctx, desired, nil); err != nil {
+		return nil, err
+	}
+
 	return &resource{ko}, nil
 }
 

--- a/pkg/resource/db_parameter_group/hooks.go
+++ b/pkg/resource/db_parameter_group/hooks.go
@@ -215,12 +215,18 @@ func (rm *resourceManager) syncParameters(
 	exit := rlog.Trace("rm.syncParameters")
 	defer func() { exit(err) }()
 
-	groupName := latest.ko.Spec.Name
-	family := latest.ko.Spec.Family
+	groupName := desired.ko.Spec.Name
+	family := desired.ko.Spec.Family
+
+	desiredOverrides := desired.ko.Spec.ParameterOverrides
+	latestOverrides := util.Parameters{}
+	// In the create code paths, we pass a nil latest...
+	if latest != nil {
+		latestOverrides = latest.ko.Spec.ParameterOverrides
+	}
 
 	toModify, _, toDelete := util.GetParametersDifference(
-		desired.ko.Spec.ParameterOverrides,
-		latest.ko.Spec.ParameterOverrides,
+		desiredOverrides, latestOverrides,
 	)
 
 	// NOTE(jaypipes): ResetDBParameterGroup and ModifyDBParameterGroup only

--- a/pkg/resource/db_parameter_group/sdk.go
+++ b/pkg/resource/db_parameter_group/sdk.go
@@ -215,10 +215,10 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
-	// We need to instantly requeue after a create operation, otherwise the controller
-	// will override the latest resource with the desired resource overrideParameters
-	// and cause the controller to not properly compare latest and desired resources.
-	return &resource{ko}, requeueWaitWhileCreating
+	if err = rm.syncParameters(ctx, desired, nil); err != nil {
+		return nil, err
+	}
+
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/db_cluster_parameter_group/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/db_cluster_parameter_group/sdk_create_post_set_output.go.tpl
@@ -1,4 +1,3 @@
-    // We need to instantly requeue after a create operation, otherwise the controller
-    // will override the latest resource with the desired resource overrideParameters
-    // and cause the controller to not properly compare latest and desired resources.
-    return &resource{ko}, requeueWaitWhileCreating
+	if err = rm.syncParameters(ctx, desired, nil); err != nil {
+		return nil, err
+	}

--- a/templates/hooks/db_parameter_group/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/db_parameter_group/sdk_create_post_set_output.go.tpl
@@ -1,4 +1,3 @@
-    // We need to instantly requeue after a create operation, otherwise the controller
-    // will override the latest resource with the desired resource overrideParameters
-    // and cause the controller to not properly compare latest and desired resources.
-    return &resource{ko}, requeueWaitWhileCreating
+	if err = rm.syncParameters(ctx, desired, nil); err != nil {
+		return nil, err
+	}

--- a/test/e2e/db_cluster.py
+++ b/test/e2e/db_cluster.py
@@ -35,7 +35,8 @@ class StatusMatcher:
         self.match_on = status
 
     def __call__(self, record: dict) -> bool:
-        return 'Status' in record and record['Status'] == self.match_on
+        return (record is not None and 'Status' in record
+                and record['Status'] == self.match_on)
 
 
 def status_matches(status: str) -> ClusterMatchFunc:

--- a/test/e2e/db_instance.py
+++ b/test/e2e/db_instance.py
@@ -22,7 +22,7 @@ import pytest
 
 DEFAULT_WAIT_UNTIL_TIMEOUT_SECONDS = 60*30
 DEFAULT_WAIT_UNTIL_INTERVAL_SECONDS = 15
-DEFAULT_WAIT_UNTIL_DELETED_TIMEOUT_SECONDS = 60*10
+DEFAULT_WAIT_UNTIL_DELETED_TIMEOUT_SECONDS = 60*20
 DEFAULT_WAIT_UNTIL_DELETED_INTERVAL_SECONDS = 15
 
 InstanceMatchFunc = typing.NewType(
@@ -35,7 +35,7 @@ class StatusMatcher:
         self.match_on = status
 
     def __call__(self, record: dict) -> bool:
-        return ('DBInstanceStatus' in record
+        return (record is not None and 'DBInstanceStatus' in record
                 and record['DBInstanceStatus'] == self.match_on)
 
 

--- a/test/e2e/resources/db_cluster_parameter_group_aurora_postgresql14.yaml
+++ b/test/e2e/resources/db_cluster_parameter_group_aurora_postgresql14.yaml
@@ -1,0 +1,8 @@
+apiVersion: rds.services.k8s.aws/v1alpha1
+kind: DBClusterParameterGroup
+metadata:
+  name: $DB_CLUSTER_PARAMETER_GROUP_NAME
+spec:
+  name: $DB_CLUSTER_PARAMETER_GROUP_NAME
+  description: $DB_CLUSTER_PARAMETER_GROUP_DESC
+  family: aurora-postgresql14

--- a/test/e2e/resources/db_cluster_ref.yaml
+++ b/test/e2e/resources/db_cluster_ref.yaml
@@ -1,0 +1,19 @@
+apiVersion: rds.services.k8s.aws/v1alpha1
+kind: DBCluster
+metadata:
+  name: $DB_CLUSTER_ID
+spec:
+  copyTagsToSnapshot: false
+  dbClusterIdentifier: $DB_CLUSTER_ID
+  databaseName: $DB_NAME
+  dbClusterParameterGroupRef:
+    from:
+      name: $DB_CLUSTER_PARAMETER_GROUP_NAME
+  engine: aurora-postgresql
+  engineMode: provisioned
+  engineVersion: "14.6"
+  masterUsername: root
+  masterUserPassword:
+    namespace: $MASTER_USER_PASS_SECRET_NAMESPACE
+    name: $MASTER_USER_PASS_SECRET_NAME
+    key: $MASTER_USER_PASS_SECRET_KEY

--- a/test/e2e/resources/db_instance_ref.yaml
+++ b/test/e2e/resources/db_instance_ref.yaml
@@ -1,0 +1,14 @@
+apiVersion: rds.services.k8s.aws/v1alpha1
+kind: DBInstance
+metadata:
+  name: $DB_INSTANCE_ID
+spec:
+  # NOTE(jaypipes): This needs to be db.t3.medium to support Aurora PostgreSQL
+  # 14.6+. Smaller sizes will result in an InvalidParameterCombination.
+  dbInstanceClass: db.t3.medium
+  dbInstanceIdentifier: $DB_INSTANCE_ID
+  dbClusterIdentifier: $DB_CLUSTER_ID
+  dbParameterGroupRef:
+    from:
+      name: $DB_PARAMETER_GROUP_NAME
+  engine: aurora-postgresql

--- a/test/e2e/resources/db_parameter_group_aurora_postgresql14.yaml
+++ b/test/e2e/resources/db_parameter_group_aurora_postgresql14.yaml
@@ -1,0 +1,8 @@
+apiVersion: rds.services.k8s.aws/v1alpha1
+kind: DBParameterGroup
+metadata:
+  name: $DB_PARAMETER_GROUP_NAME
+spec:
+  name: $DB_PARAMETER_GROUP_NAME
+  description: $DB_PARAMETER_GROUP_DESC
+  family: aurora-postgresql14

--- a/test/e2e/tests/test_db_cluster_parameter_group.py
+++ b/test/e2e/tests/test_db_cluster_parameter_group.py
@@ -29,6 +29,7 @@ from e2e import condition
 
 RESOURCE_PLURAL = 'dbclusterparametergroups'
 
+CREATE_WAIT_AFTER_SECONDS = 10
 DELETE_WAIT_AFTER_SECONDS = 10
 # NOTE(jaypipes): According to the RDS API documentation, updating tags can
 # take several minutes before the new tag values are available due to caching.
@@ -58,6 +59,7 @@ def aurora_mysql57_cluster_param_group():
     )
     k8s.create_custom_resource(ref, resource_data)
     cr = k8s.wait_resource_consumed_by_controller(ref)
+    time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
     assert cr is not None
     assert k8s.get_resource_exists(ref)

--- a/test/e2e/tests/test_db_parameter_group.py
+++ b/test/e2e/tests/test_db_parameter_group.py
@@ -30,8 +30,10 @@ from e2e import tag
 RESOURCE_PLURAL = 'dbparametergroups'
 
 CREATE_WAIT_AFTER_SECONDS = 10
-MODIFY_WAIT_AFTER_SECONDS = 10
 DELETE_WAIT_AFTER_SECONDS = 10
+# NOTE(jaypipes): According to the RDS API documentation, updating tags can
+# take several minutes before the new tag values are available due to caching.
+MODIFY_WAIT_AFTER_SECONDS = 180
 
 RESOURCE_DESC_PG13 = "Parameters for PostgreSQL 13"
 
@@ -56,8 +58,8 @@ def pg13_param_group():
         resource_name, namespace="default",
     )
     k8s.create_custom_resource(ref, resource_data)
-    time.sleep(CREATE_WAIT_AFTER_SECONDS)
     cr = k8s.wait_resource_consumed_by_controller(ref)
+    time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
     assert cr is not None
     assert k8s.get_resource_exists(ref)

--- a/test/e2e/tests/test_references.py
+++ b/test/e2e/tests/test_references.py
@@ -1,0 +1,311 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Integration tests for resource references"""
+
+import logging
+import time
+
+import pytest
+
+from acktest.k8s import condition
+from acktest.k8s import resource as k8s
+from acktest.resources import random_suffix_name
+from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_rds_resource
+from e2e.replacement_values import REPLACEMENT_VALUES
+from e2e import db_cluster
+from e2e import db_cluster_parameter_group
+from e2e import db_instance
+from e2e import db_parameter_group
+from e2e.fixtures import k8s_secret
+
+# Little longer to delete the instance and cluster since it's referred-to from
+# the parameter group...
+DELETE_INSTANCE_TIMEOUT_SECONDS = 30
+DELETE_CLUSTER_TIMEOUT_SECONDS = 60
+DELETE_WAIT_AFTER_SECONDS = 10
+CREATE_WAIT_AFTER_SECONDS = 10
+CHECK_WAIT_AFTER_REF_RESOLVE_SECONDS = 30
+
+# MUP == Master user password...
+MUP_NS = "default"
+MUP_SEC_CLUSTER_NAME_PREFIX = "dbclustersecrets"
+MUP_SEC_INSTANCE_NAME_PREFIX = "dbinstancesecrets"
+MUP_SEC_KEY = "master_user_password"
+MUP_SEC_VAL = "secretpass123456"
+
+
+@pytest.fixture(scope="module")
+def db_cluster_name():
+    return random_suffix_name("ref-db-cluster", 24)
+
+
+@pytest.fixture(scope="module")
+def cpg_name():
+    return random_suffix_name("ref-clus-paramgrp", 24)
+
+
+@pytest.fixture(scope="module")
+def pg_name():
+    return random_suffix_name("ref-paramgrp", 24)
+
+
+@pytest.fixture
+def ref_db_param_group(pg_name):
+    resource_name = pg_name
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["DB_PARAMETER_GROUP_NAME"] = resource_name
+    replacements["DB_PARAMETER_GROUP_DESC"] = "Aurora PG 14 Params"
+
+    resource_data = load_rds_resource(
+        "db_parameter_group_aurora_postgresql14",
+        additional_replacements=replacements,
+    )
+    logging.debug(resource_data)
+
+    # Create the k8s resource
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, 'dbparametergroups',
+        resource_name, namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    time.sleep(CREATE_WAIT_AFTER_SECONDS)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    yield ref, cr, resource_name
+
+    # Try to delete, if doesn't already exist
+    try:
+        _, deleted = k8s.delete_custom_resource(ref, 3, 10)
+        assert deleted
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+    except:
+        pass
+
+    db_parameter_group.wait_until_deleted(resource_name)
+
+
+@pytest.fixture
+def ref_db_cluster_param_group(cpg_name):
+    resource_name = cpg_name
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["DB_CLUSTER_PARAMETER_GROUP_NAME"] = resource_name
+    replacements["DB_CLUSTER_PARAMETER_GROUP_DESC"] = "Aurora PG 14 Params"
+
+    resource_data = load_rds_resource(
+        "db_cluster_parameter_group_aurora_postgresql14",
+        additional_replacements=replacements,
+    )
+    logging.debug(resource_data)
+
+    # Create the k8s resource
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, 'dbclusterparametergroups',
+        resource_name, namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    yield ref, cr, resource_name
+
+    # Try to delete, if doesn't already exist
+    try:
+        _, deleted = k8s.delete_custom_resource(ref, 3, 10)
+        assert deleted
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+    except:
+        pass
+
+    db_cluster_parameter_group.wait_until_deleted(resource_name)
+
+
+@pytest.fixture(scope="module")
+def ref_db_cluster(k8s_secret, db_cluster_name, cpg_name):
+    db_name = "mydb"
+    secret = k8s_secret(
+        MUP_NS,
+        random_suffix_name(MUP_SEC_CLUSTER_NAME_PREFIX, 32),
+        MUP_SEC_KEY,
+        MUP_SEC_VAL,
+    )
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["DB_CLUSTER_ID"] = db_cluster_name
+    replacements["DB_NAME"] = db_name
+    replacements["MASTER_USER_PASS_SECRET_NAMESPACE"] = secret.ns
+    replacements["MASTER_USER_PASS_SECRET_NAME"] = secret.name
+    replacements["MASTER_USER_PASS_SECRET_KEY"] = secret.key
+    replacements["DB_CLUSTER_PARAMETER_GROUP_NAME"] = cpg_name
+
+    resource_data = load_rds_resource(
+        "db_cluster_ref",
+        additional_replacements=replacements,
+    )
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, 'dbclusters',
+        db_cluster_name, namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    # NOTE(jaypipes): We specifically do NOT wait for the DBInstance to exist
+    # in the RDS API here because we will create the referred-to
+    # DBClusterParameterGroup and wait for the reference to be resolved
+
+    yield (ref, cr, db_cluster_name)
+
+    if k8s.get_resource_exists(ref):
+        # If all goes properly, we should not hit this because the test cleans
+        # up the child resource before exiting...
+        _, deleted = k8s.delete_custom_resource(
+            ref,
+            period_length=DELETE_INSTANCE_TIMEOUT_SECONDS,
+        )
+        assert deleted
+
+        db_cluster.wait_until_deleted(db_cluster_name)
+
+
+@pytest.fixture
+def ref_db_instance(db_cluster_name, pg_name):
+    db_instance_id = random_suffix_name("ref-db-instance", 20)
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements['COPY_TAGS_TO_SNAPSHOT'] = "False"
+    replacements["DB_INSTANCE_ID"] = db_instance_id
+    replacements["DB_CLUSTER_ID"] = db_cluster_name
+    replacements["DB_PARAMETER_GROUP_NAME"] = pg_name
+
+    resource_data = load_rds_resource(
+        "db_instance_ref",
+        additional_replacements=replacements,
+    )
+
+    # Create the k8s resource
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, 'dbinstances',
+        db_instance_id, namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    # NOTE(jaypipes): We specifically do NOT wait for the DBInstance to exist
+    # in the RDS API here because we will create the referred-to
+    # DBParameterGroup and wait for the reference to be resolved
+
+    yield (ref, cr, db_instance_id)
+
+    if k8s.get_resource_exists(ref):
+        # If all goes properly, we should not hit this because the test cleans
+        # up the child resource before exiting...
+        _, deleted = k8s.delete_custom_resource(
+            ref,
+            period_length=DELETE_INSTANCE_TIMEOUT_SECONDS,
+        )
+        assert deleted
+
+        db_instance.wait_until_deleted(db_instance_id)
+
+
+@service_marker
+@pytest.mark.canary
+class TestReferences:
+    def test_references(
+            self,
+            ref_db_cluster,
+            ref_db_instance,
+            ref_db_param_group,
+            ref_db_cluster_param_group,
+    ):
+        # create the resources in order that initially the reference resolution
+        # fails and then when the referenced resource gets created, then all
+        # resolutions eventually pass and resources get synced.
+        db_cluster_ref, db_cluster_cr, db_cluster_id = ref_db_cluster
+
+        time.sleep(1)
+
+        # The DB Cluster above refers to this Cluster Parameter Group by
+        # reference/name
+        db_cluster_pg_ref, db_cluster_pg_cr, db_cluster_pg_name = ref_db_cluster_param_group
+
+        time.sleep(CHECK_WAIT_AFTER_REF_RESOLVE_SECONDS)
+
+        db_cluster.wait_until(
+            db_cluster_id,
+            db_cluster.status_matches("available"),
+        )
+
+        time.sleep(60)
+
+        condition.assert_synced(db_cluster_pg_ref)
+        condition.assert_synced(db_cluster_ref)
+
+        # Instance refers to parameter group by reference and DB cluster by
+        # ID...
+        db_instance_ref, db_instance_cr, db_instance_id = ref_db_instance
+
+        # We expect the DB Instance to fail to resolve references because the
+        # DB Parameter Group it refers to does not yet exist. Let's create it
+        # now.
+        db_pg_ref, db_pg_cr, db_pg_name = ref_db_param_group
+
+        time.sleep(CHECK_WAIT_AFTER_REF_RESOLVE_SECONDS)
+
+        db_instance.wait_until(
+            db_instance_id,
+            db_instance.status_matches("available"),
+        )
+
+        time.sleep(60)
+
+        condition.assert_synced(db_pg_ref)
+        condition.assert_synced(db_instance_ref)
+
+        # NOTE(jaypipes): We need to manually delete the DB Instance first
+        # because pytest fixtures will try to clean up the DB Parameter Group
+        # fixture *first* (because it was initialized after DB Instance) but if
+        # we try to delete the DB Parameter Group before the DB Instance, the
+        # cascading delete protection of resource references will mean the DB
+        # Parameter Group won't be deleted.
+        _, deleted = k8s.delete_custom_resource(
+            db_instance_ref,
+            period_length=DELETE_INSTANCE_TIMEOUT_SECONDS,
+        )
+        assert deleted
+
+        # Wait a bit before trying to delete the cluster since the instance is
+        # part of the cluster and sometimes the delete cluster complains if
+        # it's too soon after deleting the last DB instance in it.
+        time.sleep(60)
+
+        db_instance.wait_until_deleted(db_instance_id)
+
+        # Same for the DB cluster because it refers to the DB cluster
+        # parameter group...
+        _, deleted = k8s.delete_custom_resource(
+            db_cluster_ref,
+            period_length=DELETE_CLUSTER_TIMEOUT_SECONDS,
+        )
+        assert deleted
+
+        db_cluster.wait_until_deleted(db_cluster_id)


### PR DESCRIPTION
This patch fixes both the DB Parameter Group and the DB Cluster Parameter Group resources failure to properly get to ACK.ResourceSynced=True quickly and reliably. I removed the manual requeueWhileCreating condition for both Param Group and Cluster Param Group resources, replacing that sdk_create_post_set_output hook with a call to `syncParameters`, supplying a `nil` `latest` parameter. This allowed the parameter overrides to be immediately set after the parameter group was created.

Added a lengthy e2e test for RDS resource references based on the YAML definitions present in the related issue
(aws-controllers-k8s/community#1727) with a DBCluster resource that references a DB Cluster Parameter Group, a DBInstance resource that references a DB Parameter Group (by AWSResourceReference) and the DB Cluster (by DBClusterIdentifier).

Fixes Issue aws-controllers-k8s/community#1727

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
