### PR TITLE
Add annotations to configure final snapshot and automated backup deletion

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-06-11T19:26:48Z"
+  build_date: "2024-06-11T21:00:10Z"
   build_hash: 14cef51778d471698018b6c38b604181a6948248
   go_version: go1.22.3
   version: v0.34.0
-api_directory_checksum: 471f6857e01011a1a487f29512fa093d340122d2
+api_directory_checksum: 03d7817f582e395d13fd3eb447996b9c6ff7a0e7
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.232
 generator_config_info:
-  file_checksum: 00210e222c5049e16a3951f79273ec678156ed08
+  file_checksum: 6289988e39ed3478c6a38753adc1298031f0acf9
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/annotation.go
+++ b/apis/v1alpha1/annotation.go
@@ -27,4 +27,19 @@ var (
 	// compute the "reference" delta, and can result in the rds-controller making unnecessary password
 	// updates to the DBInstance or DBCluster.
 	LastAppliedSecretAnnotation = fmt.Sprintf("%s/last-applied-secret-reference", GroupVersion.Group)
+	// SkipFinalSnapshot is the annotation key used to skip the final snapshot when deleting a DBInstance
+	// or DBCluster. If this annotation is set to "true", the final snapshot will be skipped. The default
+	// value is "true" - meaning that when the annotation is not present, the final snapshot will be skipped.
+	SkipFinalSnapshotAnnotation = fmt.Sprintf("%s/skip-final-snapshot", GroupVersion.Group)
+	// FinalDBSnapshotIdentifier is the annotation key used to specify the final snapshot identifier when
+	// deleting a DBInstance or DBCluster. If this annotation is set, the final snapshot will be created with
+	// the specified identifier.
+	//
+	// If the SkipFinalSnapshot annotation is set to "true", this annotation will be ignored.
+	FinalDBSnapshotIdentifierAnnotation = fmt.Sprintf("%s/final-db-snapshot-identifier", GroupVersion.Group)
+	// DeleteAutomatedBackups is the annotation key used to specify whether automated backups should be
+	// deleted when deleting a DBInstance or DBCluster. If this annotation is set to "true", automated backups
+	// will be deleted. The default value is "false" - meaning that when the annotation is not present, automated
+	// backups will not be deleted.
+	DeleteAutomatedBackupsAnnotation = fmt.Sprintf("%s/delete-automated-backups", GroupVersion.Group)
 )

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -48,12 +48,6 @@ operations:
       # This flag was designed as a protect flag but not necessary in controller
       # side when customer need to make the engine version change
       AllowMajorVersionUpgrade: true
-  DeleteDBCluster:
-    override_values:
-      # Clearly this is not ideal, but will suffice until we add custom hook
-      # points to the build_request methods to enable a genmeration of the
-      # final snapshot identifier to use.
-      SkipFinalSnapshot: true
   ModifyDBInstance:
     override_values:
       # The whole concept of a "maintenance window" isn't aligned with the
@@ -73,12 +67,6 @@ operations:
       # makes to a resource's Spec to be reconciled by the ACK service
       # controller, not a different service.
       AllowMajorVersionUpgrade: true
-  DeleteDBInstance:
-    override_values:
-      # Clearly this is not ideal, but will suffice until we add custom hook
-      # points to the build_request methods to enable a genmeration of the
-      # final snapshot identifier to use.
-      SkipFinalSnapshot: true
 resources:
   DBCluster:
     update_operation:
@@ -97,6 +85,8 @@ resources:
         template_path: hooks/db_cluster/sdk_read_many_post_set_output.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/db_cluster/sdk_delete_pre_build_request.go.tpl
+      sdk_delete_post_build_request:
+        template_path: hooks/db_cluster/sdk_delete_post_build_request.go.tpl
       sdk_file_end:
         template_path: hooks/db_cluster/sdk_file_end.go.tpl
     exceptions:
@@ -228,6 +218,8 @@ resources:
         template_path: hooks/db_instance/sdk_update_post_set_output.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/db_instance/sdk_delete_pre_build_request.go.tpl
