### PR TITLE
feat: add DBInstanceParameterGroupName field to DBCluster

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-08-04T17:30:04Z"
+  build_date: "2026-08-07T19:12:09Z"
   build_hash: db232581a560896c2dc461a244f96d5bf3191ec6
-  go_version: go1.26.5
+  go_version: go1.26.4
   version: v0.62.0
-api_directory_checksum: 81211ae123aafed5b831e83e8e420bb188895d79
+api_directory_checksum: 670f10419a6568475360d4d363d970694fc10fb8
 api_version: v1alpha1
 aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: 8bc796cb417e5f245e8f34c171853f1583e847b0
+  file_checksum: 7bc29c8300748a05f647fc8f8d92808f11fe8c40
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/db_cluster.go
+++ b/apis/v1alpha1/db_cluster.go
@@ -140,6 +140,25 @@ type DBClusterSpec struct {
 	//     group.
 	DBClusterParameterGroupName *string                                  `json:"dbClusterParameterGroupName,omitempty"`
 	DBClusterParameterGroupRef  *ackv1alpha1.AWSResourceReferenceWrapper `json:"dbClusterParameterGroupRef,omitempty"`
+	// The name of the DB parameter group to apply to all instances of the DB cluster.
+	//
+	// When you apply a parameter group using the DBInstanceParameterGroupName parameter,
+	// the DB cluster isn't rebooted automatically. Also, parameter changes are
+	// applied immediately rather than during the next maintenance window.
+	//
+	// Valid for Cluster Type: Aurora DB clusters only
+	//
+	// Default: The existing name setting
+	//
+	// Constraints:
+	//
+	//   - The DB parameter group must be in the same DB parameter group family
+	//     as this DB cluster.
+	//
+	//   - The DBInstanceParameterGroupName parameter is valid in combination with
+	//     the AllowMajorVersionUpgrade parameter for a major version upgrade only.
+	DBInstanceParameterGroupName *string                                  `json:"dbInstanceParameterGroupName,omitempty"`
+	DBInstanceParameterGroupRef  *ackv1alpha1.AWSResourceReferenceWrapper `json:"dbInstanceParameterGroupRef,omitempty"`
 	// A DB subnet group to associate with this DB cluster.
 	//
 	// This setting is required to create a Multi-AZ DB cluster.

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -202,6 +202,13 @@ resources:
         references:
           resource: DBClusterParameterGroup
           path: Spec.Name
+      DBInstanceParameterGroupName:
+        from:
+          operation: ModifyDBCluster
+          path: DBInstanceParameterGroupName
+        references:
+          resource: DBParameterGroup
+          path: Spec.Name
       DBSubnetGroupName:
         references:
           resource: DBSubnetGroup

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1686,6 +1686,16 @@ func (in *DBClusterSpec) DeepCopyInto(out *DBClusterSpec) {
 		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.DBInstanceParameterGroupName != nil {
+		in, out := &in.DBInstanceParameterGroupName, &out.DBInstanceParameterGroupName
+		*out = new(string)
+		**out = **in
+	}
+	if in.DBInstanceParameterGroupRef != nil {
+		in, out := &in.DBInstanceParameterGroupRef, &out.DBInstanceParameterGroupRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.DBSubnetGroupName != nil {
 		in, out := &in.DBSubnetGroupName, &out.DBSubnetGroupName
 		*out = new(string)

--- a/config/crd/bases/rds.services.k8s.aws_dbclusters.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbclusters.yaml
@@ -215,6 +215,43 @@ spec:
                         type: string
                     type: object
                 type: object
+              dbInstanceParameterGroupName:
+                description: |-
+                  The name of the DB parameter group to apply to all instances of the DB cluster.
+
+                  When you apply a parameter group using the DBInstanceParameterGroupName parameter,
+                  the DB cluster isn't rebooted automatically. Also, parameter changes are
+                  applied immediately rather than during the next maintenance window.
+
+                  Valid for Cluster Type: Aurora DB clusters only
+
+                  Default: The existing name setting
+
+                  Constraints:
+
+                     * The DB parameter group must be in the same DB parameter group family
+                     as this DB cluster.
+
+                     * The DBInstanceParameterGroupName parameter is valid in combination with
+                     the AllowMajorVersionUpgrade parameter for a major version upgrade only.
+                type: string
+              dbInstanceParameterGroupRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               dbSubnetGroupName:
                 description: |-
                   A DB subnet group to associate with this DB cluster.

--- a/generator.yaml
+++ b/generator.yaml
@@ -202,6 +202,13 @@ resources:
         references:
           resource: DBClusterParameterGroup
           path: Spec.Name
+      DBInstanceParameterGroupName:
+        from:
+          operation: ModifyDBCluster
+          path: DBInstanceParameterGroupName
+        references:
+          resource: DBParameterGroup
+          path: Spec.Name
       DBSubnetGroupName:
         references:
           resource: DBSubnetGroup

--- a/helm/crds/rds.services.k8s.aws_dbclusters.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbclusters.yaml
@@ -215,6 +215,43 @@ spec:
                         type: string
                     type: object
                 type: object
+              dbInstanceParameterGroupName:
+                description: |-
+                  The name of the DB parameter group to apply to all instances of the DB cluster.
+
+                  When you apply a parameter group using the DBInstanceParameterGroupName parameter,
+                  the DB cluster isn't rebooted automatically. Also, parameter changes are
+                  applied immediately rather than during the next maintenance window.
+
+                  Valid for Cluster Type: Aurora DB clusters only
+
+                  Default: The existing name setting
+
+                  Constraints:
+
+                    - The DB parameter group must be in the same DB parameter group family
+                      as this DB cluster.
+
+                    - The DBInstanceParameterGroupName parameter is valid in combination with
+                      the AllowMajorVersionUpgrade parameter for a major version upgrade only.
+                type: string
+              dbInstanceParameterGroupRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               dbSubnetGroupName:
                 description: |-
                   A DB subnet group to associate with this DB cluster.

--- a/pkg/resource/db_cluster/custom_update.go
+++ b/pkg/resource/db_cluster/custom_update.go
@@ -574,6 +574,14 @@ func (rm *resourceManager) newCustomUpdateRequestPayload(
 		}
 		if requireEngineVersionUpdate(desired.ko.Spec.EngineVersion, latest.ko.Spec.EngineVersion, autoMinorVersionUpgrade) {
 			res.EngineVersion = desired.ko.Spec.EngineVersion
+			// AWS only accepts DBInstanceParameterGroupName in combination
+			// with AllowMajorVersionUpgrade, and only for a major version
+			// upgrade. Sending it on a minor version change fails with
+			// InvalidParameterCombination.
+			if desired.ko.Spec.DBInstanceParameterGroupName != nil &&
+				isMajorVersionUpgrade(desired.ko.Spec.EngineVersion, latest.ko.Spec.EngineVersion) {
+				res.DBInstanceParameterGroupName = desired.ko.Spec.DBInstanceParameterGroupName
+			}
 		}
 	}
 	if desired.ko.Spec.MasterUserPassword != nil && delta.DifferentAt("Spec.MasterUserPassword") {
@@ -686,7 +694,14 @@ func getCloudwatchLogExportsConfigDifferences(cloudwatchLogExportsConfigDesired 
 }
 
 func requireEngineVersionUpdate(desiredEngineVersion *string, latestEngineVersion *string, autoMinorVersionUpgrade bool) bool {
-	desiredMajorEngineVersion := r.FindString(*desiredEngineVersion)
-	latestMajorEngineVersion := r.FindString(*latestEngineVersion)
-	return !autoMinorVersionUpgrade || desiredMajorEngineVersion != latestMajorEngineVersion
+	return !autoMinorVersionUpgrade || isMajorVersionUpgrade(desiredEngineVersion, latestEngineVersion)
+}
+
+// isMajorVersionUpgrade returns true when the desired engine version is in a
+// different major version family than the latest observed engine version.
+func isMajorVersionUpgrade(desiredEngineVersion *string, latestEngineVersion *string) bool {
+	if desiredEngineVersion == nil || latestEngineVersion == nil {
+		return false
+	}
+	return r.FindString(*desiredEngineVersion) != r.FindString(*latestEngineVersion)
 }

--- a/pkg/resource/db_cluster/custom_update_test.go
+++ b/pkg/resource/db_cluster/custom_update_test.go
@@ -104,3 +104,144 @@ func TestNewCustomUpdateRequestPayload_PreferredBackupWindowNotInDelta(t *testin
 	assert.NotNil(t, input)
 	assert.Nil(t, input.PreferredBackupWindow)
 }
+
+func TestNewCustomUpdateRequestPayload_DBInstanceParameterGroupName_MajorUpgrade(t *testing.T) {
+	rm := &resourceManager{}
+	ctx := context.Background()
+
+	desired := &resource{
+		ko: &svcapitypes.DBCluster{
+			Spec: svcapitypes.DBClusterSpec{
+				DBClusterIdentifier:          aws.String("test-cluster"),
+				EngineVersion:                aws.String("17.1"),
+				DBInstanceParameterGroupName: aws.String("custom-pg-17"),
+			},
+		},
+	}
+
+	latest := &resource{
+		ko: &svcapitypes.DBCluster{
+			Spec: svcapitypes.DBClusterSpec{
+				DBClusterIdentifier:          aws.String("test-cluster"),
+				EngineVersion:                aws.String("16.4"),
+				DBInstanceParameterGroupName: aws.String("custom-pg-17"),
+			},
+		},
+	}
+
+	delta := ackcompare.NewDelta()
+	delta.Add("Spec.EngineVersion", latest.ko.Spec.EngineVersion, desired.ko.Spec.EngineVersion)
+
+	input, err := rm.newCustomUpdateRequestPayload(ctx, desired, latest, delta)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, input)
+	assert.Equal(t, "17.1", *input.EngineVersion)
+	assert.Equal(t, "custom-pg-17", *input.DBInstanceParameterGroupName)
+}
+
+func TestNewCustomUpdateRequestPayload_DBInstanceParameterGroupName_NoEngineChange(t *testing.T) {
+	rm := &resourceManager{}
+	ctx := context.Background()
+
+	desired := &resource{
+		ko: &svcapitypes.DBCluster{
+			Spec: svcapitypes.DBClusterSpec{
+				DBClusterIdentifier:          aws.String("test-cluster"),
+				EngineVersion:                aws.String("16.4"),
+				DBInstanceParameterGroupName: aws.String("custom-pg-16"),
+			},
+		},
+	}
+
+	latest := &resource{
+		ko: &svcapitypes.DBCluster{
+			Spec: svcapitypes.DBClusterSpec{
+				DBClusterIdentifier: aws.String("test-cluster"),
+				EngineVersion:       aws.String("16.4"),
+			},
+		},
+	}
+
+	delta := ackcompare.NewDelta()
+	delta.Add("Spec.DBInstanceParameterGroupName", latest.ko.Spec.DBInstanceParameterGroupName, desired.ko.Spec.DBInstanceParameterGroupName)
+
+	input, err := rm.newCustomUpdateRequestPayload(ctx, desired, latest, delta)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, input)
+	assert.Nil(t, input.EngineVersion)
+	assert.Nil(t, input.DBInstanceParameterGroupName)
+}
+
+func TestNewCustomUpdateRequestPayload_DBInstanceParameterGroupName_MinorUpgrade(t *testing.T) {
+	rm := &resourceManager{}
+	ctx := context.Background()
+
+	desired := &resource{
+		ko: &svcapitypes.DBCluster{
+			Spec: svcapitypes.DBClusterSpec{
+				DBClusterIdentifier:          aws.String("test-cluster"),
+				EngineVersion:                aws.String("16.5"),
+				AutoMinorVersionUpgrade:      aws.Bool(true),
+				DBInstanceParameterGroupName: aws.String("custom-pg-16"),
+			},
+		},
+	}
+
+	latest := &resource{
+		ko: &svcapitypes.DBCluster{
+			Spec: svcapitypes.DBClusterSpec{
+				DBClusterIdentifier:     aws.String("test-cluster"),
+				EngineVersion:           aws.String("16.4"),
+				AutoMinorVersionUpgrade: aws.Bool(true),
+			},
+		},
+	}
+
+	delta := ackcompare.NewDelta()
+	delta.Add("Spec.EngineVersion", latest.ko.Spec.EngineVersion, desired.ko.Spec.EngineVersion)
+
+	input, err := rm.newCustomUpdateRequestPayload(ctx, desired, latest, delta)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, input)
+	assert.Nil(t, input.EngineVersion)
+	assert.Nil(t, input.DBInstanceParameterGroupName)
+}
+
+func TestNewCustomUpdateRequestPayload_DBInstanceParameterGroupName_MinorUpgradeAutoMinorDisabled(t *testing.T) {
+	rm := &resourceManager{}
+	ctx := context.Background()
+
+	desired := &resource{
+		ko: &svcapitypes.DBCluster{
+			Spec: svcapitypes.DBClusterSpec{
+				DBClusterIdentifier:          aws.String("test-cluster"),
+				EngineVersion:                aws.String("14.18"),
+				AutoMinorVersionUpgrade:      aws.Bool(false),
+				DBInstanceParameterGroupName: aws.String("custom-pg-14"),
+			},
+		},
+	}
+
+	latest := &resource{
+		ko: &svcapitypes.DBCluster{
+			Spec: svcapitypes.DBClusterSpec{
+				DBClusterIdentifier:     aws.String("test-cluster"),
+				EngineVersion:           aws.String("14.15"),
+				AutoMinorVersionUpgrade: aws.Bool(false),
+			},
+		},
+	}
+
+	delta := ackcompare.NewDelta()
+	delta.Add("Spec.EngineVersion", latest.ko.Spec.EngineVersion, desired.ko.Spec.EngineVersion)
+
+	input, err := rm.newCustomUpdateRequestPayload(ctx, desired, latest, delta)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, input)
+	assert.Equal(t, "14.18", *input.EngineVersion)
+	assert.Nil(t, input.DBInstanceParameterGroupName)
+}

