### PR TITLE
Move documentation overrides to `documentation.yaml`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-05-15T22:54:34Z"
-  build_hash: 8f3ba427974fd6e769926778d54834eaee3b81a3
-  go_version: go1.19
-  version: v0.26.1
-api_directory_checksum: b3f33aebf366349bde7945f7b627ae788a18c0d5
+  build_date: "2023-06-20T18:17:08Z"
+  build_hash: e9b68590da73ce9143ba1e4361cebdc1d876c81e
+  go_version: go1.19.1
+  version: v0.26.1-7-ge9b6859
+api_directory_checksum: e013615d0330f1fb2af178b203d6ff3b5ac846be
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.232
 generator_config_info:
-  file_checksum: 1c65701c9ae781dcda0fb8c04fed4de60e25a9ef
+  file_checksum: 7b42e2abe3d0679c9e1f72cf08441fce9db9c350
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/db_cluster_parameter_group.go
+++ b/apis/v1alpha1/db_cluster_parameter_group.go
@@ -89,21 +89,10 @@ type DBClusterParameterGroupSpec struct {
 	// This value is stored as a lowercase string.
 	// +kubebuilder:validation:Required
 	Name *string `json:"name"`
-	// These are ONLY user-defined parameter overrides for the DB cluster parameter group. This does not contain default or system parameters.
+	// These are ONLY user-defined parameter overrides for the
+	// DB cluster parameter group. This does not contain default or system
+	// parameters.
 	ParameterOverrides map[string]*string `json:"parameterOverrides,omitempty"`
-	// A list of parameters in the DB cluster parameter group to modify.
-	//
-	// Valid Values (for the application method): immediate | pending-reboot
-	//
-	// You can use the immediate value with dynamic parameters only. You can use
-	// the pending-reboot value for both dynamic and static parameters.
-	//
-	// When the application method is immediate, changes to dynamic parameters are
-	// applied immediately to the DB clusters associated with the parameter group.
-	// When the application method is pending-reboot, changes to dynamic and static
-	// parameters are applied after a reboot without failover to the DB clusters
-	// associated with the parameter group.
-	//
 	// DEPRECATED - do not use.  Prefer ParameterOverrides instead.
 	Parameters []*Parameter `json:"parameters,omitempty"`
 	// Tags to assign to the DB cluster parameter group.

--- a/apis/v1alpha1/db_parameter_group.go
+++ b/apis/v1alpha1/db_parameter_group.go
@@ -95,7 +95,8 @@ type DBParameterGroupSpec struct {
 	// This value is stored as a lowercase string.
 	// +kubebuilder:validation:Required
 	Name *string `json:"name"`
-	// These are ONLY user-defined parameter overrides for the DB parameter group. This does not contain default or system parameters.
+	// These are ONLY user-defined parameter overrides for the DB parameter
+	// group. This does not contain default or system parameters.
 	ParameterOverrides map[string]*string `json:"parameterOverrides,omitempty"`
 	// Tags to assign to the DB parameter group.
 	Tags []*Tag `json:"tags,omitempty"`

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -185,15 +185,11 @@ resources:
         from:
           operation: ModifyDBClusterParameterGroup
           path: Parameters
-        documentation:  DEPRECATED - do not use.  Prefer ParameterOverrides instead.
       ParameterOverrides:
         custom_field:
           # Map keys are the parameter name and the values are the parameter value.
           # We automatically determine the "apply method" for parameters.
           map_of: String
-        documentation: These are ONLY user-defined parameter overrides for the
-          DB cluster parameter group. This does not contain default or system
-          parameters.
       Tags:
         compare:
           # We have a custom comparison function...
@@ -365,9 +361,6 @@ resources:
           # the user needs to do is specify the parameter name and value they
           # want to override...
           map_of: String
-        documentation:
-          These are ONLY user-defined parameter overrides for the DB parameter
-          group. This does not contain default or system parameters.
       Tags:
         compare:
           # We have a custom comparison function...

--- a/config/crd/bases/rds.services.k8s.aws_dbclusterparametergroups.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbclusterparametergroups.yaml
@@ -75,17 +75,7 @@ spec:
                   parameters.
                 type: object
               parameters:
-                description: "A list of parameters in the DB cluster parameter group
-                  to modify. \n Valid Values (for the application method): immediate
-                  | pending-reboot \n You can use the immediate value with dynamic
-                  parameters only. You can use the pending-reboot value for both dynamic
-                  and static parameters. \n When the application method is immediate,
-                  changes to dynamic parameters are applied immediately to the DB
-                  clusters associated with the parameter group. When the application
-                  method is pending-reboot, changes to dynamic and static parameters
-                  are applied after a reboot without failover to the DB clusters associated
-                  with the parameter group. \n DEPRECATED - do not use.  Prefer ParameterOverrides
-                  instead."
+                description: DEPRECATED - do not use.  Prefer ParameterOverrides instead.
                 items:
                   description: "This data type is used as a request parameter in the
                     ModifyDBParameterGroup and ResetDBParameterGroup actions. \n This

--- a/documentation.yaml
+++ b/documentation.yaml
@@ -1,0 +1,17 @@
+resources:
+  DBClusterParameterGroup:
+    fields:
+      Parameters: 
+        override: |
+          DEPRECATED - do not use.  Prefer ParameterOverrides instead.
+      ParameterOverrides: 
+        append: |
+          These are ONLY user-defined parameter overrides for the
+          DB cluster parameter group. This does not contain default or system
+          parameters.
+  DBParameterGroup:
+    fields:
+      ParameterOverrides: 
+        append: |
+          These are ONLY user-defined parameter overrides for the DB parameter
+          group. This does not contain default or system parameters.

--- a/generator.yaml
+++ b/generator.yaml
@@ -185,15 +185,11 @@ resources:
         from:
           operation: ModifyDBClusterParameterGroup
           path: Parameters
-        documentation:  DEPRECATED - do not use.  Prefer ParameterOverrides instead.
       ParameterOverrides:
         custom_field:
           # Map keys are the parameter name and the values are the parameter value.
           # We automatically determine the "apply method" for parameters.
           map_of: String
-        documentation: These are ONLY user-defined parameter overrides for the
-          DB cluster parameter group. This does not contain default or system
-          parameters.
       Tags:
         compare:
           # We have a custom comparison function...
@@ -365,9 +361,6 @@ resources:
           # the user needs to do is specify the parameter name and value they
           # want to override...
           map_of: String
-        documentation:
-          These are ONLY user-defined parameter overrides for the DB parameter
-          group. This does not contain default or system parameters.
       Tags:
         compare:
           # We have a custom comparison function...

--- a/helm/crds/rds.services.k8s.aws_dbclusterparametergroups.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbclusterparametergroups.yaml
@@ -76,17 +76,7 @@ spec:
                   parameters.
                 type: object
               parameters:
-                description: "A list of parameters in the DB cluster parameter group
-                  to modify. \n Valid Values (for the application method): immediate
-                  | pending-reboot \n You can use the immediate value with dynamic
-                  parameters only. You can use the pending-reboot value for both dynamic
-                  and static parameters. \n When the application method is immediate,
-                  changes to dynamic parameters are applied immediately to the DB
-                  clusters associated with the parameter group. When the application
-                  method is pending-reboot, changes to dynamic and static parameters
-                  are applied after a reboot without failover to the DB clusters associated
-                  with the parameter group. \n DEPRECATED - do not use.  Prefer ParameterOverrides
-                  instead."
+                description: DEPRECATED - do not use.  Prefer ParameterOverrides instead.
                 items:
                   description: "This data type is used as a request parameter in the
                     ModifyDBParameterGroup and ResetDBParameterGroup actions. \n This


### PR DESCRIPTION
Description of changes:
Uses the new `documentation.yaml` overrides file to generate custom docstrings for each resource

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
