### PR TITLE
Enforce a requeue on delete for DBInstance and DBCluster

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-08-22T23:47:01Z"
-  build_hash: 1045a5e99038b11b0630ca2f2f69c3bae4bedba6
-  go_version: go1.25.0
-  version: v0.51.0-1-g1045a5e
+  build_date: "2025-09-03T20:10:59Z"
+  build_hash: 1d9076d0211773ff8ab8682b28b912c7ece10676
+  go_version: go1.24.5
+  version: v0.51.0-2-g1d9076d
 api_directory_checksum: 90b0d1adcc91f4a1b1f1b436e3ac0c30d9271678
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: ecb60f0fe79237eb820e68d823e6da2bf0829140
+  file_checksum: 746b45e4dfa86a7e3fc4979703205281a4b71e8f
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -157,6 +157,8 @@ resources:
         template_path: hooks/db_cluster/sdk_delete_pre_build_request.go.tpl
       sdk_delete_post_build_request:
         template_path: hooks/db_cluster/sdk_delete_post_build_request.go.tpl
+      sdk_delete_post_request:
+        template_path: hooks/common/sdk_delete_post_request.go.tpl
       sdk_file_end:
         template_path: hooks/db_cluster/sdk_file_end.go.tpl
     exceptions:
@@ -310,6 +312,8 @@ resources:
         template_path: hooks/db_instance/sdk_delete_pre_build_request.go.tpl
       sdk_delete_post_build_request:
         template_path: hooks/db_instance/sdk_delete_post_build_request.go.tpl
+      sdk_delete_post_request:
+        template_path: hooks/common/sdk_delete_post_request.go.tpl
       sdk_file_end:
         template_path: hooks/db_instance/sdk_file_end.go.tpl
     exceptions:

--- a/generator.yaml
+++ b/generator.yaml
@@ -157,6 +157,8 @@ resources:
         template_path: hooks/db_cluster/sdk_delete_pre_build_request.go.tpl
       sdk_delete_post_build_request:
         template_path: hooks/db_cluster/sdk_delete_post_build_request.go.tpl
+      sdk_delete_post_request:
+        template_path: hooks/common/sdk_delete_post_request.go.tpl
       sdk_file_end:
         template_path: hooks/db_cluster/sdk_file_end.go.tpl
     exceptions:
@@ -310,6 +312,8 @@ resources:
         template_path: hooks/db_instance/sdk_delete_pre_build_request.go.tpl
       sdk_delete_post_build_request:
         template_path: hooks/db_instance/sdk_delete_post_build_request.go.tpl
+      sdk_delete_post_request:
+        template_path: hooks/common/sdk_delete_post_request.go.tpl
       sdk_file_end:
         template_path: hooks/db_instance/sdk_file_end.go.tpl
     exceptions:

--- a/pkg/resource/db_cluster/resource.go
+++ b/pkg/resource/db_cluster/resource.go
@@ -97,11 +97,11 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["dbClusterIdentifier"]
+	primaryKey, ok := fields["dbClusterIdentifier"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: dbClusterIdentifier"))
 	}
-	r.ko.Spec.DBClusterIdentifier = &tmp
+	r.ko.Spec.DBClusterIdentifier = &primaryKey
 
 	return nil
 }

--- a/pkg/resource/db_cluster/sdk.go
+++ b/pkg/resource/db_cluster/sdk.go
@@ -1562,6 +1562,10 @@ func (rm *resourceManager) sdkDelete(
 	_ = resp
 	resp, err = rm.sdkapi.DeleteDBCluster(ctx, input)
 	rm.metrics.RecordAPICall("DELETE", "DeleteDBCluster", err)
+	if err == nil {
+		_ = resp
+		err = ackrequeue.Needed(fmt.Errorf("wait for DBInstance deletion"))
+	}
 	return nil, err
 }
 

--- a/pkg/resource/db_cluster_endpoint/resource.go
+++ b/pkg/resource/db_cluster_endpoint/resource.go
@@ -103,11 +103,11 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["dbClusterEndpointIdentifier"]
+	primaryKey, ok := fields["dbClusterEndpointIdentifier"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: dbClusterEndpointIdentifier"))
 	}
-	r.ko.Spec.DBClusterEndpointIdentifier = &tmp
+	r.ko.Spec.DBClusterEndpointIdentifier = &primaryKey
 
 	f1, f1ok := fields["dbClusterIdentifier"]
 	if f1ok {

--- a/pkg/resource/db_cluster_parameter_group/resource.go
+++ b/pkg/resource/db_cluster_parameter_group/resource.go
@@ -97,11 +97,11 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["name"]
+	primaryKey, ok := fields["name"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: name"))
 	}
-	r.ko.Spec.Name = &tmp
+	r.ko.Spec.Name = &primaryKey
 
 	return nil
 }