+      sdk_delete_post_build_request:
+        template_path: hooks/db_instance/sdk_delete_post_build_request.go.tpl
       sdk_file_end:
         template_path: hooks/db_instance/sdk_file_end.go.tpl
     exceptions:

--- a/generator.yaml
+++ b/generator.yaml
@@ -48,12 +48,6 @@ operations:
       # This flag was designed as a protect flag but not necessary in controller
       # side when customer need to make the engine version change
       AllowMajorVersionUpgrade: true
-  DeleteDBCluster:
-    override_values:
-      # Clearly this is not ideal, but will suffice until we add custom hook
-      # points to the build_request methods to enable a genmeration of the
-      # final snapshot identifier to use.
-      SkipFinalSnapshot: true
   ModifyDBInstance:
     override_values:
       # The whole concept of a "maintenance window" isn't aligned with the
@@ -73,12 +67,6 @@ operations:
       # makes to a resource's Spec to be reconciled by the ACK service
       # controller, not a different service.
       AllowMajorVersionUpgrade: true
-  DeleteDBInstance:
-    override_values:
-      # Clearly this is not ideal, but will suffice until we add custom hook
-      # points to the build_request methods to enable a genmeration of the
-      # final snapshot identifier to use.
-      SkipFinalSnapshot: true
 resources:
   DBCluster:
     update_operation:
@@ -97,6 +85,8 @@ resources:
         template_path: hooks/db_cluster/sdk_read_many_post_set_output.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/db_cluster/sdk_delete_pre_build_request.go.tpl
+      sdk_delete_post_build_request:
+        template_path: hooks/db_cluster/sdk_delete_post_build_request.go.tpl
       sdk_file_end:
         template_path: hooks/db_cluster/sdk_file_end.go.tpl
     exceptions:
@@ -228,6 +218,8 @@ resources:
         template_path: hooks/db_instance/sdk_update_post_set_output.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/db_instance/sdk_delete_pre_build_request.go.tpl
+      sdk_delete_post_build_request:
+        template_path: hooks/db_instance/sdk_delete_post_build_request.go.tpl
       sdk_file_end:
         template_path: hooks/db_instance/sdk_file_end.go.tpl
     exceptions:

--- a/pkg/resource/db_cluster/hooks.go
+++ b/pkg/resource/db_cluster/hooks.go
@@ -350,3 +350,19 @@ func compareSecretReferenceChanges(
 		delta.Add("Spec.MasterUserPassword", oldRef, newRef)
 	}
 }
+
+// setDeleteDBClusterInput uses the resource annotations to complete
+// the input for the DeleteDBCluster API call.
+func setDeleteDBClusterInput(
+	r *resource,
+	input *svcsdk.DeleteDBClusterInput,
+) error {
+	params, err := util.ParseDeletionAnnotations(r.ko.GetAnnotations())
+	if err != nil {
+		return err
+	}
+	input.SkipFinalSnapshot = params.SkipFinalSnapshot
+	input.FinalDBSnapshotIdentifier = params.FinalDBSnapshotIdentifier
+	input.DeleteAutomatedBackups = params.DeleteAutomatedBackup
+	return nil
+}

--- a/pkg/resource/db_cluster/sdk.go
+++ b/pkg/resource/db_cluster/sdk.go
@@ -1531,6 +1531,11 @@ func (rm *resourceManager) sdkDelete(
 	if err != nil {
 		return nil, err
 	}
+	err = setDeleteDBClusterInput(r, input)
+	if err != nil {
+		return nil, err
+	}
+
 	var resp *svcsdk.DeleteDBClusterOutput
 	_ = resp
 	resp, err = rm.sdkapi.DeleteDBClusterWithContext(ctx, input)
@@ -1548,7 +1553,6 @@ func (rm *resourceManager) newDeleteRequestPayload(
 	if r.ko.Spec.DBClusterIdentifier != nil {
 		res.SetDBClusterIdentifier(*r.ko.Spec.DBClusterIdentifier)
 	}
-	res.SetSkipFinalSnapshot(true)
 
 	return res, nil
 }

--- a/pkg/resource/db_instance/hooks.go
+++ b/pkg/resource/db_instance/hooks.go
@@ -565,3 +565,19 @@ func compareSecretReferenceChanges(
 		delta.Add("Spec.MasterUserPassword", oldRef, newRef)
 	}
 }
