### PR TITLE
Copy IAM authentication state from status

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,7 +1,7 @@
 ack_generate_info:
-  build_date: "2023-09-14T23:59:25Z"
+  build_date: "2023-11-07T03:25:11Z"
   build_hash: 892f29d00a4c4ad21a2fa32919921de18190979d
-  go_version: go1.21.0
+  go_version: go1.21.3
   version: v0.27.1
 api_directory_checksum: ec327bd746176accff503d6ca1306e08a55ac61b
 api_version: v1alpha1

--- a/pkg/resource/db_cluster/sdk.go
+++ b/pkg/resource/db_cluster/sdk.go
@@ -647,6 +647,12 @@ func (rm *resourceManager) sdkFind(
 		ko.Spec.DBClusterParameterGroupName = ko.Status.DBClusterParameterGroup
 	}
 
+	if r.ko.Spec.EnableIAMDatabaseAuthentication != nil {
+		// If the desired resource has IAM authentication explicitly enabled or disabled then update the spec of the
+		// latest resource with the value from the status.
+		ko.Spec.EnableIAMDatabaseAuthentication = ko.Status.IAMDatabaseAuthenticationEnabled
+	}
+
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/db_cluster/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/db_cluster/sdk_read_many_post_set_output.go.tpl
@@ -30,3 +30,9 @@
 		// resource with the value from the status.
 		ko.Spec.DBClusterParameterGroupName = ko.Status.DBClusterParameterGroup
 	}
+
+	if r.ko.Spec.EnableIAMDatabaseAuthentication != nil  {
+	    // If the desired resource has IAM authentication explicitly enabled or disabled then update the spec of the
+	    // latest resource with the value from the status.
+		ko.Spec.EnableIAMDatabaseAuthentication = ko.Status.IAMDatabaseAuthenticationEnabled
+	}

--- a/test/e2e/db_cluster.py
+++ b/test/e2e/db_cluster.py
@@ -30,17 +30,18 @@ ClusterMatchFunc = typing.NewType(
     typing.Callable[[dict], bool],
 )
 
-class StatusMatcher:
-    def __init__(self, status):
-        self.match_on = status
+class AttributeMatcher:
+    def __init__(self, match_on: str, expected_value: typing.Any):
+        self.match_on = match_on
+        self.expected_value = expected_value
 
-    def __call__(self, record: dict) -> bool:
-        return (record is not None and 'Status' in record
-                and record['Status'] == self.match_on)
+    def __call__(self, record: typing.Dict[str, typing.Any]) -> bool:
+        return (record is not None and self.match_on in record
+                and record[self.match_on] == self.expected_value)
 
 
 def status_matches(status: str) -> ClusterMatchFunc:
-    return StatusMatcher(status)
+    return AttributeMatcher("Status", status)
 
 
 def wait_until(

--- a/test/e2e/resources/db_cluster_aurora_postgres.yaml
+++ b/test/e2e/resources/db_cluster_aurora_postgres.yaml
@@ -1,0 +1,19 @@
+apiVersion: rds.services.k8s.aws/v1alpha1
+kind: DBCluster
+metadata:
+  name: $DB_CLUSTER_ID
+spec:
+  autoMinorVersionUpgrade: false
+  copyTagsToSnapshot: false
+  dbClusterIdentifier: $DB_CLUSTER_ID
+  enableIAMDatabaseAuthentication: false
+  engine: aurora-postgresql
+  engineMode: provisioned
+  engineVersion: "14.9"
+  masterUsername: root
+  masterUserPassword:
+    namespace: $MASTER_USER_PASS_SECRET_NAMESPACE
+    name: $MASTER_USER_PASS_SECRET_NAME
+    key: $MASTER_USER_PASS_SECRET_KEY
+  port: 5432
+  storageEncrypted: true

--- a/test/e2e/tests/test_db_cluster.py
+++ b/test/e2e/tests/test_db_cluster.py
@@ -65,7 +65,7 @@ def aurora_mysql_cluster(k8s_secret):
     db_name = "mydb"
     secret = k8s_secret(
         MUP_NS,
-        MUP_SEC_NAME,
+        f"{MUP_SEC_NAME}-mysql",
         MUP_SEC_KEY,
         MUP_SEC_VAL,
     )
@@ -114,7 +114,7 @@ def aurora_postgres_cluster(k8s_secret):
     db_cluster_id = random_suffix_name("my-aurora-postgres", 20)
     secret = k8s_secret(
         MUP_NS,
-        MUP_SEC_NAME,
+        f"{MUP_SEC_NAME}-postgres",
         MUP_SEC_KEY,
         MUP_SEC_VAL,
     )

--- a/test/e2e/tests/test_db_cluster.py
+++ b/test/e2e/tests/test_db_cluster.py
@@ -108,6 +108,53 @@ def aurora_mysql_cluster(k8s_secret):
 
     db_cluster.wait_until_deleted(db_cluster_id)
 
+
+@pytest.fixture
+def aurora_postgres_cluster(k8s_secret):
+    db_cluster_id = random_suffix_name("my-aurora-postgres", 20)
+    secret = k8s_secret(
+        MUP_NS,
+        MUP_SEC_NAME,
+        MUP_SEC_KEY,
+        MUP_SEC_VAL,
+    )
+
+    resource_data = load_rds_resource(
+        "db_cluster_aurora_postgres",
+        additional_replacements={
+            "DB_CLUSTER_ID": db_cluster_id,
+            "MASTER_USER_PASS_SECRET_NAMESPACE": secret.ns,
+            "MASTER_USER_PASS_SECRET_NAME": secret.name,
+            "MASTER_USER_PASS_SECRET_KEY": secret.key,
+        },
+    )
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+        db_cluster_id, namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    assert cr is not None
+    assert 'status' in cr
+    assert 'status' in cr['status']
+    assert cr['status']['status'] == 'creating'
+    condition.assert_not_synced(ref)
+
+    yield (ref, cr, db_cluster_id)
+
+    # Try to delete, if doesn't already exist
+    try:
+        _, deleted = k8s.delete_custom_resource(ref, 3, 10)
+        assert deleted
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+    except:
+        pass
+
+    db_cluster.wait_until_deleted(db_cluster_id)
+
+
 @service_marker
 @pytest.mark.canary
 class TestDBCluster:
@@ -183,3 +230,30 @@ class TestDBCluster:
             }
         ]
         assert latest_tags == after_update_expected_tags
+
+    def test_flip_enable_iam_db_authn(
+            self, aurora_postgres_cluster,
+    ):
+        ref, _, db_cluster_id = aurora_postgres_cluster
+
+        db_cluster.wait_until(
+            db_cluster_id,
+            db_cluster.status_matches('available'),
+        )
+
+        current = db_cluster.get(db_cluster_id)
+        assert current is not None
+        assert current["IAMDatabaseAuthenticationEnabled"] == False
+        k8s.patch_custom_resource(
+            ref,
+            {"spec": {"enableIAMDatabaseAuthentication": True}},
+        )
+
+        db_cluster.wait_until(
+            db_cluster_id,
+            db_cluster.AttributeMatcher("IAMDatabaseAuthenticationEnabled", True),
+        )
+
+        latest = db_cluster.get(db_cluster_id)
+        assert latest is not None
+        assert latest["IAMDatabaseAuthenticationEnabled"] == True


### PR DESCRIPTION
Issue #, if available: #1937

Description of changes: Like the parameter groups the IAM authentication flag has different names in the input and output to the API. A hook is need to correctly set the value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
