### PR TITLE
fix: add AllocatedStorage to customPreCompare delta check

### DIFF
--- a/pkg/resource/db_instance/hooks.go
+++ b/pkg/resource/db_instance/hooks.go
@@ -168,6 +168,14 @@ func customPreCompare(delta *ackcompare.Delta, a *resource, b *resource) {
 			}
 		}
 
+		if ackcompare.HasNilDifference(a.ko.Spec.AllocatedStorage, b.ko.Spec.AllocatedStorage) {
+			delta.Add("Spec.AllocatedStorage", a.ko.Spec.AllocatedStorage, b.ko.Spec.AllocatedStorage)
+		} else if a.ko.Spec.AllocatedStorage != nil && b.ko.Spec.AllocatedStorage != nil {
+			if *a.ko.Spec.AllocatedStorage != *b.ko.Spec.AllocatedStorage {
+				delta.Add("Spec.AllocatedStorage", a.ko.Spec.AllocatedStorage, b.ko.Spec.AllocatedStorage)
+			}
+		}
+
 		if ackcompare.HasNilDifference(a.ko.Spec.MaxAllocatedStorage, b.ko.Spec.MaxAllocatedStorage) {
 			delta.Add("Spec.MaxAllocatedStorage", a.ko.Spec.MaxAllocatedStorage, b.ko.Spec.MaxAllocatedStorage)
 		} else if a.ko.Spec.MaxAllocatedStorage != nil && b.ko.Spec.MaxAllocatedStorage != nil {

--- a/test/e2e/tests/test_db_instance.py
+++ b/test/e2e/tests/test_db_instance.py
@@ -507,3 +507,33 @@ class TestDBInstance:
         assert latest is not None
         assert latest['DBInstanceStatus'] == 'available'
         assert latest['MultiAZ'] is True
+
+    def test_update_allocated_storage(
+            self,
+            postgres14_t3_micro_instance,
+    ):
+        (ref, cr, _) = postgres14_t3_micro_instance
+        db_instance_id = cr["spec"]["dbInstanceIdentifier"]
+
+        # Wait for the resource to get synced
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES)
+
+        latest = db_instance.get(db_instance_id)
+        assert latest is not None
+        assert latest['DBInstanceStatus'] == 'available'
+        assert latest['AllocatedStorage'] == 5
+
+        updates = {
+            "spec": {"allocatedStorage": 10},
+        }
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(35)
+
+        condition.assert_not_synced(ref)
+        cr = k8s.get_resource(ref)
+        assert cr is not None
+        assert cr['spec']['allocatedStorage'] == 10
+
+        latest = db_instance.get(db_instance_id)
+        assert latest is not None
+        assert latest['PendingModifiedValues']['AllocatedStorage'] == 10


### PR DESCRIPTION
Issue [#2845](https://github.com/aws-controllers-k8s/community/issues/2845)

Description of changes:
AllocatedStorage was marked compare.is_ignored in generator.yaml but
was never added to the customPreCompare hook, so changes to
allocatedStorage produced an empty delta and no ModifyDBInstance call.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
