### PR TITLE
fix: remove DBClusterQuotaExceededFault from list of terminal codes for DBCluster

### DIFF
--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -96,7 +96,6 @@ resources:
         template_path: hooks/db_cluster/sdk_file_end.go.tpl
     exceptions:
       terminal_codes:
-        - DBClusterQuotaExceededFault
         - DBSubnetGroupDoesNotCoverEnoughAZs
         - InsufficientStorageClusterCapacity
         - InvalidParameter


### PR DESCRIPTION
According to [docs](https://github.com/aws-controllers-k8s/community/blob/2f5db7826bd2bba3fc221191135cdf7bd3b5ce7f/docs/content/docs/contributor-docs/code-generator-config.md#terminal_codes-specifying-terminal-codes-to-indicate-terminal-state):
> An `ACK.Terminal` `Condition` is placed on a custom resource (inside of its `Status`) when the controller realizes that, without the user changing the resource's `Spec`, the resource will not be able to be reconciled (i.e., the desired state will never match the actual state).

ISTM that quotas being exceeded do not meet this standard. If another resource is deleted, freeing up some of the quota, then the resource can be reconciled with no change to the resource's `Spec`.

Hopefully I'm not taking this out of context, but I believe I've found somewhere else where @jaypipes has agreed with this logic: https://github.com/aws-controllers-k8s/rds-controller/pull/105#discussion_r935747748

This PR removes a single quota fault from a single kind. If the community agrees, then perhaps the same should be done with other quota faults.


Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
