### PR TITLE
DBInstance/DBCluster password updates on secret ref changes

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,9 +1,9 @@
 ack_generate_info:
-  build_date: "2024-02-14T04:08:17Z"
+  build_date: "2024-02-26T20:53:40Z"
   build_hash: 947081ffebdeefcf2c61c4ca6d7e68810bdf9d08
   go_version: go1.22.0
   version: v0.30.0
-api_directory_checksum: ec327bd746176accff503d6ca1306e08a55ac61b
+api_directory_checksum: 11c44032679e136f20ebca3e336bdc3bd8f71312
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.232
 generator_config_info:

--- a/apis/v1alpha1/annotation.go
+++ b/apis/v1alpha1/annotation.go
@@ -1,0 +1,30 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package v1alpha1
+
+import "fmt"
+
+var (
+	// LastAppliedConfigMapAnnotation is the annotation key used to store the namespaced name
+	// of the last used secret for setting the master user password of a DBInstance or DBCluster.
+	//
+	// The secret namespaced name stored in this annotation is used to compute the "reference" delta
+	// when the user updates the DBInstance or DBCluster resource.
+	//
+	// This annotation is only applied by the rds-controller, and should not be modified by the user.
+	// In case the user modifies this annotation, the rds-controller may not be able to correctly
+	// compute the "reference" delta, and can result in the rds-controller making unnecessary password
+	// updates to the DBInstance or DBCluster.
+	LastAppliedSecretAnnotation = fmt.Sprintf("%s/last-applied-secret-reference", GroupVersion.Group)
+)

--- a/pkg/resource/db_cluster/custom_update.go
+++ b/pkg/resource/db_cluster/custom_update.go
@@ -64,6 +64,16 @@ func (rm *resourceManager) customUpdate(
 		ackcondition.SetSynced(desired, corev1.ConditionTrue, nil, nil)
 		return desired, nil
 	}