+
+// setDeleteDBInstanceInput uses the resource annotations to complete
+// the input for the DeleteDBInstance API call.
+func setDeleteDBInstanceInput(
+	r *resource,
+	input *svcsdk.DeleteDBInstanceInput,
+) error {
+	params, err := util.ParseDeletionAnnotations(r.ko.GetAnnotations())
+	if err != nil {
+		return err
+	}
+	input.SkipFinalSnapshot = params.SkipFinalSnapshot
+	input.FinalDBSnapshotIdentifier = params.FinalDBSnapshotIdentifier
+	input.DeleteAutomatedBackups = params.DeleteAutomatedBackup
+	return nil
+}

--- a/pkg/resource/db_instance/sdk.go
+++ b/pkg/resource/db_instance/sdk.go
@@ -2971,6 +2971,11 @@ func (rm *resourceManager) sdkDelete(
 	if err != nil {
 		return nil, err
 	}
+	err = setDeleteDBInstanceInput(r, input)
+	if err != nil {
+		return nil, err
+	}
+
 	var resp *svcsdk.DeleteDBInstanceOutput
 	_ = resp
 	resp, err = rm.sdkapi.DeleteDBInstanceWithContext(ctx, input)
@@ -2988,7 +2993,6 @@ func (rm *resourceManager) newDeleteRequestPayload(
 	if r.ko.Spec.DBInstanceIdentifier != nil {
 		res.SetDBInstanceIdentifier(*r.ko.Spec.DBInstanceIdentifier)
 	}
-	res.SetSkipFinalSnapshot(true)
 
 	return res, nil
 }

--- a/pkg/util/annotations.go
+++ b/pkg/util/annotations.go
@@ -1,0 +1,66 @@
+package util
+
+import (
+	"strconv"
+
+	svcapitypes "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
+)
+
+type DeleteInputAnnotationParameters struct {
+	SkipFinalSnapshot         *bool
+	FinalDBSnapshotIdentifier *string
+	DeleteAutomatedBackup     *bool
+}
+
+var (
+	// If not specified skipFinalSnapshot will be set to true by default.
+	//
+	// Kept for historical purpuse: This was the value that we set in the generator.yaml
+	// before writing this annotation parsing functions.
+	//
+	//   DeleteDBCluster:
+	//     override_values:
+	//       # Clearly this is not ideal, but will suffice until we add custom hook
+	//       # points to the build_request methods to enable a genmeration of the
+	//       # final snapshot identifier to use.
+	//       SkipFinalSnapshot: true
+	defaultSkipFinalSnapshot = true
+)
+
+// parseDeletionAnnotations parses the deletion annotations on the supplied
+// resource.
+func ParseDeletionAnnotations(annotations map[string]string) (*DeleteInputAnnotationParameters, error) {
+	params := &DeleteInputAnnotationParameters{
+		SkipFinalSnapshot: &defaultSkipFinalSnapshot,
+	}
+	if len(annotations) == 0 {
+		return params, nil
+	}
+
+	// Parse SkipFinalSnapshot annotation
+	skipFinalSnapshotAnnotationValue, ok := annotations[svcapitypes.SkipFinalSnapshotAnnotation]
+	if ok && skipFinalSnapshotAnnotationValue != "" {
+		skipFinalSnapshot, err := strconv.ParseBool(skipFinalSnapshotAnnotationValue)
+		if err != nil {
+			return nil, err
+		}
+		params.SkipFinalSnapshot = &skipFinalSnapshot
+	}
+
+	// Parse FinalDBSnapshotIdentifier annotation
+	finalDBSnapshotIdentifierAnnotationValue, ok := annotations[svcapitypes.FinalDBSnapshotIdentifierAnnotation]
+	if ok {
+		params.FinalDBSnapshotIdentifier = &finalDBSnapshotIdentifierAnnotationValue
+	}
+
+	// Parse DeleteAutomatedBackup annotation
+	deleteAutomatedBackupAnnotationValue, ok := annotations[svcapitypes.DeleteAutomatedBackupsAnnotation]
+	if ok && deleteAutomatedBackupAnnotationValue != "" {
+		deleteAutomatedBackup, err := strconv.ParseBool(deleteAutomatedBackupAnnotationValue)
+		if err != nil {
+			return nil, err
+		}
+		params.DeleteAutomatedBackup = &deleteAutomatedBackup
+	}
+	return params, nil
+}

--- a/pkg/util/annotations_test.go
+++ b/pkg/util/annotations_test.go
@@ -1,0 +1,86 @@
+package util_test
+
+import (
+	"reflect"
+	"testing"
+
+	svcapitypes "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
+	"github.com/aws-controllers-k8s/rds-controller/pkg/util"
+	"github.com/aws/aws-sdk-go/aws"
+)
+
+func TestParseDeletionAnnotations(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        *util.DeleteInputAnnotationParameters
+		wantErr     bool
+	}{
+		{
+			name:        "no annotations",
+			annotations: map[string]string{},
+			want: &util.DeleteInputAnnotationParameters{
+				SkipFinalSnapshot:         aws.Bool(true),
+				FinalDBSnapshotIdentifier: nil,
+				DeleteAutomatedBackup:     nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "all annotations set - turn on all snapshot options",
+			annotations: map[string]string{
+				svcapitypes.SkipFinalSnapshotAnnotation:         "false",
+				svcapitypes.FinalDBSnapshotIdentifierAnnotation: "final-snapshot",
+				svcapitypes.DeleteAutomatedBackupsAnnotation:    "false",
+			},
+			want: &util.DeleteInputAnnotationParameters{
+				SkipFinalSnapshot:         aws.Bool(false),
+				FinalDBSnapshotIdentifier: aws.String("final-snapshot"),
+				DeleteAutomatedBackup:     aws.Bool(false),
+			},
+			wantErr: false,
+		},
+		{
+			name: "all annotations set - turn off all snapshot options",
+			annotations: map[string]string{
+				svcapitypes.SkipFinalSnapshotAnnotation:      "true",
+				svcapitypes.DeleteAutomatedBackupsAnnotation: "true",
+			},
+			want: &util.DeleteInputAnnotationParameters{
+				SkipFinalSnapshot:         aws.Bool(true),
+				FinalDBSnapshotIdentifier: nil,
+				DeleteAutomatedBackup:     aws.Bool(true),
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid SkipFinalSnapshot annotation",
+			annotations: map[string]string{
+				svcapitypes.SkipFinalSnapshotAnnotation: "invalid",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "invalid DeleteAutomatedBackups annotation",
+			annotations: map[string]string{
+				svcapitypes.DeleteAutomatedBackupsAnnotation: "invalid",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := util.ParseDeletionAnnotations(tt.annotations)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseDeletionAnnotations() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseDeletionAnnotations() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/templates/hooks/db_cluster/sdk_delete_post_build_request.go.tpl
+++ b/templates/hooks/db_cluster/sdk_delete_post_build_request.go.tpl
@@ -1,0 +1,4 @@
+	err = setDeleteDBClusterInput(r, input)
+	if err != nil {
+		return nil, err
+	}

--- a/templates/hooks/db_instance/sdk_delete_post_build_request.go.tpl
+++ b/templates/hooks/db_instance/sdk_delete_post_build_request.go.tpl
@@ -1,0 +1,4 @@
+	err = setDeleteDBInstanceInput(r, input)
+	if err != nil {
+		return nil, err
+	}


### PR DESCRIPTION
This commit adds support for configuring delete options for DBInstances
and DBclusters via resource annotations:
- `SkipFinalSnapshot` (default: true): Skip taking a final snapshot
  before deletion
- `FinalDBSnapshotIdentifier`: Specify the identifier of the final
  snapshot
- `DeleteAutomatedBackups` (default: true): Delete automated backups
  associated with the instance/cluster

The generator config is updated to use `sdk_delete_post_build_request`
hook which parses the annotations and set the appropriate fields on
`DeleteDBInstanceInput` and `DeleteDBClusterInput`.

The default behaviour remains unchanged (skip final snapshot, retain
automated backups), but users can now opt-in to taking a final snapshot
or deleting automatedd backups by setting the corresponding annotations
on the resource.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
