### PR TITLE
fix: remove SubnetIDs duplicates

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-03-27T16:30:34Z"
-  build_hash: 980cb1e4734f673d16101cf55206b84ca639ec01
+  build_date: "2025-04-11T18:51:18Z"
+  build_hash: 0909e7f0adb8ffe4120a8c20d5d58b991f2539e9
   go_version: go1.24.1
-  version: v0.44.0
+  version: v0.44.0-3-g0909e7f
 api_directory_checksum: 2960d5d47c03026d9207068e776eef99e09f798a
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/pkg/resource/db_subnet_group/sdk.go
+++ b/pkg/resource/db_subnet_group/sdk.go
@@ -171,13 +171,14 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	if ko.Status.Subnets != nil {
+		f0 := []*string{}
 		for _, subnetIdIter := range ko.Status.Subnets {
 			if subnetIdIter.SubnetIdentifier != nil {
-				ko.Spec.SubnetIDs = append(ko.Spec.SubnetIDs, subnetIdIter.SubnetIdentifier)
+				f0 = append(f0, subnetIdIter.SubnetIdentifier)
 			}
 		}
+		ko.Spec.SubnetIDs = f0
 	}
-
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/db_subnet_group/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/db_subnet_group/sdk_read_many_post_set_output.go.tpl
@@ -7,10 +7,12 @@
         ko.Spec.Tags = tags
 	}
 
-        if ko.Status.Subnets != nil {
-                for _, subnetIdIter := range ko.Status.Subnets {
-                        if subnetIdIter.SubnetIdentifier != nil {
-                                ko.Spec.SubnetIDs = append(ko.Spec.SubnetIDs, subnetIdIter.SubnetIdentifier)
-                        }
-                }
-        }
+	if ko.Status.Subnets != nil {
+		f0 := []*string{}
+		for _, subnetIdIter := range ko.Status.Subnets {
+			if subnetIdIter.SubnetIdentifier != nil {
+				f0 = append(f0, subnetIdIter.SubnetIdentifier)
+			}
+		}
+		ko.Spec.SubnetIDs = f0
+	}


### PR DESCRIPTION
Issue [#2083](https://github.com/aws-controllers-k8s/community/issues/2083)

Description of changes:
In sdkFind hook, the SubnetIDs returned by AWS are appended 
to the latest resource Spec.SubnetIDs. This ended up being an 
issue because the latest resource is a deep copy of desired. 
And there were unnecessary update calls were being made due 
to this issue.

This change ensures the only the SubnetIDs returned by the 
DescribeDBSubnetGroup call are populated in the latest SubnetIDs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
