### PR TITLE
fix storageType delta

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2025-02-20T18:29:28Z"
+  build_date: "2025-03-07T22:57:51Z"
   build_hash: a326346bd3a6973254d247c9ab2dc76790c36241
   go_version: go1.24.0
   version: v0.43.2

--- a/templates/hooks/db_cluster/delta_pre_compare.go.tpl
+++ b/templates/hooks/db_cluster/delta_pre_compare.go.tpl
@@ -1,2 +1,12 @@
     compareTags(delta, a, b)
+
+    // Handle special case for StorageType field for Aurora engines
+    // When StorageType is set to "aurora" (default), the API doesn't return it
+
+    isAuroraEngine := (b.ko.Spec.Engine != nil && (*b.ko.Spec.Engine == "aurora-mysql" || *b.ko.Spec.Engine == "aurora-postgresql"))
+    
+    if isAuroraEngine && (a.ko.Spec.StorageType != nil && *a.ko.Spec.StorageType == "aurora" && b.ko.Spec.StorageType == nil) {
+            b.ko.Spec.StorageType = aws.String("aurora")
+    }  
+
     compareSecretReferenceChanges(delta, a, b)


### PR DESCRIPTION
Fixes:
``` When the StorageType parameter for a DBCluster is explicitly set to its default value ("aurora"), the AWS RDS API doesn't return this field in the response. However, when set to a non-default value (like "aurora-iopt1"), the API does return the field. This inconsistency causes problems with the controller's delta comparison logic.```

Description of changes:
Modified the `delta_pre_compare` hook to default the StorageType field to "aurora" when it's nil in the latest resource state. This addresses the issue where the AWS RDS API doesn't return the StorageType field when it's set to the default value "aurora".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
