### PR TITLE
feat: adding the ability to enable cross-region automated backup replication

### DIFF
--- a/apis/v1alpha1/db_instance.go
+++ b/apis/v1alpha1/db_instance.go
@@ -150,6 +150,22 @@ type DBInstanceSpec struct {
 	// Example: us-east-1d
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
 	AvailabilityZone *string `json:"availabilityZone,omitempty"`
+	// BackupCrossRegionReplication enables cross-region automated backup replication.
+	// When set to true, automated backups will be replicated to the specified destination region.
+	// Default: false
+	// +kubebuilder:validation:XValidation:rule="!self || has(self.backupCrossRegionReplicationDestinationRegion)",message="BackupCrossRegionReplicationDestinationRegion is required when BackupCrossRegionReplication is true"
+	BackupCrossRegionReplication *bool `json:"backupCrossRegionReplication,omitempty"`
+	// BackupCrossRegionReplicationDestinationRegion specifies the AWS region where
+	// automated backups should be replicated. Required when BackupCrossRegionReplication is true.
+	BackupCrossRegionReplicationDestinationRegion *string `json:"backupCrossRegionReplicationDestinationRegion,omitempty"`
+	// BackupCrossRegionReplicationKMSKeyID specifies the AWS KMS key identifier for encryption
+	// of the replicated automated backups. The KMS key ID is the Amazon Resource Name (ARN) for
+	// the KMS encryption key in the destination AWS Region.
+	BackupCrossRegionReplicationKMSKeyID *string `json:"backupCrossRegionReplicationKMSKeyID,omitempty"`
+	// BackupCrossRegionReplicationRetentionPeriod specifies the number of days to retain
+	// replicated automated backups in the destination region.
+	// Default: 7
+	BackupCrossRegionReplicationRetentionPeriod *int64 `json:"backupCrossRegionReplicationRetentionPeriod,omitempty"`
 	// The number of days for which automated backups are retained. Setting this
 	// parameter to a positive number enables backups. Setting this parameter to
 	// 0 disables automated backups.

--- a/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
@@ -200,6 +200,37 @@ spec:
                      * Can't be set to 0 for an RDS Custom for Oracle DB instance.
                 format: int64
                 type: integer
+              backupCrossRegionReplication:
+                default: false
+                description: |-
+                  BackupCrossRegionReplication enables cross-region automated backup replication.
+                  When set to true, automated backups will be replicated to the specified destination region.
+                  Default: false
+                type: boolean
+              backupCrossRegionReplicationDestinationRegion:
+                description: |-
+                  BackupCrossRegionReplicationDestinationRegion specifies the AWS region where
+                  automated backups should be replicated. Required when BackupCrossRegionReplication is true.
+                type: string
+              backupCrossRegionReplicationKMSKeyID:
+                description: |-
+                  BackupCrossRegionReplicationKMSKeyID specifies the AWS KMS key identifier for encryption
+                  of the replicated automated backups. The KMS key ID is the Amazon Resource Name (ARN) for
+                  the KMS encryption key in the destination AWS Region.
+                type: string
+              backupCrossRegionReplicationRetentionPeriod:
+                default: 7
+                description: |-
+                  BackupCrossRegionReplicationRetentionPeriod specifies the number of days to retain
+                  replicated automated backups in the destination region.
+
+                  Default: 7
+
+                  Constraints:
+
+                     * Must be a value from 0 to 35.
+                format: int64
+                type: integer
               backupTarget:
                 description: |-
                   The location for storing automated backups and manual snapshots.

--- a/generator.yaml
+++ b/generator.yaml
@@ -465,6 +465,27 @@ resources:
       IOPS:
         late_initialize:
           skip_incomplete_check: {}
+      BackupCrossRegionReplication:
+        custom_field:
+          # This field controls whether to call Start/Stop operations
+          # It's not directly mapped to an AWS API field
+          documentation: |
+            Enables cross-region automated backup replication.
+            When true, calls StartDBInstanceAutomatedBackupsReplication.
+            When false, calls StopDBInstanceAutomatedBackupsReplication.
+      BackupCrossRegionReplicationDestinationRegion:
+        documentation: |
+          The AWS region where automated backups should be replicated.
+          Required when BackupCrossRegionReplication is true.
+      BackupCrossRegionReplicationRetentionPeriod:
+        documentation: |
+          Number of days to retain replicated automated backups.
+          Default: 7
+      BackupCrossRegionReplicationKMSKeyID:
+        documentation: |
+          The AWS KMS key identifier for encryption of the replicated automated backups.
+          The KMS key ID is the Amazon Resource Name (ARN) for the KMS encryption key
+          in the destination AWS Region.
       Tags:
         compare:
           # We have a custom comparison function...

--- a/pkg/resource/db_instance/delta.go
+++ b/pkg/resource/db_instance/delta.go
@@ -64,6 +64,34 @@ func newResourceDelta(
 			delta.Add("Spec.BackupTarget", a.ko.Spec.BackupTarget, b.ko.Spec.BackupTarget)
 		}
 	}
