### PR TITLE
prevent DB Instance desired field state flapping

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2023-05-01T22:38:52Z"
-  build_hash: 6657565bb742e5cd4cd340d01d5e4786b5fbabc0
-  go_version: go1.19
-  version: v0.26.0
+  build_date: "2023-05-11T22:58:32Z"
+  build_hash: 9e2542cf2c0f92c014524c269474055cca758d70
+  go_version: go1.19.4
+  version: v0.26.0-3-g9e2542c
 api_directory_checksum: b3f33aebf366349bde7945f7b627ae788a18c0d5
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.232

--- a/config/controller/deployment.yaml
+++ b/config/controller/deployment.yaml
@@ -73,6 +73,9 @@ spec:
           capabilities:
             drop:
               - ALL
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 10
       serviceAccountName: ack-rds-controller
       hostIPC: false

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -145,10 +145,7 @@ spec:
                             blockOwnerDeletion:
                               description: If true, AND if the owner has the "foregroundDeletion"
                                 finalizer, then the owner cannot be deleted from the
-                                key-value store until this reference is removed. See
-                                https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
-                                for how the garbage collector interacts with this
-                                field and enforces the foreground deletion. Defaults
+                                key-value store until this reference is removed. Defaults
                                 to false. To set this field, a user needs "delete"
                                 permission of the owner, otherwise 422 (Unprocessable
                                 Entity) will be returned.

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -33,7 +33,7 @@ If release name contains chart name it will be used as a full name.
 
 {{- define "watch-namespace" -}}
 {{- if eq .Values.installScope "namespace" -}}
-{{- .Release.Namespace -}}
+{{ .Values.watchNamespace | default .Release.Namespace }}
 {{- end -}}
 {{- end -}}
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -116,6 +116,9 @@ spec:
           capabilities:
             drop:
               - ALL
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 10
       nodeSelector: {{ toYaml .Values.deployment.nodeSelector | nindent 8 }}
       {{ if .Values.deployment.tolerations -}}

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -196,6 +196,9 @@
       "type": "string",
       "enum": ["cluster", "namespace"]
     },
