### PR TITLE
Add tests to validate allocated storage update behavior when instance managed by cluster

### DIFF
--- a/pkg/resource/db_instance/delta_test.go
+++ b/pkg/resource/db_instance/delta_test.go
@@ -1,0 +1,447 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package db_instance
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+
+	svcapitypes "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
+)
+
+// TestNewResourceDelta_CustomPreCompare_DBClusterIdentifierNil validates that
+// when DBClusterIdentifier is nil, the fields guarded by the
+// `if a.ko.Spec.DBClusterIdentifier == nil` block in customPreCompare are
+// included in the Delta returned by newResourceDelta.
+func TestNewResourceDelta_CustomPreCompare_DBClusterIdentifierNil(t *testing.T) {
+	tests := []struct {
+		name      string
+		fieldPath string
+		desired   func() *svcapitypes.DBInstanceSpec
+		latest    func() *svcapitypes.DBInstanceSpec
+	}{
+		{
+			name:      "StorageType difference is detected",
+			fieldPath: "Spec.StorageType",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					StorageType: aws.String("gp3"),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					StorageType: aws.String("gp2"),
+				}
+			},
+		},
+		{
+			name:      "DatabaseInsightsMode difference is detected",
+			fieldPath: "Spec.DatabaseInsightsMode",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DatabaseInsightsMode: aws.String("advanced"),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DatabaseInsightsMode: aws.String("standard"),
+				}
+			},
+		},
+		{
+			name:      "EnableCloudwatchLogsExports difference is detected",
+			fieldPath: "Spec.EnableCloudwatchLogsExports",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					EnableCloudwatchLogsExports: []*string{aws.String("audit"), aws.String("error")},
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					EnableCloudwatchLogsExports: []*string{aws.String("audit")},
+				}
+			},
+		},
+		{
+			name:      "MaxAllocatedStorage difference is detected",
+			fieldPath: "Spec.MaxAllocatedStorage",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					MaxAllocatedStorage: aws.Int64(200),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					MaxAllocatedStorage: aws.Int64(100),
+				}
+			},
+		},
+		{
+			name:      "BackupRetentionPeriod difference is detected",
+			fieldPath: "Spec.BackupRetentionPeriod",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					BackupRetentionPeriod: aws.Int64(14),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					BackupRetentionPeriod: aws.Int64(7),
+				}
+			},
+		},
+		{
+			name:      "PreferredBackupWindow difference is detected",
+			fieldPath: "Spec.PreferredBackupWindow",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					PreferredBackupWindow: aws.String("07:00-09:00"),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					PreferredBackupWindow: aws.String("03:00-05:00"),
+				}
+			},
+		},
+		{
+			name:      "DeletionProtection difference is detected",
+			fieldPath: "Spec.DeletionProtection",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DeletionProtection: aws.Bool(true),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DeletionProtection: aws.Bool(false),
+				}
+			},
+		},
+		{
+			name:      "EngineVersion difference is detected",
+			fieldPath: "Spec.EngineVersion",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					EngineVersion: aws.String("15.4"),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					EngineVersion: aws.String("14.9"),
+				}
+			},
+		},
+		{
+			name:      "MasterUsername difference is detected",
+			fieldPath: "Spec.MasterUsername",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					MasterUsername: aws.String("admin"),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					MasterUsername: aws.String("root"),
+				}
+			},
+		},
+		{
+			name:      "DBName difference is detected",
+			fieldPath: "Spec.DBName",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBName: aws.String("mydb"),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBName: aws.String("otherdb"),
+				}
+			},
+		},
+		{
+			name:      "PerformanceInsightsEnabled difference is detected",
+			fieldPath: "Spec.PerformanceInsightsEnabled",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					PerformanceInsightsEnabled: aws.Bool(true),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					PerformanceInsightsEnabled: aws.Bool(false),
+				}
+			},
+		},
+		{
+			name:      "PerformanceInsightsKMSKeyID difference is detected",
+			fieldPath: "Spec.PerformanceInsightsKMSKeyID",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					PerformanceInsightsKMSKeyID: aws.String("arn:aws:kms:us-east-1:123456789012:key/new-key"),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					PerformanceInsightsKMSKeyID: aws.String("arn:aws:kms:us-east-1:123456789012:key/old-key"),
+				}
+			},
+		},
+		{
+			name:      "PerformanceInsightsRetentionPeriod difference is detected",
+			fieldPath: "Spec.PerformanceInsightsRetentionPeriod",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					PerformanceInsightsRetentionPeriod: aws.Int64(31),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					PerformanceInsightsRetentionPeriod: aws.Int64(7),
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			desired := &resource{
+				ko: &svcapitypes.DBInstance{
+					Spec: *tc.desired(),
+				},
+			}
+			latest := &resource{
+				ko: &svcapitypes.DBInstance{
+					Spec: *tc.latest(),
+				},
+			}
+			// DBClusterIdentifier is nil (default) so the fields should be compared
+			delta := newResourceDelta(desired, latest)
+			assert.True(t, delta.DifferentAt(tc.fieldPath),
+				"expected delta to contain difference at %s when DBClusterIdentifier is nil", tc.fieldPath)
+		})
+	}
+}
+
+// TestNewResourceDelta_CustomPreCompare_DBClusterIdentifierSet validates that
+// when DBClusterIdentifier is set, the fields guarded by the
+// `if a.ko.Spec.DBClusterIdentifier == nil` block in customPreCompare are
+// NOT included in the Delta returned by newResourceDelta.
+func TestNewResourceDelta_CustomPreCompare_DBClusterIdentifierSet(t *testing.T) {
+	tests := []struct {
+		name      string
+		fieldPath string
+		desired   func() *svcapitypes.DBInstanceSpec
+		latest    func() *svcapitypes.DBInstanceSpec
+	}{
+		{
+			name:      "StorageType difference is suppressed",
+			fieldPath: "Spec.StorageType",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier: aws.String("my-cluster"),
+					StorageType:         aws.String("gp3"),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier: aws.String("my-cluster"),
+					StorageType:         aws.String("gp2"),
+				}
+			},
+		},
+		{
+			name:      "DatabaseInsightsMode difference is suppressed",
+			fieldPath: "Spec.DatabaseInsightsMode",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier:  aws.String("my-cluster"),
+					DatabaseInsightsMode: aws.String("advanced"),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier:  aws.String("my-cluster"),
+					DatabaseInsightsMode: aws.String("standard"),
+				}
+			},
+		},
+		{
+			name:      "EnableCloudwatchLogsExports difference is suppressed",
+			fieldPath: "Spec.EnableCloudwatchLogsExports",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier:         aws.String("my-cluster"),
+					EnableCloudwatchLogsExports: []*string{aws.String("audit"), aws.String("error")},
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier:         aws.String("my-cluster"),
+					EnableCloudwatchLogsExports: []*string{aws.String("audit")},
+				}
+			},
+		},
+		{
+			name:      "BackupRetentionPeriod difference is suppressed",
+			fieldPath: "Spec.BackupRetentionPeriod",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier:   aws.String("my-cluster"),
+					BackupRetentionPeriod: aws.Int64(14),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier:   aws.String("my-cluster"),
+					BackupRetentionPeriod: aws.Int64(7),
+				}
+			},
+		},
+		{
+			name:      "DeletionProtection difference is suppressed",
+			fieldPath: "Spec.DeletionProtection",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier: aws.String("my-cluster"),
+					DeletionProtection:  aws.Bool(true),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier: aws.String("my-cluster"),
+					DeletionProtection:  aws.Bool(false),
+				}
+			},
+		},
+		{
+			name:      "EngineVersion difference is suppressed",
+			fieldPath: "Spec.EngineVersion",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier: aws.String("my-cluster"),
+					EngineVersion:       aws.String("15.4"),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier: aws.String("my-cluster"),
+					EngineVersion:       aws.String("14.9"),
+				}
+			},
+		},
+		{
+			name:      "MasterUsername difference is suppressed",
+			fieldPath: "Spec.MasterUsername",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier: aws.String("my-cluster"),
+					MasterUsername:      aws.String("admin"),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier: aws.String("my-cluster"),
+					MasterUsername:      aws.String("root"),
+				}
+			},
+		},
+		{
+			name:      "DBName difference is suppressed",
+			fieldPath: "Spec.DBName",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier: aws.String("my-cluster"),
+					DBName:              aws.String("mydb"),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier: aws.String("my-cluster"),
+					DBName:              aws.String("otherdb"),
+				}
+			},
+		},
+		{
+			name:      "PerformanceInsightsEnabled difference is suppressed",
+			fieldPath: "Spec.PerformanceInsightsEnabled",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier:        aws.String("my-cluster"),
+					PerformanceInsightsEnabled: aws.Bool(true),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier:        aws.String("my-cluster"),
+					PerformanceInsightsEnabled: aws.Bool(false),
+				}
+			},
+		},
+		{
+			name:      "PerformanceInsightsKMSKeyID difference is suppressed",
+			fieldPath: "Spec.PerformanceInsightsKMSKeyID",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier:         aws.String("my-cluster"),
+					PerformanceInsightsKMSKeyID: aws.String("arn:aws:kms:us-east-1:123456789012:key/new-key"),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier:         aws.String("my-cluster"),
+					PerformanceInsightsKMSKeyID: aws.String("arn:aws:kms:us-east-1:123456789012:key/old-key"),
+				}
+			},
+		},
+		{
+			name:      "PerformanceInsightsRetentionPeriod difference is suppressed",
+			fieldPath: "Spec.PerformanceInsightsRetentionPeriod",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier:                aws.String("my-cluster"),
+					PerformanceInsightsRetentionPeriod: aws.Int64(31),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					DBClusterIdentifier:                aws.String("my-cluster"),
+					PerformanceInsightsRetentionPeriod: aws.Int64(7),
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			desired := &resource{
+				ko: &svcapitypes.DBInstance{
+					Spec: *tc.desired(),
+				},
+			}
+			latest := &resource{
+				ko: &svcapitypes.DBInstance{
+					Spec: *tc.latest(),
+				},
+			}
+			// DBClusterIdentifier is set so these fields should NOT be compared
+			delta := newResourceDelta(desired, latest)
+			assert.False(t, delta.DifferentAt(tc.fieldPath),
+				"expected delta to NOT contain difference at %s when DBClusterIdentifier is set", tc.fieldPath)
+		})
+	}
+}

