### PR TITLE
Prevent incorrect DB Cluster engine version patching during updates

### DIFF
--- a/pkg/resource/db_cluster/custom_update.go
+++ b/pkg/resource/db_cluster/custom_update.go
@@ -324,11 +324,6 @@ func (rm *resourceManager) customUpdate(
 	} else {
 		ko.Spec.EngineMode = nil
 	}
-	if resp.DBCluster.EngineVersion != nil {
-		ko.Spec.EngineVersion = resp.DBCluster.EngineVersion
-	} else {
-		ko.Spec.EngineVersion = nil
-	}
 	if resp.DBCluster.GlobalWriteForwardingRequested != nil {
 		ko.Status.GlobalWriteForwardingRequested = resp.DBCluster.GlobalWriteForwardingRequested
 	} else {


### PR DESCRIPTION
fixes: https://github.com/aws-controllers-k8s/community/issues/2380

Description of changes:

When `ModifyDBCluster` is called for an engine version update, the API response might still reflect the *old* version while the update is in progress asynchronously. Previously, we patched `ko` with this potentially outdated version from the response. This caused the next reconciliation to incorrectly see a mismatch between the desired (new) version and the patched (old) version, leading to unnecessary downgrade attempts.

**Fix:**

The `customUpdate` function does not patch `EngineVersion`


**Example:**

1.  **User Spec:** `EngineVersion: "11.0"`
2.  **Current State:** `EngineVersion: "10.0"`
3.  `ModifyDBCluster` is called to update to `11.0`.
4.  **API Response:** (while updating) `EngineVersion: "10.0"`
5.  **Old Behavior:** `ko.Spec.EngineVersion` patched to `10.0`. Next reconcile might try to downgrade.
6.  **New Behavior:** desired is set and not patched to ko during the update


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
