### PR TITLE
fix: prevent DBCluster Aurora AllocatedStorage reconcile loop

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-06-05T17:05:21Z"
-  build_hash: 8d8f5f2406b145d2bf19f9bba75086b2445ffe4b
+  build_date: "2026-06-12T17:01:11Z"
+  build_hash: 2970ca9b3789515150e27ab80630175a8c77cba4
   go_version: go1.26.3
-  version: v0.59.1-6-g8d8f5f2
+  version: v0.59.1-7-g2970ca9
 api_directory_checksum: 9eb1602bb21828e84682ddeb8ee21a05cfa88e47
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/pkg/resource/db_cluster/delta.go
+++ b/pkg/resource/db_cluster/delta.go
@@ -50,6 +50,13 @@ func newResourceDelta(
 		b.ko.Spec.StorageType = aws.String("aurora")
 	}
 
+	// Clear AllocatedStorage on the desired side for Aurora; the observed side
+	// is already cleared on create/read (v1.9.0+). This mainly covers clusters
+	// created before that fix, which retain a stale allocatedStorage in spec
+	// that otherwise produces a delta every reconcile ModifyDBCluster can't
+	// resolve, leaving the cluster perpetually out of sync.
+	clearAuroraAllocatedStorage(a.ko)
+
 	// When autoMinorVersionUpgrade is enabled and the engine version
 	// difference is only a minor version change (same major version),
 	// normalize the desired engine version to match the latest. This

--- a/pkg/resource/db_cluster/delta_test.go
+++ b/pkg/resource/db_cluster/delta_test.go
@@ -168,3 +168,67 @@ func TestNewResourceDelta_EngineVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestNewResourceDelta_AllocatedStorage(t *testing.T) {
+	tests := []struct {
+		name                    string
+		engine                  string
+		desiredAllocatedStorage *int64
+		latestAllocatedStorage  *int64
+		expectDifferentAt       bool
+	}{
+		{
+			name:                    "aurora with allocatedStorage in spec, observed nil",
+			engine:                  "aurora-postgresql",
+			desiredAllocatedStorage: aws.Int64(1),
+			latestAllocatedStorage:  nil,
+			expectDifferentAt:       false,
+		},
+		{
+			name:                    "aurora mysql with allocatedStorage in spec, observed nil",
+			engine:                  "aurora-mysql",
+			desiredAllocatedStorage: aws.Int64(100),
+			latestAllocatedStorage:  nil,
+			expectDifferentAt:       false,
+		},
+		{
+			name:                    "non-aurora with matching allocatedStorage",
+			engine:                  "mysql",
+			desiredAllocatedStorage: aws.Int64(100),
+			latestAllocatedStorage:  aws.Int64(100),
+			expectDifferentAt:       false,
+		},
+		{
+			name:                    "non-aurora with changed allocatedStorage",
+			engine:                  "mysql",
+			desiredAllocatedStorage: aws.Int64(200),
+			latestAllocatedStorage:  aws.Int64(100),
+			expectDifferentAt:       true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			desired := &resource{
+				ko: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						Engine:           aws.String(tc.engine),
+						AllocatedStorage: tc.desiredAllocatedStorage,
+					},
+				},
+			}
+			latest := &resource{
+				ko: &svcapitypes.DBCluster{
+					Spec: svcapitypes.DBClusterSpec{
+						Engine:           aws.String(tc.engine),
+						AllocatedStorage: tc.latestAllocatedStorage,
+					},
+				},
+			}
+
+			delta := newResourceDelta(desired, latest)
+			assert.Equal(t, tc.expectDifferentAt, delta.DifferentAt("Spec.AllocatedStorage"),
+				"Spec.AllocatedStorage delta mismatch")
+		})
+	}
+}

--- a/templates/hooks/db_cluster/delta_pre_compare.go.tpl
+++ b/templates/hooks/db_cluster/delta_pre_compare.go.tpl
@@ -6,6 +6,13 @@
             b.ko.Spec.StorageType = aws.String("aurora")
     }
 
+    // Clear AllocatedStorage on the desired side for Aurora; the observed side
+    // is already cleared on create/read (v1.9.0+). This mainly covers clusters
+    // created before that fix, which retain a stale allocatedStorage in spec
+    // that otherwise produces a delta every reconcile ModifyDBCluster can't
+    // resolve, leaving the cluster perpetually out of sync.
+    clearAuroraAllocatedStorage(a.ko)
+
     // When autoMinorVersionUpgrade is enabled and the engine version
     // difference is only a minor version change (same major version),
     // normalize the desired engine version to match the latest. This


### PR DESCRIPTION
Description of changes:
AllocatedStorage does not apply to Aurora clusters, but a value left in
the spec compared against the cleared observed side produced a delta on
every reconcile that ModifyDBCluster could not resolve. Clear it on the
desired side too in delta_pre_compare so Aurora clusters reach synced.

Resolves aws-controllers-k8s/community#2914

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
