### PR TITLE
Fix DBInstance AWS defaults causing permanent diff after adoption via adopt-or-create

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-04-30T16:49:35Z"
-  build_hash: 32cbc5732e8a0441fc485c2abe81a96b4111c0ae
+  build_date: "2026-05-12T00:11:29Z"
+  build_hash: ece451c52fa72a9f7cfca3b086b8a4729b592ae4
   go_version: go1.26.2
-  version: v0.58.1-2-g32cbc57
+  version: v0.58.1-4-gece451c
 api_directory_checksum: a35626c9dd4783afbee4b0991d2ed63ab37f7444
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 5a894c6aa0a2477572941c1b12912e4fa3428a09
+  file_checksum: 30872f6b99dd1d34d9207aa8f716b7196962550d
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2026-05-12T00:11:29Z"
+  build_date: "2026-05-12T17:28:30Z"
   build_hash: ece451c52fa72a9f7cfca3b086b8a4729b592ae4
   go_version: go1.26.2
   version: v0.58.1-4-gece451c
@@ -7,7 +7,7 @@ api_directory_checksum: a35626c9dd4783afbee4b0991d2ed63ab37f7444
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 30872f6b99dd1d34d9207aa8f716b7196962550d
+  file_checksum: d67d4cd541e5ed1f67765c514735d79f5e089fa3
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -443,6 +443,9 @@ resources:
           skip_incomplete_check: {}
         compare:
           is_ignored: true
+      MonitoringInterval:
+        late_initialize:
+          skip_incomplete_check: {}
       # Used by restore db instance from db snapshot
       DBSnapshotIdentifier:
         from:

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -446,6 +446,12 @@ resources:
       MonitoringInterval:
         late_initialize:
           skip_incomplete_check: {}
+      PubliclyAccessible:
+        late_initialize:
+          skip_incomplete_check: {}
+      CopyTagsToSnapshot:
+        late_initialize:
+          skip_incomplete_check: {}
       # Used by restore db instance from db snapshot
       DBSnapshotIdentifier:
         from:

--- a/generator.yaml
+++ b/generator.yaml
@@ -443,6 +443,9 @@ resources:
           skip_incomplete_check: {}
         compare:
           is_ignored: true
+      MonitoringInterval:
+        late_initialize:
+          skip_incomplete_check: {}
       # Used by restore db instance from db snapshot
       DBSnapshotIdentifier:
         from:

--- a/generator.yaml
+++ b/generator.yaml
@@ -446,6 +446,12 @@ resources:
       MonitoringInterval:
         late_initialize:
           skip_incomplete_check: {}
+      PubliclyAccessible:
+        late_initialize:
+          skip_incomplete_check: {}
+      CopyTagsToSnapshot:
+        late_initialize:
+          skip_incomplete_check: {}
       # Used by restore db instance from db snapshot
       DBSnapshotIdentifier:
         from:

--- a/pkg/resource/db_instance/manager.go
+++ b/pkg/resource/db_instance/manager.go
@@ -50,7 +50,7 @@ var (
 // +kubebuilder:rbac:groups=rds.services.k8s.aws,resources=dbinstances,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rds.services.k8s.aws,resources=dbinstances/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{"AllocatedStorage", "AutoMinorVersionUpgrade", "AvailabilityZone", "BackupRetentionPeriod", "BackupTarget", "CACertificateIdentifier", "DBName", "DatabaseInsightsMode", "DeletionProtection", "EngineVersion", "IOPS", "KMSKeyID", "LicenseModel", "MasterUsername", "MonitoringInterval", "MultiAZ", "NetworkType", "PerformanceInsightsEnabled", "PerformanceInsightsKMSKeyID", "PerformanceInsightsRetentionPeriod", "PreferredBackupWindow", "PreferredMaintenanceWindow", "StorageEncrypted", "StorageThroughput", "StorageType"}
+var lateInitializeFieldNames = []string{"AllocatedStorage", "AutoMinorVersionUpgrade", "AvailabilityZone", "BackupRetentionPeriod", "BackupTarget", "CACertificateIdentifier", "CopyTagsToSnapshot", "DBName", "DatabaseInsightsMode", "DeletionProtection", "EngineVersion", "IOPS", "KMSKeyID", "LicenseModel", "MasterUsername", "MonitoringInterval", "MultiAZ", "NetworkType", "PerformanceInsightsEnabled", "PerformanceInsightsKMSKeyID", "PerformanceInsightsRetentionPeriod", "PreferredBackupWindow", "PreferredMaintenanceWindow", "PubliclyAccessible", "StorageEncrypted", "StorageThroughput", "StorageType"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -277,6 +277,9 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	if observedKo.Spec.CACertificateIdentifier != nil && latestKo.Spec.CACertificateIdentifier == nil {
 		latestKo.Spec.CACertificateIdentifier = observedKo.Spec.CACertificateIdentifier
 	}
+	if observedKo.Spec.CopyTagsToSnapshot != nil && latestKo.Spec.CopyTagsToSnapshot == nil {
+		latestKo.Spec.CopyTagsToSnapshot = observedKo.Spec.CopyTagsToSnapshot
+	}
 	if observedKo.Spec.DBName != nil && latestKo.Spec.DBName == nil {
 		latestKo.Spec.DBName = observedKo.Spec.DBName
 	}
@@ -324,6 +327,9 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	}
 	if observedKo.Spec.PreferredMaintenanceWindow != nil && latestKo.Spec.PreferredMaintenanceWindow == nil {
 		latestKo.Spec.PreferredMaintenanceWindow = observedKo.Spec.PreferredMaintenanceWindow
+	}
+	if observedKo.Spec.PubliclyAccessible != nil && latestKo.Spec.PubliclyAccessible == nil {
+		latestKo.Spec.PubliclyAccessible = observedKo.Spec.PubliclyAccessible
 	}
 	if observedKo.Spec.StorageEncrypted != nil && latestKo.Spec.StorageEncrypted == nil {
 		latestKo.Spec.StorageEncrypted = observedKo.Spec.StorageEncrypted

--- a/pkg/resource/db_instance/manager.go
+++ b/pkg/resource/db_instance/manager.go
@@ -50,7 +50,7 @@ var (
 // +kubebuilder:rbac:groups=rds.services.k8s.aws,resources=dbinstances,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rds.services.k8s.aws,resources=dbinstances/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{"AllocatedStorage", "AutoMinorVersionUpgrade", "AvailabilityZone", "BackupRetentionPeriod", "BackupTarget", "CACertificateIdentifier", "DBName", "DatabaseInsightsMode", "DeletionProtection", "EngineVersion", "IOPS", "KMSKeyID", "LicenseModel", "MasterUsername", "MultiAZ", "NetworkType", "PerformanceInsightsEnabled", "PerformanceInsightsKMSKeyID", "PerformanceInsightsRetentionPeriod", "PreferredBackupWindow", "PreferredMaintenanceWindow", "StorageEncrypted", "StorageThroughput", "StorageType"}
+var lateInitializeFieldNames = []string{"AllocatedStorage", "AutoMinorVersionUpgrade", "AvailabilityZone", "BackupRetentionPeriod", "BackupTarget", "CACertificateIdentifier", "DBName", "DatabaseInsightsMode", "DeletionProtection", "EngineVersion", "IOPS", "KMSKeyID", "LicenseModel", "MasterUsername", "MonitoringInterval", "MultiAZ", "NetworkType", "PerformanceInsightsEnabled", "PerformanceInsightsKMSKeyID", "PerformanceInsightsRetentionPeriod", "PreferredBackupWindow", "PreferredMaintenanceWindow", "StorageEncrypted", "StorageThroughput", "StorageType"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -300,6 +300,9 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	}
 	if observedKo.Spec.MasterUsername != nil && latestKo.Spec.MasterUsername == nil {
 		latestKo.Spec.MasterUsername = observedKo.Spec.MasterUsername
+	}
+	if observedKo.Spec.MonitoringInterval != nil && latestKo.Spec.MonitoringInterval == nil {
+		latestKo.Spec.MonitoringInterval = observedKo.Spec.MonitoringInterval
 	}
 	if observedKo.Spec.MultiAZ != nil && latestKo.Spec.MultiAZ == nil {
 		latestKo.Spec.MultiAZ = observedKo.Spec.MultiAZ

--- a/test/e2e/resources/db_instance_postgres17_adopt.yaml
+++ b/test/e2e/resources/db_instance_postgres17_adopt.yaml
@@ -1,0 +1,17 @@
+apiVersion: rds.services.k8s.aws/v1alpha1
+kind: DBInstance
+metadata:
+  annotations:
+    services.k8s.aws/adoption-policy: adopt-or-create
+    services.k8s.aws/deletion-policy: retain
+  name: $DB_INSTANCE_ID
+spec:
+  allocatedStorage: 20
+  dbInstanceClass: db.t4g.micro
+  dbInstanceIdentifier: $DB_INSTANCE_ID
+  engine: postgres
+  engineVersion: "17"
+  manageMasterUserPassword: true
+  masterUsername: dbadmin
+  multiAZ: false
+  storageType: gp2

--- a/test/e2e/tests/test_db_instance_adopt.py
+++ b/test/e2e/tests/test_db_instance_adopt.py
@@ -121,7 +121,7 @@ class TestDBInstanceAdoption:
             assert latest['DBInstanceClass'] == 'db.t4g.micro'
             assert latest['Engine'] == 'postgres'
             assert latest['EngineVersion'].startswith('17')
-            assert latest['ManageMasterUserPassword'] is True
+            assert 'MasterUserSecret' in latest
             assert latest['MasterUsername'] == 'dbadmin'
             assert latest['MultiAZ'] is False
             assert latest['StorageType'] == 'gp2'

--- a/test/e2e/tests/test_db_instance_adopt.py
+++ b/test/e2e/tests/test_db_instance_adopt.py
@@ -1,0 +1,155 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Integration tests for the RDS API DBInstance resource adoption via
+adopt-or-create policy.
+
+This test uses the same adopt-or-create manifest for both stages:
+1. First apply — no existing AWS resource, so adopt-or-create creates it.
+2. Delete the K8s CR with retain policy — AWS instance stays alive.
+3. Second apply — AWS resource exists, so adopt-or-create adopts it.
+4. Validate the adopted resource reaches a synced state and spec fields match.
+"""
+
+import time
+
+import boto3
+import pytest
+
+from acktest.k8s import resource as k8s
+from acktest.resources import random_suffix_name
+from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_rds_resource
+from e2e.replacement_values import REPLACEMENT_VALUES
+from e2e import condition
+from e2e import db_instance
+
+RESOURCE_PLURAL = 'dbinstances'
+
+MAX_WAIT_FOR_SYNCED_MINUTES = 20
+DELETE_WAIT_AFTER_SECONDS = 30
+
+
+@service_marker
+class TestDBInstanceAdoption:
+    def test_adopt_or_create_reaches_synced(self):
+        """Validates that when adopting an existing DBInstance with
+        adopt-or-create, the resource reaches a synced state and the spec
+        fields explicitly set in the manifest match the AWS resource.
+
+        Uses the same manifest for both initial creation and subsequent
+        adoption to ensure spec parity.
+        """
+        db_instance_id = random_suffix_name("pg17-adopt", 24)
+
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements["DB_INSTANCE_ID"] = db_instance_id
+
+        resource_data = load_rds_resource(
+            "db_instance_postgres17_adopt",
+            additional_replacements=replacements,
+        )
+
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            db_instance_id, namespace="default",
+        )
+
+        try:
+            # --- Stage 1: Initial create via adopt-or-create ---
+            k8s.create_custom_resource(ref, resource_data)
+            cr = k8s.wait_resource_consumed_by_controller(ref)
+
+            assert cr is not None
+            assert k8s.get_resource_exists(ref)
+
+            # Wait for the resource to reach synced state (instance available)
+            assert k8s.wait_on_condition(
+                ref, "ACK.ResourceSynced", "True",
+                wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES,
+            )
+
+            latest = db_instance.get(db_instance_id)
+            assert latest is not None
+            assert latest['DBInstanceStatus'] == 'available'
+
+            # --- Stage 2: Delete K8s CR, retain AWS resource ---
+            _, deleted = k8s.delete_custom_resource(ref, 3, 10)
+            assert deleted
+            time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+            # Confirm K8s resource is gone but AWS instance persists
+            assert not k8s.get_resource_exists(ref)
+            latest = db_instance.get(db_instance_id)
+            assert latest is not None
+            assert latest['DBInstanceStatus'] == 'available'
+
+            # --- Stage 3: Re-apply same manifest to adopt existing instance ---
+            k8s.create_custom_resource(ref, resource_data)
+            cr = k8s.wait_resource_consumed_by_controller(ref)
+
+            assert cr is not None
+            assert k8s.get_resource_exists(ref)
+
+            # --- Stage 4: Validate adoption reaches synced state ---
+            assert k8s.wait_on_condition(
+                ref, "ACK.ResourceSynced", "True",
+                wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES,
+            )
+
+            cr = k8s.get_resource(ref)
+            assert cr is not None
+            assert 'status' in cr
+            assert 'dbInstanceStatus' in cr['status']
+            assert cr['status']['dbInstanceStatus'] == 'available'
+            condition.assert_synced(ref)
+
+            # Verify that spec fields explicitly set in the manifest match AWS
+            latest = db_instance.get(db_instance_id)
+            assert latest is not None
+            assert latest['DBInstanceStatus'] == 'available'
+            assert latest['AllocatedStorage'] == 20
+            assert latest['DBInstanceClass'] == 'db.t4g.micro'
+            assert latest['Engine'] == 'postgres'
+            assert latest['EngineVersion'].startswith('17')
+            assert latest['ManageMasterUserPassword'] is True
+            assert latest['MasterUsername'] == 'dbadmin'
+            assert latest['MultiAZ'] is False
+            assert latest['StorageType'] == 'gp2'
+
+            # Verify annotations are preserved
+            assert cr['metadata']['annotations'].get(
+                'services.k8s.aws/adoption-policy'
+            ) == 'adopt-or-create'
+            assert cr['metadata']['annotations'].get(
+                'services.k8s.aws/deletion-policy'
+            ) == 'retain'
+
+        finally:
+            # Cleanup: delete K8s resource if it still exists
+            try:
+                _, deleted = k8s.delete_custom_resource(ref, 3, 10)
+            except:
+                pass
+            time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+            # Delete the AWS instance directly since retain policy keeps it
+            c = boto3.client('rds')
+            try:
+                c.delete_db_instance(
+                    DBInstanceIdentifier=db_instance_id,
+                    SkipFinalSnapshot=True,
+                    DeleteAutomatedBackups=True,
+                )
+                db_instance.wait_until_deleted(db_instance_id)
+            except c.exceptions.DBInstanceNotFoundFault:
+                pass


### PR DESCRIPTION
Issue #, if available: [2617](https://github.com/aws-controllers-k8s/community/issues/2617)

Description of changes:
Adds MonitoringInterval, PubliclyAccessible, and CopyTagsToSnapshot to the late initialization configuration for DBInstance. Without this, adopting an existing DBInstance with `adopt-or-create` without explicitly setting the field results in a permanent diff. The controller consistently sees these empty fields as drifted from the defaults set by AWS. With the PR the controller will pick up the AWS default values after adoption when unset preventing subsequent reconciliation loops from incorrectly seeing an erroneous delta. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
