### PR TITLE
fix: prevent reconcile loops on dbcluster when autoMinorVersionUpgrad…

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-03-24T19:20:24Z"
-  build_hash: f0b080577c1ea030a347541b1f7a81843f33c9b6
+  build_date: "2026-04-09T05:26:09Z"
+  build_hash: a9e2ceaadfc00a742e2ea2b6d6c68348f03e52a5
   go_version: go1.26.1
-  version: v0.58.0-2-gf0b0805
+  version: v0.58.0-3-ga9e2cea
 api_directory_checksum: a35626c9dd4783afbee4b0991d2ed63ab37f7444
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/pkg/resource/db_cluster/delta.go
+++ b/pkg/resource/db_cluster/delta.go
@@ -53,6 +53,21 @@ func newResourceDelta(
 		b.ko.Spec.StorageType = aws.String("aurora")
 	}
 
+	// When autoMinorVersionUpgrade is enabled and the engine version
+	// difference is only a minor version change (same major version),
+	// normalize the desired engine version to match the latest. This
+	// prevents the delta from firing on every reconcile when AWS
+	// auto-upgrades the minor version.
+	if a.ko.Spec.EngineVersion != nil && b.ko.Spec.EngineVersion != nil {
+		autoMinorVersionUpgrade := true
+		if a.ko.Spec.AutoMinorVersionUpgrade != nil {
+			autoMinorVersionUpgrade = *a.ko.Spec.AutoMinorVersionUpgrade
+		}
+		if !requireEngineVersionUpdate(a.ko.Spec.EngineVersion, b.ko.Spec.EngineVersion, autoMinorVersionUpgrade) {
+			a.ko.Spec.EngineVersion = b.ko.Spec.EngineVersion
+		}
+	}
+
 	compareSecretReferenceChanges(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.AllocatedStorage, b.ko.Spec.AllocatedStorage) {

--- a/templates/hooks/db_cluster/delta_pre_compare.go.tpl
+++ b/templates/hooks/db_cluster/delta_pre_compare.go.tpl
@@ -4,9 +4,24 @@
     // When StorageType is set to "aurora" (default), the API doesn't return it
 
     isAuroraEngine := (b.ko.Spec.Engine != nil && (*b.ko.Spec.Engine == "aurora-mysql" || *b.ko.Spec.Engine == "aurora-postgresql"))
-    
+
     if isAuroraEngine && (a.ko.Spec.StorageType != nil && *a.ko.Spec.StorageType == "aurora" && b.ko.Spec.StorageType == nil) {
             b.ko.Spec.StorageType = aws.String("aurora")
-    }  
+    }
+
+    // When autoMinorVersionUpgrade is enabled and the engine version
+    // difference is only a minor version change (same major version),
+    // normalize the desired engine version to match the latest. This
+    // prevents the delta from firing on every reconcile when AWS
+    // auto-upgrades the minor version.
+    if a.ko.Spec.EngineVersion != nil && b.ko.Spec.EngineVersion != nil {
+        autoMinorVersionUpgrade := true
+        if a.ko.Spec.AutoMinorVersionUpgrade != nil {
+            autoMinorVersionUpgrade = *a.ko.Spec.AutoMinorVersionUpgrade
+        }
+        if !requireEngineVersionUpdate(a.ko.Spec.EngineVersion, b.ko.Spec.EngineVersion, autoMinorVersionUpgrade) {
+            a.ko.Spec.EngineVersion = b.ko.Spec.EngineVersion
+        }
+    }
 
     compareSecretReferenceChanges(delta, a, b)


### PR DESCRIPTION
…e is true

Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/2850 (specifically for the dbcluster)

Description of changes:

When autoMinorVersionUpgrade is enabled on a DBCluster, AWS may automatically upgrade the engine minor version (e.g. 16.8 → 16.11). The controller detects a diff between the desired spec and the observed state on every reconcile, logging "desired resource state has changed" and causing the dbcluster resource to be in an unhealthy state.

This PR attempts to fix that by adding a version compare with autominorupgrade check in the delta_pre_compare hook 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
