### PR TITLE
Ignore DBInstance StorageType when owned by a DBCluster

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-04-22T18:28:27Z"
-  build_hash: c55e8227b1ff5ac6a8b8e1421a2f2076fa6a77bd
+  build_date: "2026-04-27T22:01:58Z"
+  build_hash: a8dd015d9d12fcefe9bacd128eed5c2308c19e4d
   go_version: go1.26.2
-  version: v0.58.1
+  version: v0.58.1-1-ga8dd015
 api_directory_checksum: a35626c9dd4783afbee4b0991d2ed63ab37f7444
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: c5c2439f981fa274d188720d9913aba340548118
+  file_checksum: 5a894c6aa0a2477572941c1b12912e4fa3428a09
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -441,6 +441,8 @@ resources:
       StorageType:
         late_initialize:
           skip_incomplete_check: {}
+        compare:
+          is_ignored: true
       # Used by restore db instance from db snapshot
       DBSnapshotIdentifier:
         from:

--- a/generator.yaml
+++ b/generator.yaml
@@ -441,6 +441,8 @@ resources:
       StorageType:
         late_initialize:
           skip_incomplete_check: {}
+        compare:
+          is_ignored: true
       # Used by restore db instance from db snapshot
       DBSnapshotIdentifier:
         from:

--- a/pkg/resource/db_instance/delta.go
+++ b/pkg/resource/db_instance/delta.go
@@ -370,13 +370,6 @@ func newResourceDelta(
 			delta.Add("Spec.StorageThroughput", a.ko.Spec.StorageThroughput, b.ko.Spec.StorageThroughput)
 		}
 	}
-	if ackcompare.HasNilDifference(a.ko.Spec.StorageType, b.ko.Spec.StorageType) {
-		delta.Add("Spec.StorageType", a.ko.Spec.StorageType, b.ko.Spec.StorageType)
-	} else if a.ko.Spec.StorageType != nil && b.ko.Spec.StorageType != nil {
-		if *a.ko.Spec.StorageType != *b.ko.Spec.StorageType {
-			delta.Add("Spec.StorageType", a.ko.Spec.StorageType, b.ko.Spec.StorageType)
-		}
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.TDECredentialARN, b.ko.Spec.TDECredentialARN) {
 		delta.Add("Spec.TDECredentialARN", a.ko.Spec.TDECredentialARN, b.ko.Spec.TDECredentialARN)
 	} else if a.ko.Spec.TDECredentialARN != nil && b.ko.Spec.TDECredentialARN != nil {

--- a/pkg/resource/db_instance/hooks.go
+++ b/pkg/resource/db_instance/hooks.go
@@ -152,6 +152,13 @@ func customPreCompare(delta *ackcompare.Delta, a *resource, b *resource) {
 	// With the following change, we ensure we don't try to update the following fields id DBClusterIdentifier
 	// is defined.
 	if a.ko.Spec.DBClusterIdentifier == nil {
+		if ackcompare.HasNilDifference(a.ko.Spec.StorageType, b.ko.Spec.StorageType) {
+			delta.Add("Spec.StorageType", a.ko.Spec.StorageType, b.ko.Spec.StorageType)
+		} else if a.ko.Spec.StorageType != nil && b.ko.Spec.StorageType != nil {
+			if *a.ko.Spec.StorageType != *b.ko.Spec.StorageType {
+				delta.Add("Spec.StorageType", a.ko.Spec.StorageType, b.ko.Spec.StorageType)
+			}
+		}
 		if ackcompare.HasNilDifference(a.ko.Spec.DatabaseInsightsMode, b.ko.Spec.DatabaseInsightsMode) {
 			delta.Add("Spec.DatabaseInsightsMode", a.ko.Spec.DatabaseInsightsMode, b.ko.Spec.DatabaseInsightsMode)
 		} else if a.ko.Spec.DatabaseInsightsMode != nil && b.ko.Spec.DatabaseInsightsMode != nil {


### PR DESCRIPTION
Issue #, if available: [2683](https://github.com/aws-controllers-k8s/community/issues/2683#issuecomment-4235544670)

Description of changes:
When a DBInstance is owned by a DBCluster, including `Spec.StorageType` in the `ModifyDBInstance` payload results in an error similar to the below. When the DBCluster itself updates the storage type this can result in a persistent error on the underlying DBInstance(s) as the ACK Controller interprets the new value set by the DBCluster as delta and attempts to update the DBInstances storage type. This PR resolves the issue by ignoring `Spec.StorageType` in delta.go when `Spec.DBClusterIdentifier` has been set to avoid the change being detected as drift and to omit the value in any `ModifyDBInstance` payload when another value is changed.  

```
api error InvalidParameterCombination: You can''t specify the storage type for a DB instance in an Aurora DB cluster.'
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