+	if ackcompare.HasNilDifference(a.ko.Spec.BackupCrossRegionReplication, b.ko.Spec.BackupCrossRegionReplication) {
+		delta.Add("Spec.BackupCrossRegionReplication", a.ko.Spec.BackupCrossRegionReplication, b.ko.Spec.BackupCrossRegionReplication)
+	} else if a.ko.Spec.BackupCrossRegionReplication != nil && b.ko.Spec.BackupCrossRegionReplication != nil {
+		if *a.ko.Spec.BackupCrossRegionReplication != *b.ko.Spec.BackupCrossRegionReplication {
+			delta.Add("Spec.BackupCrossRegionReplication", a.ko.Spec.BackupCrossRegionReplication, b.ko.Spec.BackupCrossRegionReplication)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.BackupCrossRegionReplicationDestinationRegion, b.ko.Spec.BackupCrossRegionReplicationDestinationRegion) {
+		delta.Add("Spec.BackupCrossRegionReplicationDestinationRegion", a.ko.Spec.BackupCrossRegionReplicationDestinationRegion, b.ko.Spec.BackupCrossRegionReplicationDestinationRegion)
+	} else if a.ko.Spec.BackupCrossRegionReplicationDestinationRegion != nil && b.ko.Spec.BackupCrossRegionReplicationDestinationRegion != nil {
+		if *a.ko.Spec.BackupCrossRegionReplicationDestinationRegion != *b.ko.Spec.BackupCrossRegionReplicationDestinationRegion {
+			delta.Add("Spec.BackupCrossRegionReplicationDestinationRegion", a.ko.Spec.BackupCrossRegionReplicationDestinationRegion, b.ko.Spec.BackupCrossRegionReplicationDestinationRegion)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.BackupCrossRegionReplicationRetentionPeriod, b.ko.Spec.BackupCrossRegionReplicationRetentionPeriod) {
+		delta.Add("Spec.BackupCrossRegionReplicationRetentionPeriod", a.ko.Spec.BackupCrossRegionReplicationRetentionPeriod, b.ko.Spec.BackupCrossRegionReplicationRetentionPeriod)
+	} else if a.ko.Spec.BackupCrossRegionReplicationRetentionPeriod != nil && b.ko.Spec.BackupCrossRegionReplicationRetentionPeriod != nil {
+		if *a.ko.Spec.BackupCrossRegionReplicationRetentionPeriod != *b.ko.Spec.BackupCrossRegionReplicationRetentionPeriod {
+			delta.Add("Spec.BackupCrossRegionReplicationRetentionPeriod", a.ko.Spec.BackupCrossRegionReplicationRetentionPeriod, b.ko.Spec.BackupCrossRegionReplicationRetentionPeriod)
+		}
+	}
+	if ackcompare.HasNilDifference(a.ko.Spec.BackupCrossRegionReplicationKMSKeyID, b.ko.Spec.BackupCrossRegionReplicationKMSKeyID) {
+		delta.Add("Spec.BackupCrossRegionReplicationKMSKeyID", a.ko.Spec.BackupCrossRegionReplicationKMSKeyID, b.ko.Spec.BackupCrossRegionReplicationKMSKeyID)
+	} else if a.ko.Spec.BackupCrossRegionReplicationKMSKeyID != nil && b.ko.Spec.BackupCrossRegionReplicationKMSKeyID != nil {
+		if *a.ko.Spec.BackupCrossRegionReplicationKMSKeyID != *b.ko.Spec.BackupCrossRegionReplicationKMSKeyID {
+			delta.Add("Spec.BackupCrossRegionReplicationKMSKeyID", a.ko.Spec.BackupCrossRegionReplicationKMSKeyID, b.ko.Spec.BackupCrossRegionReplicationKMSKeyID)
+		}
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.CACertificateIdentifier, b.ko.Spec.CACertificateIdentifier) {
 		delta.Add("Spec.CACertificateIdentifier", a.ko.Spec.CACertificateIdentifier, b.ko.Spec.CACertificateIdentifier)
 	} else if a.ko.Spec.CACertificateIdentifier != nil && b.ko.Spec.CACertificateIdentifier != nil {


### PR DESCRIPTION
Issue #, if available:
refs [#2725](https://github.com/aws-controllers-k8s/community/issues/2725)

Description of changes:
Adding the ability to enable cross-region replication on automated backups

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
