### PR TITLE
Add reference for MasterUserSecretKMSKeyID

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-03-30T14:52:36Z"
+  build_date: "2023-03-30T18:50:28Z"
   build_hash: fa24753ea8b657d8815ae3eac7accd0958f5f9fb
   go_version: go1.19.4
   version: v0.25.0
-api_directory_checksum: c260842c2919b6d1d7ddc4b1dc40cacea82dc551
+api_directory_checksum: 54ea7e387b74b590907eb5136a9a802b0e97a738
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.232
 generator_config_info:
-  file_checksum: c3a80c129c39b07e24dd80a830d5254626362121
+  file_checksum: 1c65701c9ae781dcda0fb8c04fed4de60e25a9ef
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/db_cluster.go
+++ b/apis/v1alpha1/db_cluster.go
@@ -422,7 +422,8 @@ type DBClusterSpec struct {
 	// Services Region.
 	//
 	// Valid for: Aurora DB clusters and Multi-AZ DB clusters
-	MasterUserSecretKMSKeyID *string `json:"masterUserSecretKMSKeyID,omitempty"`
+	MasterUserSecretKMSKeyID  *string                                  `json:"masterUserSecretKMSKeyID,omitempty"`
+	MasterUserSecretKMSKeyRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"masterUserSecretKMSKeyRef,omitempty"`
 	// The name of the master user for the DB cluster.
 	//
 	// Constraints:

--- a/apis/v1alpha1/db_instance.go
+++ b/apis/v1alpha1/db_instance.go
@@ -705,7 +705,8 @@ type DBInstanceSpec struct {
 	// There is a default KMS key for your Amazon Web Services account. Your Amazon
 	// Web Services account has a different default KMS key for each Amazon Web
 	// Services Region.
-	MasterUserSecretKMSKeyID *string `json:"masterUserSecretKMSKeyID,omitempty"`
+	MasterUserSecretKMSKeyID  *string                                  `json:"masterUserSecretKMSKeyID,omitempty"`
+	MasterUserSecretKMSKeyRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"masterUserSecretKMSKeyRef,omitempty"`
 	// The name for the master user.
 	//
 	// # Amazon Aurora

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -114,6 +114,11 @@ resources:
           resource: Key
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
+      MasterUserSecretKmsKeyId:
+        references:
+          resource: Key
+          service_name: kms
+          path: Status.ACKResourceMetadata.ARN
       DBClusterParameterGroupName:
         references:
           resource: DBClusterParameterGroup
@@ -237,6 +242,11 @@ resources:
       MasterUserPassword:
         is_secret: true
       KmsKeyId:
+        references:
+          resource: Key
+          service_name: kms
+          path: Status.ACKResourceMetadata.ARN
+      MasterUserSecretKmsKeyId:
         references:
           resource: Key
           service_name: kms

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1233,6 +1233,11 @@ func (in *DBClusterSpec) DeepCopyInto(out *DBClusterSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.MasterUserSecretKMSKeyRef != nil {
+		in, out := &in.MasterUserSecretKMSKeyRef, &out.MasterUserSecretKMSKeyRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.MasterUsername != nil {
 		in, out := &in.MasterUsername, &out.MasterUsername
 		*out = new(string)
@@ -2657,6 +2662,11 @@ func (in *DBInstanceSpec) DeepCopyInto(out *DBInstanceSpec) {
 		in, out := &in.MasterUserSecretKMSKeyID, &out.MasterUserSecretKMSKeyID
 		*out = new(string)
 		**out = **in
+	}
+	if in.MasterUserSecretKMSKeyRef != nil {
+		in, out := &in.MasterUserSecretKMSKeyRef, &out.MasterUserSecretKMSKeyRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.MasterUsername != nil {
 		in, out := &in.MasterUsername, &out.MasterUsername

--- a/config/crd/bases/rds.services.k8s.aws_dbclusters.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbclusters.yaml
@@ -391,6 +391,19 @@ spec:
                   account has a different default KMS key for each Amazon Web Services
                   Region. \n Valid for: Aurora DB clusters and Multi-AZ DB clusters"
                 type: string
+              masterUserSecretKMSKeyRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               masterUsername:
                 description: "The name of the master user for the DB cluster. \n Constraints:
                   \n * Must be 1 to 16 letters or numbers. \n * First character must

--- a/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
@@ -500,6 +500,19 @@ spec:
                   account has a different default KMS key for each Amazon Web Services
                   Region."
                 type: string
+              masterUserSecretKMSKeyRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               masterUsername:
                 description: "The name for the master user. \n Amazon Aurora \n Not
                   applicable. The name for the master user is managed by the DB cluster.

--- a/generator.yaml
+++ b/generator.yaml
@@ -114,6 +114,11 @@ resources:
           resource: Key
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
+      MasterUserSecretKmsKeyId:
+        references:
+          resource: Key
+          service_name: kms
+          path: Status.ACKResourceMetadata.ARN
       DBClusterParameterGroupName:
         references:
           resource: DBClusterParameterGroup
@@ -237,6 +242,11 @@ resources:
       MasterUserPassword:
         is_secret: true
       KmsKeyId:
+        references:
+          resource: Key
+          service_name: kms
+          path: Status.ACKResourceMetadata.ARN
+      MasterUserSecretKmsKeyId:
         references:
           resource: Key
           service_name: kms

--- a/helm/crds/rds.services.k8s.aws_dbclusters.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbclusters.yaml
@@ -391,6 +391,19 @@ spec:
                   account has a different default KMS key for each Amazon Web Services
                   Region. \n Valid for: Aurora DB clusters and Multi-AZ DB clusters"
                 type: string
+              masterUserSecretKMSKeyRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               masterUsername:
                 description: "The name of the master user for the DB cluster. \n Constraints:
                   \n - Must be 1 to 16 letters or numbers. \n - First character must

--- a/helm/crds/rds.services.k8s.aws_dbinstances.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbinstances.yaml
@@ -502,6 +502,19 @@ spec:
                   account has a different default KMS key for each Amazon Web Services
                   Region."
                 type: string
+              masterUserSecretKMSKeyRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               masterUsername:
                 description: "The name for the master user. \n # Amazon Aurora \n
                   Not applicable. The name for the master user is managed by the DB

--- a/pkg/resource/db_cluster/delta.go
+++ b/pkg/resource/db_cluster/delta.go
@@ -262,6 +262,9 @@ func newResourceDelta(
 			delta.Add("Spec.MasterUserSecretKMSKeyID", a.ko.Spec.MasterUserSecretKMSKeyID, b.ko.Spec.MasterUserSecretKMSKeyID)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.MasterUserSecretKMSKeyRef, b.ko.Spec.MasterUserSecretKMSKeyRef) {
+		delta.Add("Spec.MasterUserSecretKMSKeyRef", a.ko.Spec.MasterUserSecretKMSKeyRef, b.ko.Spec.MasterUserSecretKMSKeyRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.MasterUsername, b.ko.Spec.MasterUsername) {
 		delta.Add("Spec.MasterUsername", a.ko.Spec.MasterUsername, b.ko.Spec.MasterUsername)
 	} else if a.ko.Spec.MasterUsername != nil && b.ko.Spec.MasterUsername != nil {

--- a/pkg/resource/db_cluster/references.go
+++ b/pkg/resource/db_cluster/references.go
@@ -36,6 +36,9 @@ import (
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
 
+// +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
+// +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
+
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups,verbs=get;list
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups/status,verbs=get;list
 
@@ -64,6 +67,9 @@ func (rm *resourceManager) ResolveReferences(
 		err = resolveReferenceForKMSKeyID(ctx, apiReader, namespace, ko)
 	}
 	if err == nil {
+		err = resolveReferenceForMasterUserSecretKMSKeyID(ctx, apiReader, namespace, ko)
+	}
+	if err == nil {
 		err = resolveReferenceForVPCSecurityGroupIDs(ctx, apiReader, namespace, ko)
 	}
 
@@ -90,6 +96,9 @@ func validateReferenceFields(ko *svcapitypes.DBCluster) error {
 	if ko.Spec.KMSKeyRef != nil && ko.Spec.KMSKeyID != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("KMSKeyID", "KMSKeyRef")
 	}
+	if ko.Spec.MasterUserSecretKMSKeyRef != nil && ko.Spec.MasterUserSecretKMSKeyID != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("MasterUserSecretKMSKeyID", "MasterUserSecretKMSKeyRef")
+	}
 	if ko.Spec.VPCSecurityGroupRefs != nil && ko.Spec.VPCSecurityGroupIDs != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("VPCSecurityGroupIDs", "VPCSecurityGroupRefs")
 	}
@@ -99,7 +108,7 @@ func validateReferenceFields(ko *svcapitypes.DBCluster) error {
 // hasNonNilReferences returns true if resource contains a reference to another
 // resource
 func hasNonNilReferences(ko *svcapitypes.DBCluster) bool {
-	return false || (ko.Spec.DBClusterParameterGroupRef != nil) || (ko.Spec.DBSubnetGroupRef != nil) || (ko.Spec.KMSKeyRef != nil) || (ko.Spec.VPCSecurityGroupRefs != nil)
+	return false || (ko.Spec.DBClusterParameterGroupRef != nil) || (ko.Spec.DBSubnetGroupRef != nil) || (ko.Spec.KMSKeyRef != nil) || (ko.Spec.MasterUserSecretKMSKeyRef != nil) || (ko.Spec.VPCSecurityGroupRefs != nil)
 }
 
 // resolveReferenceForDBClusterParameterGroupName reads the resource referenced
@@ -324,6 +333,30 @@ func getReferencedResourceState_Key(
 			namespace, name,
 			"Status.ACKResourceMetadata.ARN")
 	}
+	return nil
+}
+
+// resolveReferenceForMasterUserSecretKMSKeyID reads the resource referenced
+// from MasterUserSecretKMSKeyRef field and sets the MasterUserSecretKMSKeyID
+// from referenced resource
+func resolveReferenceForMasterUserSecretKMSKeyID(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.DBCluster,
+) error {
+	if ko.Spec.MasterUserSecretKMSKeyRef != nil && ko.Spec.MasterUserSecretKMSKeyRef.From != nil {
+		arr := ko.Spec.MasterUserSecretKMSKeyRef.From
+		if arr == nil || arr.Name == nil || *arr.Name == "" {
+			return fmt.Errorf("provided resource reference is nil or empty: MasterUserSecretKMSKeyRef")
+		}
+		obj := &kmsapitypes.Key{}
+		if err := getReferencedResourceState_Key(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return err
+		}
+		ko.Spec.MasterUserSecretKMSKeyID = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
 	return nil
 }
 

--- a/pkg/resource/db_instance/delta.go
+++ b/pkg/resource/db_instance/delta.go
@@ -309,6 +309,9 @@ func newResourceDelta(
 			delta.Add("Spec.MasterUserSecretKMSKeyID", a.ko.Spec.MasterUserSecretKMSKeyID, b.ko.Spec.MasterUserSecretKMSKeyID)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.MasterUserSecretKMSKeyRef, b.ko.Spec.MasterUserSecretKMSKeyRef) {
+		delta.Add("Spec.MasterUserSecretKMSKeyRef", a.ko.Spec.MasterUserSecretKMSKeyRef, b.ko.Spec.MasterUserSecretKMSKeyRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.MasterUsername, b.ko.Spec.MasterUsername) {
 		delta.Add("Spec.MasterUsername", a.ko.Spec.MasterUsername, b.ko.Spec.MasterUsername)
 	} else if a.ko.Spec.MasterUsername != nil && b.ko.Spec.MasterUsername != nil {


### PR DESCRIPTION
For DBCluster and DBInstance resources, the MasterUserSecretKMSKeyID field can refer to a KMS Key resource.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
