### PR TITLE
fix: requeue after syncing parameter overrides to refresh status

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-06-03T20:03:44Z"
-  build_hash: b26b7d212548d15b7add7e7fee44052449457e85
+  build_date: "2026-06-05T17:05:21Z"
+  build_hash: 8d8f5f2406b145d2bf19f9bba75086b2445ffe4b
   go_version: go1.26.3
-  version: v0.59.1-5-gb26b7d2
+  version: v0.59.1-6-g8d8f5f2
 api_directory_checksum: 9eb1602bb21828e84682ddeb8ee21a05cfa88e47
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/pkg/resource/db_cluster_parameter_group/hooks.go
+++ b/pkg/resource/db_cluster_parameter_group/hooks.go
@@ -53,6 +53,12 @@ var (
 		errParameterGroupJustCreated,
 		100*time.Millisecond,
 	)
+
+	errParametersModified         = fmt.Errorf("parameter overrides modified, requeuing to refresh status")
+	requeueWaitAfterParameterSync = ackrequeue.NeededAfter(
+		errParametersModified,
+		5*time.Second,
+	)
 )
 
 // customUpdate is required to fix
@@ -80,6 +86,7 @@ func (rm *resourceManager) customUpdate(
 		if err = rm.syncParameters(ctx, desired, latest); err != nil {
 			return nil, err
 		}
+		return desired, requeueWaitAfterParameterSync
 	}
 	return desired, nil
 }
@@ -301,6 +308,9 @@ func (rm *resourceManager) getParameters(
 				}
 			}
 
+			if param.ParameterValue == nil {
+				continue
+			}
 			params[pName] = param.ParameterValue
 			p := svcapitypes.Parameter{
 				ParameterName:  param.ParameterName,

--- a/pkg/resource/db_parameter_group/hooks.go
+++ b/pkg/resource/db_parameter_group/hooks.go
@@ -46,6 +46,12 @@ var (
 		errParameterGroupJustCreated,
 		100*time.Millisecond,
 	)
+
+	errParametersModified         = fmt.Errorf("parameter overrides modified, requeuing to refresh status")
+	requeueWaitAfterParameterSync = ackrequeue.NeededAfter(
+		errParametersModified,
+		5*time.Second,
+	)
 )
 
 // customUpdate is required to fix
@@ -73,6 +79,7 @@ func (rm *resourceManager) customUpdate(
 		if err = rm.syncParameters(ctx, desired, latest); err != nil {
 			return nil, err
 		}
+		return desired, requeueWaitAfterParameterSync
 	}
 	return desired, nil
 }
@@ -299,6 +306,9 @@ func (rm *resourceManager) getParameters(
 				}
 			}
 
