### PR TITLE
fix: issue 2614 dbcluster respect only supplying major engineVersion

### DIFF
--- a/pkg/resource/db_cluster/delta.go
+++ b/pkg/resource/db_cluster/delta.go
@@ -45,6 +45,10 @@ func newResourceDelta(
 	}
 	compareTags(delta, a, b)
 
+	// Handle case where auto update minor version is true
+	// DBCluster Engine Version is major version and RDS Cluster Version is major and minor
+	reconcileDBClusterEngineVersion(a, b)
+
 	// Handle special case for StorageType field for Aurora engines
 	// When StorageType is set to "aurora" (default), the API doesn't return it
 
@@ -147,7 +151,9 @@ func newResourceDelta(
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.DatabaseInsightsMode, b.ko.Spec.DatabaseInsightsMode) {
-		delta.Add("Spec.DatabaseInsightsMode", a.ko.Spec.DatabaseInsightsMode, b.ko.Spec.DatabaseInsightsMode)
+		if a.ko.Spec.DatabaseInsightsMode != nil {
+			delta.Add("Spec.DatabaseInsightsMode", a.ko.Spec.DatabaseInsightsMode, b.ko.Spec.DatabaseInsightsMode)
+		}
 	} else if a.ko.Spec.DatabaseInsightsMode != nil && b.ko.Spec.DatabaseInsightsMode != nil {
 		if *a.ko.Spec.DatabaseInsightsMode != *b.ko.Spec.DatabaseInsightsMode {
 			delta.Add("Spec.DatabaseInsightsMode", a.ko.Spec.DatabaseInsightsMode, b.ko.Spec.DatabaseInsightsMode)

--- a/pkg/resource/db_cluster/hooks.go
+++ b/pkg/resource/db_cluster/hooks.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	svcapitypes "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
 	"github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"

--- a/pkg/resource/db_cluster/hooks.go
+++ b/pkg/resource/db_cluster/hooks.go
@@ -400,3 +400,19 @@ func setDeleteDBClusterInput(
 	input.DeleteAutomatedBackups = params.DeleteAutomatedBackup
 	return nil
 }
+
+// RDS will choose preferred engine minor version if only
+// engine major version is provided and controler should not
+// treat them as different, such as spec has 14, status has 14.1
+// controller should treat them as same
+func reconcileDBClusterEngineVersion(
+	a *resource,
+	b *resource,
+) {
+	if a != nil && b != nil &&
+		a.ko.Spec.EngineVersion != nil && b.ko.Spec.EngineVersion != nil &&
+		strings.HasPrefix(*b.ko.Spec.EngineVersion, *a.ko.Spec.EngineVersion) &&
+		b.ko.Spec.AutoMinorVersionUpgrade != nil && *b.ko.Spec.AutoMinorVersionUpgrade {
+		a.ko.Spec.EngineVersion = b.ko.Spec.EngineVersion
+	}
+}

--- a/pkg/resource/db_cluster/hooks.go
+++ b/pkg/resource/db_cluster/hooks.go
@@ -403,7 +403,7 @@ func setDeleteDBClusterInput(
 }
 
 // RDS will choose preferred engine minor version if only
-// engine major version is provided and controler should not
+// engine major version is provided and controller should not
 // treat them as different, such as spec has 14, status has 14.1
 // controller should treat them as same
 func reconcileDBClusterEngineVersion(

--- a/pkg/resource/db_instance/delta.go
+++ b/pkg/resource/db_instance/delta.go
@@ -202,7 +202,9 @@ func newResourceDelta(
 		delta.Add("Spec.DBSubnetGroupRef", a.ko.Spec.DBSubnetGroupRef, b.ko.Spec.DBSubnetGroupRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.DatabaseInsightsMode, b.ko.Spec.DatabaseInsightsMode) {
-		delta.Add("Spec.DatabaseInsightsMode", a.ko.Spec.DatabaseInsightsMode, b.ko.Spec.DatabaseInsightsMode)
+		if a.ko.Spec.DatabaseInsightsMode != nil {
+			delta.Add("Spec.DatabaseInsightsMode", a.ko.Spec.DatabaseInsightsMode, b.ko.Spec.DatabaseInsightsMode)
+		}
 	} else if a.ko.Spec.DatabaseInsightsMode != nil && b.ko.Spec.DatabaseInsightsMode != nil {
 		if *a.ko.Spec.DatabaseInsightsMode != *b.ko.Spec.DatabaseInsightsMode {
 			delta.Add("Spec.DatabaseInsightsMode", a.ko.Spec.DatabaseInsightsMode, b.ko.Spec.DatabaseInsightsMode)


### PR DESCRIPTION
Issue #, if available: 2614

Description of changes:
DBCluster is not respecting only supplying major egineVersion.  it is reporting a delta because RDS has major/minor version.  This prevents FieldExports from being populated.

In addition, existing DBCluster where DatabaseInsightsMode is nil, new controller results in continuous modifications to the RDS DB Instances.  if databaseInsightsMode is not set, do not report as a delta.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