--- a/pkg/resource/db_cluster/delta.go
+++ b/pkg/resource/db_cluster/delta.go
@@ -147,6 +147,16 @@ func newResourceDelta(
 	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.DBClusterParameterGroupRef, b.ko.Spec.DBClusterParameterGroupRef) {
 		delta.Add("Spec.DBClusterParameterGroupRef", a.ko.Spec.DBClusterParameterGroupRef, b.ko.Spec.DBClusterParameterGroupRef)
 	}
+	if ackcompare.HasNilDifference(a.ko.Spec.DBInstanceParameterGroupName, b.ko.Spec.DBInstanceParameterGroupName) {
+		delta.Add("Spec.DBInstanceParameterGroupName", a.ko.Spec.DBInstanceParameterGroupName, b.ko.Spec.DBInstanceParameterGroupName)
+	} else if a.ko.Spec.DBInstanceParameterGroupName != nil && b.ko.Spec.DBInstanceParameterGroupName != nil {
+		if *a.ko.Spec.DBInstanceParameterGroupName != *b.ko.Spec.DBInstanceParameterGroupName {
+			delta.Add("Spec.DBInstanceParameterGroupName", a.ko.Spec.DBInstanceParameterGroupName, b.ko.Spec.DBInstanceParameterGroupName)
+		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.DBInstanceParameterGroupRef, b.ko.Spec.DBInstanceParameterGroupRef) {
+		delta.Add("Spec.DBInstanceParameterGroupRef", a.ko.Spec.DBInstanceParameterGroupRef, b.ko.Spec.DBInstanceParameterGroupRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.DBSubnetGroupName, b.ko.Spec.DBSubnetGroupName) {
 		delta.Add("Spec.DBSubnetGroupName", a.ko.Spec.DBSubnetGroupName, b.ko.Spec.DBSubnetGroupName)
 	} else if a.ko.Spec.DBSubnetGroupName != nil && b.ko.Spec.DBSubnetGroupName != nil {

--- a/pkg/resource/db_cluster/references.go
+++ b/pkg/resource/db_cluster/references.go
@@ -60,6 +60,10 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 		ko.Spec.DBClusterParameterGroupName = nil
 	}
 
+	if ko.Spec.DBInstanceParameterGroupRef != nil {
+		ko.Spec.DBInstanceParameterGroupName = nil
+	}
+
 	if ko.Spec.DBSubnetGroupRef != nil {
 		ko.Spec.DBSubnetGroupName = nil
 	}
@@ -104,6 +108,12 @@ func (rm *resourceManager) ResolveReferences(
 	resourceHasReferences := false
 	err := validateReferenceFields(ko)
 	if fieldHasReferences, err := rm.resolveReferenceForDBClusterParameterGroupName(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForDBInstanceParameterGroupName(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
@@ -154,6 +164,10 @@ func validateReferenceFields(ko *svcapitypes.DBCluster) error {
 
 	if ko.Spec.DBClusterParameterGroupRef != nil && ko.Spec.DBClusterParameterGroupName != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("DBClusterParameterGroupName", "DBClusterParameterGroupRef")
+	}
+
+	if ko.Spec.DBInstanceParameterGroupRef != nil && ko.Spec.DBInstanceParameterGroupName != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("DBInstanceParameterGroupName", "DBInstanceParameterGroupRef")
 	}
 
 	if ko.Spec.DBSubnetGroupRef != nil && ko.Spec.DBSubnetGroupName != nil {
@@ -267,6 +281,97 @@ func getReferencedResourceState_DBClusterParameterGroup(
 	if obj.Spec.Name == nil {
 		return ackerr.ResourceReferenceMissingTargetFieldFor(
 			"DBClusterParameterGroup",
+			namespace, name,
+			"Spec.Name")
+	}
+	return nil
+}
+
+// resolveReferenceForDBInstanceParameterGroupName reads the resource referenced
+// from DBInstanceParameterGroupRef field and sets the DBInstanceParameterGroupName
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForDBInstanceParameterGroupName(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.DBCluster,
+) (hasReferences bool, err error) {
+	if ko.Spec.DBInstanceParameterGroupRef != nil && ko.Spec.DBInstanceParameterGroupRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.DBInstanceParameterGroupRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: DBInstanceParameterGroupRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &svcapitypes.DBParameterGroup{}
+		if err := getReferencedResourceState_DBParameterGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.DBInstanceParameterGroupName = (*string)(obj.Spec.Name)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_DBParameterGroup looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_DBParameterGroup(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.DBParameterGroup,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"DBParameterGroup",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"DBParameterGroup",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"DBParameterGroup",
+			namespace, name)
+	}
+	if obj.Spec.Name == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"DBParameterGroup",
 			namespace, name,
 			"Spec.Name")
 	}

--- a/test/e2e/resources/db_parameter_group_aurora_postgresql15.yaml
+++ b/test/e2e/resources/db_parameter_group_aurora_postgresql15.yaml
@@ -1,0 +1,8 @@
+apiVersion: rds.services.k8s.aws/v1alpha1
+kind: DBParameterGroup
+metadata:
+  name: $DB_PARAMETER_GROUP_NAME
+spec:
+  name: $DB_PARAMETER_GROUP_NAME
+  description: $DB_PARAMETER_GROUP_DESC
+  family: aurora-postgresql15

--- a/test/e2e/tests/test_db_cluster.py
+++ b/test/e2e/tests/test_db_cluster.py
@@ -21,7 +21,7 @@ import pytest
 from acktest.k8s import resource as k8s
 from acktest.resources import random_suffix_name
 from e2e import (CRD_GROUP, CRD_VERSION, condition, db_cluster,
-                 load_rds_resource, service_marker, tag)
+                 db_parameter_group, load_rds_resource, service_marker, tag)
 from e2e.fixtures import k8s_secret
 from e2e.replacement_values import REPLACEMENT_VALUES
 
@@ -51,6 +51,20 @@ DELETE_WAIT_AFTER_SECONDS = 120
 CHECK_STATUS_WAIT_SECONDS = 60*2
 
 MODIFY_WAIT_AFTER_SECONDS = 20
+
+# A major version upgrade of an Aurora PostgreSQL cluster takes considerably
+# longer than a normal modification, since Aurora snapshots and clones the
+# cluster volume before running pg_upgrade.
+MAJOR_UPGRADE_TIMEOUT_SECONDS = 60*30
+
+MAX_WAIT_FOR_SYNCED_MINUTES = 20
+
+# Must be a valid major version upgrade target for the engine version in
+# db_cluster_aurora_postgres.yaml. To refresh:
+#   aws rds describe-db-engine-versions --engine aurora-postgresql \
+#     --engine-version <current> \
+#     --query 'DBEngineVersions[].ValidUpgradeTarget[?IsMajorVersionUpgrade==`true`].EngineVersion'
+MAJOR_UPGRADE_ENGINE_VERSION = "15.18"
 
 # MUP == Master user password...
 MUP_NS = "default"
@@ -198,6 +212,40 @@ def aurora_postgres_cluster_log_exports(k8s_secret):
         pass
 
     db_cluster.wait_until_deleted(db_cluster_id)
+
+@pytest.fixture
+def aurora_postgres15_parameter_group():
+    pg_name = random_suffix_name("pg-aurora-pg15", 24)
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["DB_PARAMETER_GROUP_NAME"] = pg_name
+    replacements["DB_PARAMETER_GROUP_DESC"] = "Aurora PG 15 instance params"
+
+    resource_data = load_rds_resource(
+        "db_parameter_group_aurora_postgresql15",
+        additional_replacements=replacements,
+    )
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, 'dbparametergroups',
+        pg_name, namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+    assert cr is not None
+    assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=10)
+
+    yield (ref, pg_name)
+
+    try:
+        _, deleted = k8s.delete_custom_resource(ref, 3, 10)
+        assert deleted
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+    except:
+        pass
+
+    db_parameter_group.wait_until_deleted(pg_name)
+
 
 @service_marker
 @pytest.mark.target
@@ -523,3 +571,44 @@ class TestDBCluster:
         assert latest["DatabaseInsightsMode"] == "advanced"
         assert latest["PerformanceInsightsEnabled"] == True
         assert latest["PerformanceInsightsRetentionPeriod"] == 465
+
+    def test_major_version_upgrade_with_instance_parameter_group(
+        self, aurora_postgres_cluster, aurora_postgres15_parameter_group,
+    ):
+        ref, _, db_cluster_id, _ = aurora_postgres_cluster
+        _, pg_name = aurora_postgres15_parameter_group
+
+        db_cluster.wait_until(
+            db_cluster_id,
+            db_cluster.status_matches('available'),
+        )
+
+        current = db_cluster.get(db_cluster_id)
+        assert current is not None
+        assert not current["EngineVersion"].startswith("15.")
+
+        k8s.patch_custom_resource(
+            ref,
+            {
+                "spec": {
+                    "engineVersion": MAJOR_UPGRADE_ENGINE_VERSION,
+                    "dbInstanceParameterGroupName": pg_name,
+                },
+            },
+        )
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "False", wait_periods=3)
+
+        db_cluster.wait_until(
+            db_cluster_id,
+            db_cluster.AttributeMatcher("EngineVersion", MAJOR_UPGRADE_ENGINE_VERSION),
+            timeout_seconds=MAJOR_UPGRADE_TIMEOUT_SECONDS,
+        )
+
+        assert k8s.wait_on_condition(
+            ref, "ACK.ResourceSynced", "True",
+            wait_periods=MAX_WAIT_FOR_SYNCED_MINUTES,
+        )
+
+        latest = db_cluster.get(db_cluster_id)
+        assert latest is not None
+        assert latest["EngineVersion"] == MAJOR_UPGRADE_ENGINE_VERSION


### PR DESCRIPTION
Description of changes:
The field is sourced from ModifyDBCluster and passed to AWS only during
major engine version upgrades, enabling Aurora clusters with custom
instance parameter groups to upgrade successfully.

Mark field with compare.is_ignored to prevent infinite reconciliation
since AWS never returns it in DescribeDBClusters. 

Resolves aws-controllers-k8s/community#2778

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