+			if param.ParameterValue == nil {
+				continue
+			}
 			params[pName] = param.ParameterValue
 			p := svcapitypes.Parameter{
 				ParameterName:  param.ParameterName,

--- a/test/e2e/resources/db_cluster_parameter_group_aurora_postgresql14_single_param.yaml
+++ b/test/e2e/resources/db_cluster_parameter_group_aurora_postgresql14_single_param.yaml
@@ -1,0 +1,10 @@
+apiVersion: rds.services.k8s.aws/v1alpha1
+kind: DBClusterParameterGroup
+metadata:
+  name: $DB_CLUSTER_PARAMETER_GROUP_NAME
+spec:
+  name: $DB_CLUSTER_PARAMETER_GROUP_NAME
+  description: $DB_CLUSTER_PARAMETER_GROUP_DESC
+  family: aurora-postgresql14
+  parameterOverrides:
+    log_min_duration_statement: "5000"

--- a/test/e2e/resources/db_instance_postgres14_t3_micro.yaml
+++ b/test/e2e/resources/db_instance_postgres14_t3_micro.yaml
@@ -11,7 +11,7 @@ spec:
   dbInstanceClass: db.t3.micro
   dbInstanceIdentifier: $DB_INSTANCE_ID
   engine: postgres
-  engineVersion: "14.15"
+  engineVersion: "14.18"
   masterUsername: root
   masterUserPassword:
     namespace: $MASTER_USER_PASS_SECRET_NAMESPACE

--- a/test/e2e/tests/test_db_cluster_parameter_group.py
+++ b/test/e2e/tests/test_db_cluster_parameter_group.py
@@ -158,6 +158,43 @@ def aurora_pg14_mixed_source_cluster_param_group():
     db_cluster_parameter_group.wait_until_deleted(resource_name)
 
 
+@pytest.fixture
+def aurora_pg14_single_param_cluster_param_group():
+    resource_name = random_suffix_name("aurora-pg14-single", 24)
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["DB_CLUSTER_PARAMETER_GROUP_NAME"] = resource_name
+    replacements["DB_CLUSTER_PARAMETER_GROUP_DESC"] = "Test adding new parameter overrides"
+
+    resource_data = load_rds_resource(
+        "db_cluster_parameter_group_aurora_postgresql14_single_param",
+        additional_replacements=replacements,
+    )
+    logging.debug(resource_data)
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+        resource_name, namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+    time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    yield ref, cr, resource_name
+
+    try:
+        _, deleted = k8s.delete_custom_resource(ref, 3, 10)
+        assert deleted
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+    except:
+        pass
+
+    db_cluster_parameter_group.wait_until_deleted(resource_name)
+
+
 @service_marker
 @pytest.mark.canary
 class TestDBClusterParameterGroup:
@@ -418,3 +455,49 @@ class TestDBClusterParameterGroup:
         # Even if status still contains some removed parameters temporarily,
         # controller conditions should remain healthy after processing update.
         condition.assert_synced(ref)
+
+    def test_add_parameter_override_updates_status(self, aurora_pg14_single_param_cluster_param_group):
+        ref, cr, resource_name = aurora_pg14_single_param_cluster_param_group
+
+        latest = db_cluster_parameter_group.get(resource_name)
+        assert latest is not None
+
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+
+        cr = k8s.get_resource(ref)
+        assert 'status' in cr
+        assert 'parameterOverrideStatuses' in cr['status']
+        status_params = cr['status']['parameterOverrideStatuses']
+        status_param_names = [p['parameterName'] for p in status_params]
+        assert "log_min_duration_statement" in status_param_names
+
+        condition.assert_synced(ref)
+
+        new_params = {
+            "log_min_duration_statement": "5000",
+            "log_statement": "ddl",
+        }
+        updates = {
+            "spec": {
+                "parameterOverrides": new_params,
+            },
+        }
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+
+        cr = k8s.get_resource(ref)
+        assert 'status' in cr
+        assert 'parameterOverrideStatuses' in cr['status']
+        status_params = cr['status']['parameterOverrideStatuses']
+        status_param_names = [p['parameterName'] for p in status_params]
+        assert "log_min_duration_statement" in status_param_names, \
+            f"log_min_duration_statement missing from status after update: {status_param_names}"
+        assert "log_statement" in status_param_names, \
+            f"log_statement missing from parameterOverrideStatuses after adding new override: {status_param_names}"
+
+        condition.assert_synced(ref)
+
+        all_params = db_cluster_parameter_group.get_parameters(resource_name)
+        log_statement_param = [p for p in all_params if p["ParameterName"] == "log_statement"]
+        assert len(log_statement_param) == 1
+        assert log_statement_param[0]["ParameterValue"] == "ddl"


### PR DESCRIPTION
Description of changes:
customUpdate was returning desired directly after modifying parameters
in AWS. Since no subsequent ReadOne occurs after a successful update,
ParameterOverrideStatuses never reflected newly added parameters. Now
we return a requeue error so the reconciler re-runs ReadOne and picks
up the correct status from AWS.

Fixes both DBClusterParameterGroup and DBParameterGroup resources.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
