### PR TITLE
Add inline policy recommendation for secret management

### DIFF
--- a/config/iam/recommended-inline-policy
+++ b/config/iam/recommended-inline-policy
@@ -1,0 +1,27 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "SecretsManagerPermissions",
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:CreateSecret",
+                "secretsmanager:UpdateSecret",
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DeleteSecret",
+                "secretsmanager:TagResource"
+            ],
+            "Resource": "arn:aws:secretsmanager:*:*:secret:rds!*"
+        },
+        {
+            "Sid": "KMSPermissions",
+            "Effect": "Allow",
+            "Action": [
+                "kms:Decrypt",
+                "kms:GenerateDataKey",
+                "kms:DescribeKey"
+            ],
+            "Resource": "arn:aws:kms:*:*:key/*"
+        }
+    ]
+}


### PR DESCRIPTION
**Issue**: 

When only using AmazonRDSFullAccess and setting a DBInstance `spec.manageMasterUserPassword` to true, the controller would fail on DBInstanceCreate because of insufficient permissions (first to use KMS keys then to create passwords) .

This allows the controller to create and manage secrets in secrets manager.

**Description of changes**:

Adds a recommended-inline-policy file containing the necessary policy for the RDS controller to manage secrets in the AWS SecretStore.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