--- a/pkg/resource/db_cluster_snapshot/resource.go
+++ b/pkg/resource/db_cluster_snapshot/resource.go
@@ -107,11 +107,11 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["dbClusterSnapshotIdentifier"]
+	primaryKey, ok := fields["dbClusterSnapshotIdentifier"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: dbClusterSnapshotIdentifier"))
 	}
-	r.ko.Spec.DBClusterSnapshotIdentifier = &tmp
+	r.ko.Spec.DBClusterSnapshotIdentifier = &primaryKey
 
 	f0, f0ok := fields["dbClusterIdentifier"]
 	if f0ok {

--- a/pkg/resource/db_instance/resource.go
+++ b/pkg/resource/db_instance/resource.go
@@ -97,11 +97,11 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["dbInstanceIdentifier"]
+	primaryKey, ok := fields["dbInstanceIdentifier"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: dbInstanceIdentifier"))
 	}
-	r.ko.Spec.DBInstanceIdentifier = &tmp
+	r.ko.Spec.DBInstanceIdentifier = &primaryKey
 
 	return nil
 }

--- a/pkg/resource/db_instance/sdk.go
+++ b/pkg/resource/db_instance/sdk.go
@@ -2927,6 +2927,10 @@ func (rm *resourceManager) sdkDelete(
 	_ = resp
 	resp, err = rm.sdkapi.DeleteDBInstance(ctx, input)
 	rm.metrics.RecordAPICall("DELETE", "DeleteDBInstance", err)
+	if err == nil {
+		_ = resp
+		err = ackrequeue.Needed(fmt.Errorf("wait for DBInstance deletion"))
+	}
 	return nil, err
 }
 

--- a/pkg/resource/db_parameter_group/resource.go
+++ b/pkg/resource/db_parameter_group/resource.go
@@ -97,11 +97,11 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["name"]
+	primaryKey, ok := fields["name"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: name"))
 	}
-	r.ko.Spec.Name = &tmp
+	r.ko.Spec.Name = &primaryKey
 
 	return nil
 }

--- a/pkg/resource/db_proxy/resource.go
+++ b/pkg/resource/db_proxy/resource.go
@@ -97,11 +97,11 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["name"]
+	primaryKey, ok := fields["name"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: name"))
 	}
-	r.ko.Spec.Name = &tmp
+	r.ko.Spec.Name = &primaryKey
 
 	return nil
 }

--- a/pkg/resource/db_snapshot/resource.go
+++ b/pkg/resource/db_snapshot/resource.go
@@ -111,11 +111,11 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["dbSnapshotIdentifier"]
+	primaryKey, ok := fields["dbSnapshotIdentifier"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: dbSnapshotIdentifier"))
 	}
-	r.ko.Spec.DBSnapshotIdentifier = &tmp
+	r.ko.Spec.DBSnapshotIdentifier = &primaryKey
 
 	f0, f0ok := fields["dbInstanceIdentifier"]
 	if f0ok {

--- a/pkg/resource/db_subnet_group/resource.go
+++ b/pkg/resource/db_subnet_group/resource.go
@@ -97,11 +97,11 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["name"]
+	primaryKey, ok := fields["name"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: name"))
 	}
-	r.ko.Spec.Name = &tmp
+	r.ko.Spec.Name = &primaryKey
 
 	return nil
 }

--- a/pkg/resource/global_cluster/resource.go
+++ b/pkg/resource/global_cluster/resource.go
@@ -97,11 +97,11 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	tmp, ok := fields["globalClusterIdentifier"]
+	primaryKey, ok := fields["globalClusterIdentifier"]
 	if !ok {
 		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: globalClusterIdentifier"))
 	}
-	r.ko.Spec.GlobalClusterIdentifier = &tmp
+	r.ko.Spec.GlobalClusterIdentifier = &primaryKey
 
 	return nil
 }

--- a/templates/hooks/common/sdk_delete_post_request.go.tpl
+++ b/templates/hooks/common/sdk_delete_post_request.go.tpl
@@ -1,0 +1,4 @@
+    if err == nil {
+		_ = resp
+        err = ackrequeue.Needed(fmt.Errorf("wait for DBInstance deletion"))
+    }

--- a/test/e2e/tests/test_db_instance.py
+++ b/test/e2e/tests/test_db_instance.py
@@ -94,12 +94,11 @@ def postgres14_t3_micro_instance(k8s_secret):
 
     yield (ref, cr, secret.name)
 
-    # Try to delete, if doesn't already exist
-    try:
-        _, deleted = k8s.delete_custom_resource(ref, 3, 10)
-    except:
-        pass
+    k8s.delete_custom_resource(ref)
+    assert k8s.get_resource_exists(ref)
     db_instance.wait_until_deleted(db_instance_id)
+    time.sleep(60)
+    assert not k8s.get_resource_exists(ref)
 
 @service_marker
 @pytest.mark.canary


### PR DESCRIPTION
Issue [#2618](https://github.com/aws-controllers-k8s/community/issues/2618)

Description of changes:
This requeue enforcement on delete ensures that the ACK custom resource
will not disappear until the resource in AWS is successfully removed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