+    "watchNamespace": {
+      "type": "string"
+    },    
     "resourceTags": {
       "type": "array",
       "items": {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -31,7 +31,7 @@ deployment:
 
 # If "installScope: cluster" then these labels will be applied to ClusterRole
 role:
- labels: {}
+  labels: {}
   
 metrics:
   service:
@@ -71,6 +71,10 @@ log:
 # watch for object creation in the namespace. By default installScope is
 # cluster wide.
 installScope: cluster
+
+# Set the value of the "namespace" to be watched by the controller
+# This value is only used when the `installScope` is set to "namespace". If left empty, the default value is the release namespace for the chart.
+watchNamespace: ""
 
 resourceTags:
   # Configures the ACK service controller to always set key/value pairs tags on

--- a/pkg/resource/db_cluster/resource.go
+++ b/pkg/resource/db_cluster/resource.go
@@ -45,7 +45,7 @@ func (r *resource) Identifiers() acktypes.AWSResourceIdentifiers {
 }
 
 // IsBeingDeleted returns true if the Kubernetes resource has a non-zero
-// deletion timestemp
+// deletion timestamp
 func (r *resource) IsBeingDeleted() bool {
 	return !r.ko.DeletionTimestamp.IsZero()
 }

--- a/pkg/resource/db_cluster_parameter_group/resource.go
+++ b/pkg/resource/db_cluster_parameter_group/resource.go
@@ -45,7 +45,7 @@ func (r *resource) Identifiers() acktypes.AWSResourceIdentifiers {
 }
 
 // IsBeingDeleted returns true if the Kubernetes resource has a non-zero
-// deletion timestemp
+// deletion timestamp
 func (r *resource) IsBeingDeleted() bool {
 	return !r.ko.DeletionTimestamp.IsZero()
 }

--- a/pkg/resource/db_instance/resource.go
+++ b/pkg/resource/db_instance/resource.go
@@ -45,7 +45,7 @@ func (r *resource) Identifiers() acktypes.AWSResourceIdentifiers {
 }
 
 // IsBeingDeleted returns true if the Kubernetes resource has a non-zero
-// deletion timestemp
+// deletion timestamp
 func (r *resource) IsBeingDeleted() bool {
 	return !r.ko.DeletionTimestamp.IsZero()
 }

--- a/pkg/resource/db_instance/sdk.go
+++ b/pkg/resource/db_instance/sdk.go
@@ -789,6 +789,90 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	// DescribeDBInstances returns an array of DBInstance structs that contains
+	// the *previously set* values for various mutable fields. This is
+	// problematic because it causes a "flopping" behaviour when the user has
+	// modified a Spec field from value A to value B but the output shape from
+	// ModifyDBInstance for that field contains value A, the standard SetOutput
+	// Go code generated above will set the Spec field to the *old* value
+	// again. The next time the reconciler runs, it will read the latest
+	// observed resource, see a difference between the desired and the latest
+	// state (that actually does not exist because the difference is comparing
+	// the value of the fields before they were changed) and attempt to modify
+	// the field from value B to value A again, causing a flop loop.
+	//
+	// Luckily, the Output shape's DBInstance struct contains a
+	// `PendingModifiedValues` struct which contains those field values that
+	// the user specified. So, we can use these to "reset" the Spec back to the
+	// appropriate user-specified values.
+	pmv := ko.Status.PendingModifiedValues
+	if pmv != nil {
+		if pmv.AllocatedStorage != nil {
+			ko.Spec.AllocatedStorage = pmv.AllocatedStorage
+		}
+		// NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.AutomationMode != nil {
+		//	ko.Spec.AutomationMode = pmv.AutomationMode
+		//}
+		if pmv.BackupRetentionPeriod != nil {
+			ko.Spec.BackupRetentionPeriod = pmv.BackupRetentionPeriod
+		}
+		if pmv.CACertificateIdentifier != nil {
+			ko.Spec.CACertificateIdentifier = pmv.CACertificateIdentifier
+		}
+		if pmv.DBInstanceClass != nil {
+			ko.Spec.DBInstanceClass = pmv.DBInstanceClass
+		}
+		if pmv.DBInstanceIdentifier != nil {
+			ko.Spec.DBInstanceIdentifier = pmv.DBInstanceIdentifier
+		}
+		if pmv.DBSubnetGroupName != nil {
+			ko.Spec.DBSubnetGroupName = pmv.DBSubnetGroupName
+		}
+		if pmv.EngineVersion != nil {
+			ko.Spec.EngineVersion = pmv.EngineVersion
+		}
+		// NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.IAMDatabaseAuthenticationEnabled != nil {
+		//	ko.Spec.IAMDatabaseAuthenticationEnabled = pmv.IAMDatabaseAuthenticationEnabled
+		//}
+		// NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.Iops != nil {
+		//	ko.Spec.IOPS = pmv.Iops
+		//}
+		if pmv.LicenseModel != nil {
+			ko.Spec.LicenseModel = pmv.LicenseModel
+		}
+		if pmv.MasterUserPassword != nil {
+			// NOTE(jaypipes): Type mismatch with Spec and
+			// PendingModifiedValues, so just reset to the original...
+			ko.Spec.MasterUserPassword = r.ko.Spec.MasterUserPassword
+		}
+		if pmv.MultiAZ != nil {
+			ko.Spec.MultiAZ = pmv.MultiAZ
+		}
+		// NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.PendingCloudwatchLogsExports != nil {
+		//	ko.Spec.PendingCloudwatchLogsExports = pmv.PendingCloudwatchLogsExports
+		//}
+		if pmv.Port != nil {
+			ko.Spec.Port = pmv.Port
+		}
+		// NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.ProcessorFeatures != nil {
+		//	ko.Spec.ProcessorFeatures = pmv.ProcessorFeatures
+		//}
+		// NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.ResumeFullAutomationModeTime != nil {
+		//	ko.Spec.ResumeFullAutomationModeTime = pmv.ResumeFullAutomationModeTime
+		//}
+		if pmv.StorageThroughput != nil {
+			ko.Spec.StorageThroughput = pmv.StorageThroughput
+		}
+		if pmv.StorageType != nil {
+			ko.Spec.StorageType = pmv.StorageType
+		}
+	}
 	if ko.Status.ACKResourceMetadata != nil && ko.Status.ACKResourceMetadata.ARN != nil {
 		resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
 		tags, err := rm.getTags(ctx, *resourceARN)
@@ -2602,6 +2686,86 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	rm.setStatusDefaults(ko)
+	// ModifyDBInstance returns a DBInstance struct that contains the
+	// *previously set* values for various mutable fields. This is problematic
+	// because it causes a "flopping" behaviour when the user has modified a
+	// Spec field from value A to value B but the output shape from
+	// ModifyDBInstance for that field contains value A, the standard SetOutput
+	// Go code generated above will set the Spec field to the *old* value
+	// again. The next time the reconciler runs, it will attempt to modify the
+	// field from value B to value A again, causing a flop loop.
+	//
+	// Luckily, the Output shape's DBInstance struct contains a
+	// `PendingModifiedValues` struct which contains those field values that
+	// the user specified. So, we can use these to "reset" the Spec back to the
+	// appropriate user-specific values.
+	pmv := resp.DBInstance.PendingModifiedValues
+	if pmv != nil {
+		if pmv.AllocatedStorage != nil {
+			ko.Spec.AllocatedStorage = pmv.AllocatedStorage
+		}
+		// NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.AutomationMode != nil {
+		//	ko.Spec.AutomationMode = pmv.AutomationMode
+		//}
+		if pmv.BackupRetentionPeriod != nil {
+			ko.Spec.BackupRetentionPeriod = pmv.BackupRetentionPeriod
+		}
+		if pmv.CACertificateIdentifier != nil {
+			ko.Spec.CACertificateIdentifier = pmv.CACertificateIdentifier
+		}
+		if pmv.DBInstanceClass != nil {
+			ko.Spec.DBInstanceClass = pmv.DBInstanceClass
+		}
+		if pmv.DBInstanceIdentifier != nil {
+			ko.Spec.DBInstanceIdentifier = pmv.DBInstanceIdentifier
+		}
+		if pmv.DBSubnetGroupName != nil {
+			ko.Spec.DBSubnetGroupName = pmv.DBSubnetGroupName
+		}
+		if pmv.EngineVersion != nil {
+			ko.Spec.EngineVersion = pmv.EngineVersion
+		}
+		// NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.IAMDatabaseAuthenticationEnabled != nil {
+		//	ko.Spec.IAMDatabaseAuthenticationEnabled = pmv.IAMDatabaseAuthenticationEnabled
+		//}
+		if pmv.Iops != nil {
+			ko.Spec.IOPS = pmv.Iops
+		}
+		if pmv.LicenseModel != nil {
+			ko.Spec.LicenseModel = pmv.LicenseModel
+		}
+		if pmv.MasterUserPassword != nil {
+			// NOTE(jaypipes): Type mismatch with Spec and
+			// PendingModifiedValues, so just reset to the desired...
+			ko.Spec.MasterUserPassword = desired.ko.Spec.MasterUserPassword
+		}
+		if pmv.MultiAZ != nil {
+			ko.Spec.MultiAZ = pmv.MultiAZ
+		}
+		// NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.PendingCloudwatchLogsExports != nil {
+		//	ko.Spec.PendingCloudwatchLogsExports = pmv.PendingCloudwatchLogsExports
+		//}
+		if pmv.Port != nil {
+			ko.Spec.Port = pmv.Port
+		}
+		// NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.ProcessorFeatures != nil {
+		//	ko.Spec.ProcessorFeatures = pmv.ProcessorFeatures
+		//}
+		// NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.ResumeFullAutomationModeTime != nil {
+		//	ko.Spec.ResumeFullAutomationModeTime = pmv.ResumeFullAutomationModeTime
+		//}
+		if pmv.StorageThroughput != nil {
+			ko.Spec.StorageThroughput = pmv.StorageThroughput
+		}
+		if pmv.StorageType != nil {
+			ko.Spec.StorageType = pmv.StorageType
+		}
+	}
 	// When ModifyDBInstance API is successful, it asynchronously
 	// updates the DBInstanceStatus. Requeue to find the current
 	// DBInstance status and set Synced condition accordingly
@@ -2610,6 +2774,7 @@ func (rm *resourceManager) sdkUpdate(
 		// the resource. No need to return a requeue error here.
 		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
 	}
+
 	return &resource{ko}, nil
 }
 

--- a/pkg/resource/db_parameter_group/resource.go
+++ b/pkg/resource/db_parameter_group/resource.go
@@ -45,7 +45,7 @@ func (r *resource) Identifiers() acktypes.AWSResourceIdentifiers {
 }
 
 // IsBeingDeleted returns true if the Kubernetes resource has a non-zero
-// deletion timestemp
+// deletion timestamp
 func (r *resource) IsBeingDeleted() bool {
 	return !r.ko.DeletionTimestamp.IsZero()
 }

--- a/pkg/resource/db_proxy/resource.go
+++ b/pkg/resource/db_proxy/resource.go
@@ -45,7 +45,7 @@ func (r *resource) Identifiers() acktypes.AWSResourceIdentifiers {
 }
 
 // IsBeingDeleted returns true if the Kubernetes resource has a non-zero
-// deletion timestemp
+// deletion timestamp
 func (r *resource) IsBeingDeleted() bool {
 	return !r.ko.DeletionTimestamp.IsZero()
 }

--- a/pkg/resource/db_subnet_group/resource.go
+++ b/pkg/resource/db_subnet_group/resource.go
@@ -45,7 +45,7 @@ func (r *resource) Identifiers() acktypes.AWSResourceIdentifiers {
 }
 
 // IsBeingDeleted returns true if the Kubernetes resource has a non-zero
-// deletion timestemp
+// deletion timestamp
 func (r *resource) IsBeingDeleted() bool {
 	return !r.ko.DeletionTimestamp.IsZero()
 }

--- a/pkg/resource/global_cluster/resource.go
+++ b/pkg/resource/global_cluster/resource.go
@@ -45,7 +45,7 @@ func (r *resource) Identifiers() acktypes.AWSResourceIdentifiers {
 }
 
 // IsBeingDeleted returns true if the Kubernetes resource has a non-zero
-// deletion timestemp
+// deletion timestamp
 func (r *resource) IsBeingDeleted() bool {
 	return !r.ko.DeletionTimestamp.IsZero()
 }

--- a/templates/hooks/db_instance/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/db_instance/sdk_read_many_post_set_output.go.tpl
@@ -1,10 +1,94 @@
+	// DescribeDBInstances returns an array of DBInstance structs that contains
+	// the *previously set* values for various mutable fields. This is
+	// problematic because it causes a "flopping" behaviour when the user has
+	// modified a Spec field from value A to value B but the output shape from
+	// ModifyDBInstance for that field contains value A, the standard SetOutput
+	// Go code generated above will set the Spec field to the *old* value
+	// again. The next time the reconciler runs, it will read the latest
+	// observed resource, see a difference between the desired and the latest
+	// state (that actually does not exist because the difference is comparing
+	// the value of the fields before they were changed) and attempt to modify
+	// the field from value B to value A again, causing a flop loop.
+	//
+	// Luckily, the Output shape's DBInstance struct contains a
+	// `PendingModifiedValues` struct which contains those field values that
+	// the user specified. So, we can use these to "reset" the Spec back to the
+	// appropriate user-specified values.
+	pmv := ko.Status.PendingModifiedValues
+	if pmv != nil {
+		if pmv.AllocatedStorage != nil {
+			ko.Spec.AllocatedStorage = pmv.AllocatedStorage
+		}
+        // NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.AutomationMode != nil {
+		//	ko.Spec.AutomationMode = pmv.AutomationMode
+		//}
+		if pmv.BackupRetentionPeriod != nil {
+			ko.Spec.BackupRetentionPeriod = pmv.BackupRetentionPeriod
+		}
+		if pmv.CACertificateIdentifier != nil {
+			ko.Spec.CACertificateIdentifier = pmv.CACertificateIdentifier
+		}
+		if pmv.DBInstanceClass != nil {
+			ko.Spec.DBInstanceClass = pmv.DBInstanceClass
+		}
+		if pmv.DBInstanceIdentifier != nil {
+			ko.Spec.DBInstanceIdentifier = pmv.DBInstanceIdentifier
+		}
+		if pmv.DBSubnetGroupName != nil {
+			ko.Spec.DBSubnetGroupName = pmv.DBSubnetGroupName
+		}
+		if pmv.EngineVersion != nil {
+			ko.Spec.EngineVersion = pmv.EngineVersion
+		}
+        // NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.IAMDatabaseAuthenticationEnabled != nil {
+		//	ko.Spec.IAMDatabaseAuthenticationEnabled = pmv.IAMDatabaseAuthenticationEnabled
+		//}
+        // NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.Iops != nil {
+		//	ko.Spec.IOPS = pmv.Iops
+		//}
+		if pmv.LicenseModel != nil {
+			ko.Spec.LicenseModel = pmv.LicenseModel
+		}
+		if pmv.MasterUserPassword != nil {
+			// NOTE(jaypipes): Type mismatch with Spec and
+			// PendingModifiedValues, so just reset to the original...
+			ko.Spec.MasterUserPassword = r.ko.Spec.MasterUserPassword
+		}
+		if pmv.MultiAZ != nil {
+			ko.Spec.MultiAZ = pmv.MultiAZ
+		}
+        // NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.PendingCloudwatchLogsExports != nil {
+		//	ko.Spec.PendingCloudwatchLogsExports = pmv.PendingCloudwatchLogsExports
+		//}
+		if pmv.Port != nil {
+			ko.Spec.Port = pmv.Port
+		}
+        // NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.ProcessorFeatures != nil {
+		//	ko.Spec.ProcessorFeatures = pmv.ProcessorFeatures
+		//}
+        // NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.ResumeFullAutomationModeTime != nil {
+		//	ko.Spec.ResumeFullAutomationModeTime = pmv.ResumeFullAutomationModeTime
+		//}
+		if pmv.StorageThroughput != nil {
+			ko.Spec.StorageThroughput = pmv.StorageThroughput
+		}
+		if pmv.StorageType != nil {
+			ko.Spec.StorageType = pmv.StorageType
+		}
+	}
 	if ko.Status.ACKResourceMetadata != nil && ko.Status.ACKResourceMetadata.ARN != nil {
-        resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
-        tags, err := rm.getTags(ctx, *resourceARN)
-        if err != nil {
-            return nil, err
-        }
-        ko.Spec.Tags = tags
+		resourceARN := (*string)(ko.Status.ACKResourceMetadata.ARN)
+		tags, err := rm.getTags(ctx, *resourceARN)
+		if err != nil {
+			return nil, err
+		}
+		ko.Spec.Tags = tags
 	}
 	if !instanceAvailable(&resource{ko}) {
 		// Setting resource synced condition to false will trigger a requeue of

--- a/templates/hooks/db_instance/sdk_update_post_set_output.go.tpl
+++ b/templates/hooks/db_instance/sdk_update_post_set_output.go.tpl
@@ -1,4 +1,84 @@
-    // When ModifyDBInstance API is successful, it asynchronously
+	// ModifyDBInstance returns a DBInstance struct that contains the
+	// *previously set* values for various mutable fields. This is problematic
+	// because it causes a "flopping" behaviour when the user has modified a
+	// Spec field from value A to value B but the output shape from
+	// ModifyDBInstance for that field contains value A, the standard SetOutput
+	// Go code generated above will set the Spec field to the *old* value
+	// again. The next time the reconciler runs, it will attempt to modify the
+	// field from value B to value A again, causing a flop loop.
+	//
+	// Luckily, the Output shape's DBInstance struct contains a
+	// `PendingModifiedValues` struct which contains those field values that
+	// the user specified. So, we can use these to "reset" the Spec back to the
+	// appropriate user-specific values.
+	pmv := resp.DBInstance.PendingModifiedValues
+	if pmv != nil {
+		if pmv.AllocatedStorage != nil {
+			ko.Spec.AllocatedStorage = pmv.AllocatedStorage
+		}
+        // NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.AutomationMode != nil {
+		//	ko.Spec.AutomationMode = pmv.AutomationMode
+		//}
+		if pmv.BackupRetentionPeriod != nil {
+			ko.Spec.BackupRetentionPeriod = pmv.BackupRetentionPeriod
+		}
+		if pmv.CACertificateIdentifier != nil {
+			ko.Spec.CACertificateIdentifier = pmv.CACertificateIdentifier
+		}
+		if pmv.DBInstanceClass != nil {
+			ko.Spec.DBInstanceClass = pmv.DBInstanceClass
+		}
+		if pmv.DBInstanceIdentifier != nil {
+			ko.Spec.DBInstanceIdentifier = pmv.DBInstanceIdentifier
+		}
+		if pmv.DBSubnetGroupName != nil {
+			ko.Spec.DBSubnetGroupName = pmv.DBSubnetGroupName
+		}
+		if pmv.EngineVersion != nil {
+			ko.Spec.EngineVersion = pmv.EngineVersion
+		}
+        // NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.IAMDatabaseAuthenticationEnabled != nil {
+		//	ko.Spec.IAMDatabaseAuthenticationEnabled = pmv.IAMDatabaseAuthenticationEnabled
+		//}
+		if pmv.Iops != nil {
+			ko.Spec.IOPS = pmv.Iops
+		}
+		if pmv.LicenseModel != nil {
+			ko.Spec.LicenseModel = pmv.LicenseModel
+		}
+		if pmv.MasterUserPassword != nil {
+			// NOTE(jaypipes): Type mismatch with Spec and
+			// PendingModifiedValues, so just reset to the desired...
+			ko.Spec.MasterUserPassword = desired.ko.Spec.MasterUserPassword
+		}
+		if pmv.MultiAZ != nil {
+			ko.Spec.MultiAZ = pmv.MultiAZ
+		}
+        // NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.PendingCloudwatchLogsExports != nil {
+		//	ko.Spec.PendingCloudwatchLogsExports = pmv.PendingCloudwatchLogsExports
+		//}
+		if pmv.Port != nil {
+			ko.Spec.Port = pmv.Port
+		}
+        // NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.ProcessorFeatures != nil {
+		//	ko.Spec.ProcessorFeatures = pmv.ProcessorFeatures
+		//}
+        // NOTE(jaypipes): Handle when aws-sdk-go update
+		//if pmv.ResumeFullAutomationModeTime != nil {
+		//	ko.Spec.ResumeFullAutomationModeTime = pmv.ResumeFullAutomationModeTime
+		//}
+		if pmv.StorageThroughput != nil {
+			ko.Spec.StorageThroughput = pmv.StorageThroughput
+		}
+		if pmv.StorageType != nil {
+			ko.Spec.StorageType = pmv.StorageType
+		}
+	}
+	// When ModifyDBInstance API is successful, it asynchronously
 	// updates the DBInstanceStatus. Requeue to find the current
 	// DBInstance status and set Synced condition accordingly
 	if err == nil {


### PR DESCRIPTION
Both ModifyDBInstance and DescribeDBInstances returns a DBInstance struct that contains the *previously set* values for various mutable fields. This is problematic because it causes a "flopping" behaviour when the user has modified a Spec field from value A to value B but the output shape from ModifyDBInstance for that field contains value A, the standard SetOutput Go code generated above will set the Spec field to the *old* value again. The next time the reconciler runs, it will read the latest observed resource, see a difference between the desired and the latest state (that actually does not exist because the difference is comparing the value of the fields before they were changed) and attempt to modify the field from value B to value A again, causing a flop loop.

Luckily, the Output shape's DBInstance struct contains a `PendingModifiedValues` struct which contains those field values that the user specified. So, we can use these to "reset" the Spec back to the appropriate user-specified values.

This commit does exactly this. It looks in the `PendingModifiedValues` struct for any non-nil field that matches a field in the `Spec` and if it finds a match, sets the `Spec` field to the value in `PendingModifiedValues`. This solves the flapping problem for all of the fields in `PendingModifiedValues`, including `DBInstanceClass`, `AllocatedStorage`, `MultiAZ` and `StorageType`.

Fixes Issue aws-controllers-k8s/community#1773
Fixes Issue aws-controllers-k8s/community#1716
Fixes Issue aws-controllers-k8s/community#1376

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
