### PR TITLE
fix: prevent AllocatedStorage writeback to DBCluster spec

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-05-28T18:54:12Z"
-  build_hash: a307e8ebd9503616baf5915c744a30dc3aa227c5
-  go_version: go1.26.0
-  version: v0.59.1-4-ga307e8e
+  build_date: "2026-06-03T20:03:44Z"
+  build_hash: b26b7d212548d15b7add7e7fee44052449457e85
+  go_version: go1.26.3
+  version: v0.59.1-5-gb26b7d2
 api_directory_checksum: 9eb1602bb21828e84682ddeb8ee21a05cfa88e47
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/pkg/resource/db_cluster/custom_update.go
+++ b/pkg/resource/db_cluster/custom_update.go
@@ -118,10 +118,8 @@ func (rm *resourceManager) customUpdate(
 	} else {
 		ko.Status.ActivityStreamStatus = nil
 	}
-	if resp.DBCluster.AllocatedStorage != nil {
+	if resp.DBCluster.AllocatedStorage != nil && !isAuroraEngine(resp.DBCluster.Engine) {
 		ko.Spec.AllocatedStorage = aws.Int64(int64(*resp.DBCluster.AllocatedStorage))
-	} else {
-		ko.Spec.AllocatedStorage = nil
 	}
 	if resp.DBCluster.AssociatedRoles != nil {
 		f5 := []*svcapitypes.DBClusterRole{}

--- a/pkg/resource/db_cluster/delta.go
+++ b/pkg/resource/db_cluster/delta.go
@@ -46,10 +46,7 @@ func newResourceDelta(
 
 	// Handle special case for StorageType field for Aurora engines
 	// When StorageType is set to "aurora" (default), the API doesn't return it
-
-	isAuroraEngine := (b.ko.Spec.Engine != nil && (*b.ko.Spec.Engine == "aurora-mysql" || *b.ko.Spec.Engine == "aurora-postgresql"))
-
-	if isAuroraEngine && (a.ko.Spec.StorageType != nil && *a.ko.Spec.StorageType == "aurora" && b.ko.Spec.StorageType == nil) {
+	if isAuroraEngine(b.ko.Spec.Engine) && (a.ko.Spec.StorageType != nil && *a.ko.Spec.StorageType == "aurora" && b.ko.Spec.StorageType == nil) {
 		b.ko.Spec.StorageType = aws.String("aurora")
 	}
 

--- a/pkg/resource/db_cluster/hooks.go
+++ b/pkg/resource/db_cluster/hooks.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	svcapitypes "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
 	"github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
@@ -151,6 +152,23 @@ func clusterDeleting(r *resource) bool {
 	}
 	dbcs := *r.ko.Status.Status
 	return dbcs == StatusDeleting
+}
+
+// isAuroraEngine returns true if the engine string indicates an Aurora cluster
+// (aurora, aurora-mysql, aurora-postgresql).
+func isAuroraEngine(engine *string) bool {
+	if engine == nil {
+		return false
+	}
+	return strings.HasPrefix(*engine, "aurora")
+}
+
+// clearAuroraAllocatedStorage nils out AllocatedStorage for Aurora engines.
+// AWS always returns AllocatedStorage=1 for Aurora but rejects it on input.
+func clearAuroraAllocatedStorage(ko *svcapitypes.DBCluster) {
+	if isAuroraEngine(ko.Spec.Engine) {
+		ko.Spec.AllocatedStorage = nil
+	}
 }
 
 // syncTags keeps the resource's tags in sync
@@ -299,6 +317,7 @@ func (rm *resourceManager) restoreDbClusterFromSnapshot(
 
 	rm.setResourceFromRestoreDBClusterFromSnapshotOutput(r, resp)
 	rm.setStatusDefaults(r.ko)
+	clearAuroraAllocatedStorage(r.ko)
 
 	// We expect the DB cluster to be in 'creating' status since we just
 	// issued the call to create it, but I suppose it doesn't hurt to check
@@ -332,6 +351,7 @@ func (rm *resourceManager) restoreDbClusterToPointInTime(
 
 	rm.setResourceFromRestoreDBClusterToPointInTimeOutput(r, resp)
 	rm.setStatusDefaults(r.ko)
+	clearAuroraAllocatedStorage(r.ko)
 
 	// We expect the DB cluster to be in 'creating' status since we just
 	// issued the call to create it, but I suppose it doesn't hurt to check

--- a/pkg/resource/db_cluster/sdk.go
+++ b/pkg/resource/db_cluster/sdk.go
@@ -617,6 +617,7 @@ func (rm *resourceManager) sdkFind(
 	} else {
 		ackcondition.SetSynced(&resource{ko}, corev1.ConditionTrue, nil, nil)
 	}
+	clearAuroraAllocatedStorage(ko)
 	if len(r.ko.Spec.VPCSecurityGroupIDs) > 0 {
 		// If the desired resource has security groups specified then update the spec of the latest resource with the
 		// value from the status. This is done so that when a cluster is created without security groups and gets a
@@ -1241,6 +1242,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
+	clearAuroraAllocatedStorage(ko)
 	// set the last-applied-secret-reference annotation on the DB instance
 	// resource.
 	r := &resource{ko}

--- a/templates/hooks/db_cluster/delta_pre_compare.go.tpl
+++ b/templates/hooks/db_cluster/delta_pre_compare.go.tpl
@@ -2,10 +2,7 @@
 
     // Handle special case for StorageType field for Aurora engines
     // When StorageType is set to "aurora" (default), the API doesn't return it
-
-    isAuroraEngine := (b.ko.Spec.Engine != nil && (*b.ko.Spec.Engine == "aurora-mysql" || *b.ko.Spec.Engine == "aurora-postgresql"))
-
-    if isAuroraEngine && (a.ko.Spec.StorageType != nil && *a.ko.Spec.StorageType == "aurora" && b.ko.Spec.StorageType == nil) {
+    if isAuroraEngine(b.ko.Spec.Engine) && (a.ko.Spec.StorageType != nil && *a.ko.Spec.StorageType == "aurora" && b.ko.Spec.StorageType == nil) {
             b.ko.Spec.StorageType = aws.String("aurora")
     }
 

--- a/templates/hooks/db_cluster/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/db_cluster/sdk_create_post_set_output.go.tpl
@@ -1,3 +1,4 @@
+	clearAuroraAllocatedStorage(ko)
 	// set the last-applied-secret-reference annotation on the DB instance
 	// resource.
 	r := &resource{ko}

--- a/templates/hooks/db_cluster/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/db_cluster/sdk_read_many_post_set_output.go.tpl
@@ -13,6 +13,7 @@
 	} else {
 		ackcondition.SetSynced(&resource{ko}, corev1.ConditionTrue, nil, nil)
 	}
+	clearAuroraAllocatedStorage(ko)
 	if len(r.ko.Spec.VPCSecurityGroupIDs) > 0 {
 		// If the desired resource has security groups specified then update the spec of the latest resource with the
 		// value from the status. This is done so that when a cluster is created without security groups and gets a

--- a/test/e2e/tests/test_db_cluster.py
+++ b/test/e2e/tests/test_db_cluster.py
@@ -275,6 +275,22 @@ class TestDBCluster:
         ]
         assert latest_tags == after_update_expected_tags
 
+    def test_aurora_no_allocated_storage_writeback(
+            self, aurora_postgres_cluster,
+    ):
+        ref, _, db_cluster_id, _ = aurora_postgres_cluster
+        db_cluster.wait_until(
+            db_cluster_id,
+            db_cluster.status_matches('available'),
+        )
+
+        time.sleep(CHECK_STATUS_WAIT_SECONDS)
+
+        cr = k8s.get_resource(ref)
+        assert cr is not None
+        assert cr['spec'].get('allocatedStorage') is None
+        condition.assert_synced(ref)
+
     def test_flip_enable_iam_db_authn(
             self, aurora_postgres_cluster,
     ):


### PR DESCRIPTION
Description of changes:
AWS always returns AllocatedStorage=1 for Aurora clusters even though
it's not a user-configurable value for Aurora engines. The generated
code was writing this value back into the Kubernetes resource's Spec,
causing subsequent create retries to fail with
"AllocatedStorage isn't supported for DB engine aurora-postgresql".

Resolves aws-controllers-k8s/community#2434

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