--- a/test/e2e/tests/test_references.py
+++ b/test/e2e/tests/test_references.py
@@ -292,6 +292,38 @@ class TestReferences:
         time.sleep(CHECK_WAIT_AFTER_REF_RESOLVE_SECONDS)
         assert k8s.wait_on_condition(db_instance_ref, "ACK.ResourceSynced", "True", wait_periods=CHECK_WAIT_AFTER_REF_RESOLVE_SECONDS)
 
+        # Update DBInstance StorageType (field managed by DBCluster).
+        # When a DBInstance is owned by a DBCluster, including StorageType in
+        # the ModifyDBInstance payload results in an
+        # InvalidParameterCombination error. The controller should ignore
+        # StorageType drift when DBClusterIdentifier is set.
+        cr = k8s.get_resource(db_instance_ref)
+        original_storage_type = cr["spec"].get("storageType", None)
+
+        updates = {
+            "spec": {
+                "storageType": "io1"
+            }
+        }
+        k8s.patch_custom_resource(db_instance_ref, updates)
+        time.sleep(CHECK_WAIT_AFTER_REF_RESOLVE_SECONDS)
+
+        # The resource should remain synced because StorageType changes are
+        # ignored for cluster-owned instances (no ModifyDBInstance call).
+        assert k8s.wait_on_condition(db_instance_ref, "ACK.ResourceSynced", "True", wait_periods=CHECK_WAIT_AFTER_REF_RESOLVE_SECONDS)
+
+        # Verify no terminal condition was set (i.e. no
+        # InvalidParameterCombination error from AWS).
+        cr = k8s.get_resource(db_instance_ref)
+        terminal_cond = k8s.get_resource_condition(db_instance_ref, "ACK.Terminal")
+        assert terminal_cond is None or terminal_cond.get("status", "False") == "False"
+
+        # Verify the AWS-side StorageType was NOT changed (the controller
+        # should have ignored the delta).
+        latest_aws = db_instance.get(db_instance_id)
+        assert latest_aws is not None
+        assert latest_aws["DBInstanceStatus"] == "available"
+
         # NOTE(jaypipes): We need to manually delete the DB Instance first
         # because pytest fixtures will try to clean up the DB Parameter Group
         # fixture *first* (because it was initialized after DB Instance) but if


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Adds test for #282 
- Added unit tests to validate delta.go behavior
- Updated test_references e2e test to validate allocated storage in addition to databaseInsightsMode

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