+	if delta.DifferentAt("Spec.Tags") {
+		if err = rm.syncTags(ctx, desired, latest); err != nil {
+			return nil, err
+		}
+	} else if !delta.DifferentExcept("Spec.Tags") {
+		// If the only difference between the desired and latest is in the
+		// Spec.Tags field, we can skip the modify db cluster call.
+		return desired, nil
+	}
+
 	input, err := rm.newCustomUpdateRequestPayload(ctx, desired, latest, delta)
 	if err != nil {
 		return nil, err
@@ -76,11 +86,6 @@ func (rm *resourceManager) customUpdate(
 	rm.metrics.RecordAPICall("UPDATE", "ModifyDBCluster", err)
 	if err != nil {
 		return nil, err
-	}
-	if delta.DifferentAt("Spec.Tags") {
-		if err = rm.syncTags(ctx, desired, latest); err != nil {
-			return nil, err
-		}
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
@@ -503,9 +508,20 @@ func (rm *resourceManager) customUpdate(
 	} else {
 		ko.Status.VPCSecurityGroups = nil
 	}
-
 	rm.setStatusDefaults(ko)
-	return &resource{ko}, nil
+	// When ModifyDBInstance API is successful, it asynchronously
+	// updates the DBInstanceStatus. Requeue to find the current
+	// DBInstance status and set Synced condition accordingly
+	r := &resource{ko}
+	if err == nil {
+		// set the last-applied-secret-reference annotation on the DB instance
+		// resource.
+		setLastAppliedSecretReferenceAnnotation(r)
+		// Setting resource synced condition to false will trigger a requeue of
+		// the resource. No need to return a requeue error here.
+		ackcondition.SetSynced(r, corev1.ConditionFalse, nil, nil)
+	}
+	return r, nil
 }
 
 // newCustomUpdateRequestPayload returns an SDK-specific struct for the HTTP

--- a/pkg/resource/db_cluster/delta.go
+++ b/pkg/resource/db_cluster/delta.go
@@ -43,6 +43,7 @@ func newResourceDelta(
 		return delta
 	}
 	compareTags(delta, a, b)
+	compareSecretReferenceChanges(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.AllocatedStorage, b.ko.Spec.AllocatedStorage) {
 		delta.Add("Spec.AllocatedStorage", a.ko.Spec.AllocatedStorage, b.ko.Spec.AllocatedStorage)

--- a/pkg/resource/db_cluster/hooks.go
+++ b/pkg/resource/db_cluster/hooks.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	svcapitypes "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
+	"github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
@@ -307,4 +308,45 @@ func (rm *resourceManager) restoreDbClusterFromSnapshot(
 		ackcondition.SetSynced(&resource{r.ko}, corev1.ConditionFalse, nil, nil)
 	}
 	return &resource{r.ko}, nil
+}
+
+// TODO(a-hilaly): generate this code.
+
+// getLastAppliedSecretReferenceString returns a string representation of the
+// last-applied secret reference.
+func getLastAppliedSecretReferenceString(r *v1alpha1.SecretKeyReference) string {
+	if r == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s.%s", r.Namespace, r.Name, r.Key)
+}
+
+// setLastAppliedSecretReferenceAnnotation sets the last-applied secret reference
+// annotation on the supplied resource.
+func setLastAppliedSecretReferenceAnnotation(r *resource) {
+	if r.ko.Annotations == nil {
+		r.ko.Annotations = make(map[string]string)
+	}
+	r.ko.Annotations[svcapitypes.LastAppliedSecretAnnotation] = getLastAppliedSecretReferenceString(r.ko.Spec.MasterUserPassword)
+}
+
+// getLastAppliedSecretReferenceAnnotation returns the last-applied secret reference
+// annotation on the supplied resource.
+func getLastAppliedSecretReferenceAnnotation(r *resource) string {
+	if r.ko.Annotations == nil {
+		return ""
+	}
+	return r.ko.Annotations[svcapitypes.LastAppliedSecretAnnotation]
+}
+
+func compareSecretReferenceChanges(
+	delta *ackcompare.Delta,
+	desired *resource,
+	latest *resource,
+) {
+	oldRef := getLastAppliedSecretReferenceAnnotation(desired)
+	newRef := getLastAppliedSecretReferenceString(desired.ko.Spec.MasterUserPassword)
+	if oldRef != newRef {
+		delta.Add("Spec.MasterUserPassword", oldRef, newRef)
+	}
 }

--- a/pkg/resource/db_cluster/sdk.go
+++ b/pkg/resource/db_cluster/sdk.go
@@ -1259,14 +1259,18 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
+	// set the last-applied-secret-reference annotation on the DB instance
+	// resource.
+	r := &resource{ko}
+	setLastAppliedSecretReferenceAnnotation(r)
 	// We expect the DB cluster to be in 'creating' status since we just
 	// issued the call to create it, but I suppose it doesn't hurt to check
 	// here.
-	if clusterCreating(&resource{ko}) {
+	if clusterCreating(r) {
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.
-		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
-		return &resource{ko}, nil
+		ackcondition.SetSynced(r, corev1.ConditionFalse, nil, nil)
+		return r, nil
 	}
 
 	return &resource{ko}, nil

--- a/pkg/resource/db_instance/delta.go
+++ b/pkg/resource/db_instance/delta.go
@@ -79,6 +79,7 @@ func newResourceDelta(
 	// controller should treat them as same
 	reconcileEngineVersion(a, b)
 	compareTags(delta, a, b)
+	compareSecretReferenceChanges(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.AllocatedStorage, b.ko.Spec.AllocatedStorage) {
 		delta.Add("Spec.AllocatedStorage", a.ko.Spec.AllocatedStorage, b.ko.Spec.AllocatedStorage)

--- a/pkg/resource/db_instance/sdk.go
+++ b/pkg/resource/db_instance/sdk.go
@@ -1666,16 +1666,20 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
+	// set the last-applied-secret-reference annotation on the DB instance
+	// resource.
+	r := &resource{ko}
+	setLastAppliedSecretReferenceAnnotation(r)
+
 	// We expect the DB instance to be in 'creating' status since we just
 	// issued the call to create it, but I suppose it doesn't hurt to check
 	// here.
-	if instanceCreating(&resource{ko}) {
+	if instanceCreating(r) {
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.
-		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
-		return &resource{ko}, nil
+		ackcondition.SetSynced(r, corev1.ConditionFalse, nil, nil)
+		return r, nil
 	}
-
 	return &resource{ko}, nil
 }
 
@@ -1961,7 +1965,7 @@ func (rm *resourceManager) sdkUpdate(
 	if !delta.DifferentAt("Spec.CACertificateIdentifier") {
 		input.CACertificateIdentifier = nil
 	}
-	if !delta.DifferentAt("Spec.MasterUserPassword.Name") {
+	if !delta.DifferentAt("Spec.MasterUserPassword") {
 		input.MasterUserPassword = nil
 	}
 	if !delta.DifferentAt("Spec.NetworkType") {
@@ -2770,9 +2774,13 @@ func (rm *resourceManager) sdkUpdate(
 	// updates the DBInstanceStatus. Requeue to find the current
 	// DBInstance status and set Synced condition accordingly
 	if err == nil {
+		// set the last-applied-secret-reference annotation on the DB instance
+		// resource.
+		r := &resource{ko}
+		setLastAppliedSecretReferenceAnnotation(r)
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.
-		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
+		ackcondition.SetSynced(r, corev1.ConditionFalse, nil, nil)
 	}
 
 	return &resource{ko}, nil

--- a/templates/hooks/db_cluster/delta_pre_compare.go.tpl
+++ b/templates/hooks/db_cluster/delta_pre_compare.go.tpl
@@ -1,1 +1,2 @@
     compareTags(delta, a, b)
+    compareSecretReferenceChanges(delta, a, b)

--- a/templates/hooks/db_cluster/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/db_cluster/sdk_create_post_set_output.go.tpl
@@ -1,9 +1,13 @@
+	// set the last-applied-secret-reference annotation on the DB instance
+	// resource.
+	r := &resource{ko}
+	setLastAppliedSecretReferenceAnnotation(r)
 	// We expect the DB cluster to be in 'creating' status since we just
 	// issued the call to create it, but I suppose it doesn't hurt to check
 	// here.
-	if clusterCreating(&resource{ko}) {
+	if clusterCreating(r) {
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.
-		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
-		return &resource{ko}, nil
+		ackcondition.SetSynced(r, corev1.ConditionFalse, nil, nil)
+		return r, nil
 	}

--- a/templates/hooks/db_instance/delta_pre_compare.go.tpl
+++ b/templates/hooks/db_instance/delta_pre_compare.go.tpl
@@ -35,3 +35,4 @@
 	// controller should treat them as same
 	reconcileEngineVersion(a, b)
     compareTags(delta, a, b)
+	compareSecretReferenceChanges(delta, a, b)

--- a/templates/hooks/db_instance/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/db_instance/sdk_create_post_set_output.go.tpl
@@ -1,9 +1,14 @@
+	// set the last-applied-secret-reference annotation on the DB instance
+	// resource.
+	r := &resource{ko}
+	setLastAppliedSecretReferenceAnnotation(r)
+
 	// We expect the DB instance to be in 'creating' status since we just
 	// issued the call to create it, but I suppose it doesn't hurt to check
 	// here.
-	if instanceCreating(&resource{ko}) {
+	if instanceCreating(r) {
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.
-		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
-		return &resource{ko}, nil
+		ackcondition.SetSynced(r, corev1.ConditionFalse, nil, nil)
+		return r, nil
 	}

--- a/templates/hooks/db_instance/sdk_update_post_build_request.go.tpl
+++ b/templates/hooks/db_instance/sdk_update_post_build_request.go.tpl
@@ -18,7 +18,7 @@
         if !delta.DifferentAt("Spec.CACertificateIdentifier") {
 		input.CACertificateIdentifier = nil
 	}
-        if !delta.DifferentAt("Spec.MasterUserPassword.Name") {
+        if !delta.DifferentAt("Spec.MasterUserPassword") {
 		input.MasterUserPassword = nil
 	}
         if !delta.DifferentAt("Spec.NetworkType") {

--- a/templates/hooks/db_instance/sdk_update_post_set_output.go.tpl
+++ b/templates/hooks/db_instance/sdk_update_post_set_output.go.tpl
@@ -82,7 +82,11 @@
 	// updates the DBInstanceStatus. Requeue to find the current
 	// DBInstance status and set Synced condition accordingly
 	if err == nil {
+		// set the last-applied-secret-reference annotation on the DB instance
+		// resource.
+		r := &resource{ko}
+		setLastAppliedSecretReferenceAnnotation(r)
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.
-		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
+		ackcondition.SetSynced(r, corev1.ConditionFalse, nil, nil)
 	}


### PR DESCRIPTION
This patch adds a new feature to the rds-controller allowing users to
update their `DBInstance` and `DBCluster` passwords, by modifying the
secretReference (namespace, name or key).

Prior to this patch the controller wasn't able to update `DBInstance`
and `DBCluster` passwords due to it's inability to calculate the
difference between a desired and observed states. The fact that the
API doesn't return any information about the password combined with the
controller unable to detect changes of the secret refs


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
