### PR TITLE
fix: include AutoMinorVersionUpgrade in DBCluster ModifyDBCluster payload

### DIFF
--- a/pkg/resource/db_cluster/custom_update.go
+++ b/pkg/resource/db_cluster/custom_update.go
@@ -528,6 +528,9 @@ func (rm *resourceManager) newCustomUpdateRequestPayload(
 
 	res.ApplyImmediately = aws.Bool(true)
 	res.AllowMajorVersionUpgrade = aws.Bool(true)
+	if desired.ko.Spec.AutoMinorVersionUpgrade != nil && delta.DifferentAt("Spec.AutoMinorVersionUpgrade") {
+		res.AutoMinorVersionUpgrade = desired.ko.Spec.AutoMinorVersionUpgrade
+	}
 	if desired.ko.Spec.BacktrackWindow != nil && delta.DifferentAt("Spec.BacktrackWindow") {
 		res.BacktrackWindow = desired.ko.Spec.BacktrackWindow
 	}

--- a/test/e2e/tests/test_db_cluster.py
+++ b/test/e2e/tests/test_db_cluster.py
@@ -301,6 +301,21 @@ class TestDBCluster:
         assert latest is not None
         assert latest["IAMDatabaseAuthenticationEnabled"] == True
 
+        assert latest["AutoMinorVersionUpgrade"] == False
+        k8s.patch_custom_resource(
+            ref,
+            {"spec": {"autoMinorVersionUpgrade": True}},
+        )
+
+        db_cluster.wait_until(
+            db_cluster_id,
+            db_cluster.AttributeMatcher("AutoMinorVersionUpgrade", True),
+        )
+
+        latest = db_cluster.get(db_cluster_id)
+        assert latest is not None
+        assert latest["AutoMinorVersionUpgrade"] == True
+
     def test_enable_cloudwatch_logs_exports(
         self, aurora_postgres_cluster,
     ):


### PR DESCRIPTION
Description of changes:
The custom update function was missing AutoMinorVersionUpgrade from the
ModifyDBCluster input, so changes to this field were detected as a delta
but never actually sent to the API.

Resolves aws-controllers-k8s/community#2841

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
