### PR TITLE
Add IAM Role and KMS Key references to RDS resources

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -21,6 +21,7 @@ distributed. For any package *NOT* distributed under the terms of the Apache
 License version 2.0, we include the full text of the package's License below.
 
 * `github.com/aws-controllers-k8s/ec2-controller`
+* `github.com/aws-controllers-k8s/iam-controller`
 * `github.com/aws-controllers-k8s/kms-controller`
 * `github.com/aws-controllers-k8s/runtime`
 * `github.com/aws/aws-sdk-go`
@@ -1430,6 +1431,544 @@ License Identifier: Apache-2.0
 
 License Identifier: Apache-2.0
 
+### github.com/aws-controllers-k8s/iam-controller
+
+License Identifier: Apache-2.0
+
+Subdependencies:
+* `github.com/aws-controllers-k8s/runtime`
+* `github.com/aws/aws-sdk-go`
+* `github.com/aws/aws-sdk-go-v2`
+* `github.com/aws/aws-sdk-go-v2/service/iam`
+* `github.com/aws/smithy-go`
+* `github.com/go-logr/logr`
+* `github.com/samber/lo`
+* `github.com/spf13/pflag`
+* `github.com/stretchr/testify`
+* `k8s.io/api`
+* `k8s.io/apimachinery`
+* `k8s.io/client-go`
+* `sigs.k8s.io/controller-runtime`
+* `github.com/aws/aws-sdk-go-v2/config`
+* `github.com/aws/aws-sdk-go-v2/credentials`
+* `github.com/aws/aws-sdk-go-v2/feature/ec2/imds`
+* `github.com/aws/aws-sdk-go-v2/internal/configsources`
+* `github.com/aws/aws-sdk-go-v2/internal/endpoints/v2`
+* `github.com/aws/aws-sdk-go-v2/internal/ini`
+* `github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding`
+* `github.com/aws/aws-sdk-go-v2/service/internal/presigned-url`
+* `github.com/aws/aws-sdk-go-v2/service/sso`
+* `github.com/aws/aws-sdk-go-v2/service/ssooidc`
+* `github.com/aws/aws-sdk-go-v2/service/sts`
+* `github.com/beorn7/perks`
+* `github.com/cenkalti/backoff/v4`
+* `github.com/cespare/xxhash/v2`
+* `github.com/davecgh/go-spew`
+* `github.com/emicklei/go-restful/v3`
+* `github.com/evanphx/json-patch/v5`
+* `github.com/fsnotify/fsnotify`
+* `github.com/fxamacker/cbor/v2`
+* `github.com/go-logr/zapr`
+* `github.com/go-openapi/jsonpointer`
+* `github.com/go-openapi/jsonreference`
+* `github.com/go-openapi/swag`
+* `github.com/google/btree`
+* `github.com/google/gnostic-models`
+* `github.com/google/go-cmp`
+* `github.com/google/uuid`
+* `github.com/itchyny/gojq`
+* `github.com/itchyny/timefmt-go`
+* `github.com/jaypipes/envutil`
+* `github.com/jmespath/go-jmespath`
+* `github.com/josharian/intern`
+* `github.com/json-iterator/go`
+* `github.com/mailru/easyjson`
+* `github.com/micahhausler/aws-iam-policy`
+* `github.com/modern-go/concurrent`
+* `github.com/modern-go/reflect2`
+* `github.com/munnerz/goautoneg`
+* `github.com/pkg/errors`
+* `github.com/pmezard/go-difflib`
+* `github.com/prometheus/client_golang`
+* `github.com/prometheus/client_model`
+* `github.com/prometheus/common`
+* `github.com/prometheus/procfs`
+* `github.com/x448/float16`
+* `go.uber.org/multierr`
+* `go.uber.org/zap`
+* `go.yaml.in/yaml/v2`
+* `go.yaml.in/yaml/v3`
+* `golang.org/x/exp`
+* `golang.org/x/net`
+* `golang.org/x/oauth2`
+* `golang.org/x/sync`
+* `golang.org/x/sys`
+* `golang.org/x/term`
+* `golang.org/x/text`
+* `golang.org/x/time`
+* `gomodules.xyz/jsonpatch/v2`
+* `google.golang.org/protobuf`
+* `gopkg.in/evanphx/json-patch.v4`
+* `gopkg.in/inf.v0`
+* `gopkg.in/yaml.v3`
+* `k8s.io/apiextensions-apiserver`
+* `k8s.io/klog/v2`
+* `k8s.io/kube-openapi`
+* `k8s.io/utils`
+* `sigs.k8s.io/json`
+* `sigs.k8s.io/randfill`
+* `sigs.k8s.io/structured-merge-diff/v6`
+* `sigs.k8s.io/yaml`
+
+#### github.com/aws-controllers-k8s/runtime
+
+License Identifier: Apache-2.0
+
+
+
+#### github.com/aws/aws-sdk-go-v2
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go-v2/service/iam
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/smithy-go
+
+License Identifier: Apache-2.0
+
+#### github.com/go-logr/logr
+
+License Identifier: Apache-2.0
+
+
+
+#### github.com/spf13/pflag
+
+License Identifier: BSD-3-Clause
+
+Copyright (c) 2012 Alex Ogier. All rights reserved.
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#### github.com/stretchr/testify
+
+License Identifier: MIT
+
+MIT License
+
+Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+#### k8s.io/api
+
+License Identifier: Apache-2.0
+
+#### k8s.io/apimachinery
+
+License Identifier: Apache-2.0
+
+#### k8s.io/client-go
+
+License Identifier: Apache-2.0
+
+#### sigs.k8s.io/controller-runtime
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go-v2/config
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go-v2/credentials
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go-v2/feature/ec2/imds
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go-v2/internal/configsources
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go-v2/internal/endpoints/v2
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go-v2/internal/ini
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go-v2/service/internal/presigned-url
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go-v2/service/sso
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go-v2/service/ssooidc
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go-v2/service/sts
+
+License Identifier: Apache-2.0
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#### github.com/fxamacker/cbor/v2
+
+License Identifier: MIT
+
+MIT License
+
+Copyright (c) 2019-present Faye Amacker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+
+
+
+
+
+
+
+#### github.com/google/btree
+
+License Identifier: Apache-2.0
+
+#### github.com/google/gnostic-models
+
+License Identifier: Apache-2.0
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#### github.com/micahhausler/aws-iam-policy
+
+License Identifier: MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2023, Micah Hausler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+
+
+
+
+
+
+#### github.com/pmezard/go-difflib
+
+License Identifier: BSD-3-Clause
+
+Copyright (c) 2013, Patrick Mezard
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+    The names of its contributors may not be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+
+
+
+
+
+
+#### github.com/x448/float16
+
+License Identifier: MIT
+
+MIT License
+
+Copyright (c) 2019 Montgomery Edwards⁴⁴⁸ and Faye Amacker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+
+
+
+#### go.yaml.in/yaml/v2
+
+License Identifier: Apache-2.0
+
+#### go.yaml.in/yaml/v3
+
+License Identifier: Apache-2.0
+
+#### golang.org/x/exp
+
+License Identifier: BSD-3-Clause
+
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+
+
+#### golang.org/x/sync
+
+License Identifier: BSD-3-Clause
+
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+
+
+
+
+
+
+
+
+
+
+#### gopkg.in/evanphx/json-patch.v4
+
+License Identifier: BSD-3-Clause
+
+Copyright (c) 2014, Evan Phoenix
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of the Evan Phoenix nor the names of its contributors 
+  may be used to endorse or promote products derived from this software 
+  without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#### sigs.k8s.io/randfill
+
+License Identifier: Apache-2.0
+
+#### sigs.k8s.io/structured-merge-diff/v6
+
+License Identifier: Apache-2.0
+
 ### github.com/aws-controllers-k8s/kms-controller
 
 License Identifier: Apache-2.0
@@ -1545,627 +2084,6 @@ SOFTWARE.
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#### github.com/pmezard/go-difflib
-
-License Identifier: BSD-3-Clause
-
-Copyright (c) 2013, Patrick Mezard
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-    Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-    Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-    The names of its contributors may not be used to endorse or promote
-products derived from this software without specific prior written
-permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-### github.com/aws-controllers-k8s/runtime
-
-License Identifier: Apache-2.0
-
-Subdependencies:
-* `github.com/aws/aws-sdk-go-v2`
-* `github.com/aws/aws-sdk-go-v2/config`
-* `github.com/aws/aws-sdk-go-v2/credentials`
-* `github.com/aws/aws-sdk-go-v2/service/sts`
-* `github.com/aws/smithy-go`
-* `github.com/cenkalti/backoff/v4`
-* `github.com/go-logr/logr`
-* `github.com/go-logr/zapr`
-* `github.com/google/go-cmp`
-* `github.com/itchyny/gojq`
-* `github.com/jaypipes/envutil`
-* `github.com/micahhausler/aws-iam-policy`
-* `github.com/pkg/errors`
-* `github.com/prometheus/client_golang`
-* `github.com/spf13/pflag`
-* `github.com/stretchr/testify`
-* `go.uber.org/zap`
-* `k8s.io/api`
-* `k8s.io/apimachinery`
-* `k8s.io/client-go`
-* `k8s.io/klog/v2`
-* `k8s.io/utils`
-* `sigs.k8s.io/controller-runtime`
-* `github.com/aws/aws-sdk-go-v2/feature/ec2/imds`
-* `github.com/aws/aws-sdk-go-v2/internal/configsources`
-* `github.com/aws/aws-sdk-go-v2/internal/endpoints/v2`
-* `github.com/aws/aws-sdk-go-v2/internal/ini`
-* `github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding`
-* `github.com/aws/aws-sdk-go-v2/service/internal/presigned-url`
-* `github.com/aws/aws-sdk-go-v2/service/sso`
-* `github.com/aws/aws-sdk-go-v2/service/ssooidc`
-* `github.com/beorn7/perks`
-* `github.com/cespare/xxhash/v2`
-* `github.com/davecgh/go-spew`
-* `github.com/emicklei/go-restful/v3`
-* `github.com/evanphx/json-patch`
-* `github.com/evanphx/json-patch/v5`
-* `github.com/fsnotify/fsnotify`
-* `github.com/fxamacker/cbor/v2`
-* `github.com/go-openapi/jsonpointer`
-* `github.com/go-openapi/jsonreference`
-* `github.com/go-openapi/swag`
-* `github.com/google/btree`
-* `github.com/google/gnostic-models`
-* `github.com/google/uuid`
-* `github.com/itchyny/timefmt-go`
-* `github.com/josharian/intern`
-* `github.com/json-iterator/go`
-* `github.com/mailru/easyjson`
-* `github.com/modern-go/concurrent`
-* `github.com/modern-go/reflect2`
-* `github.com/munnerz/goautoneg`
-* `github.com/pmezard/go-difflib`
-* `github.com/prometheus/client_model`
-* `github.com/prometheus/common`
-* `github.com/prometheus/procfs`
-* `github.com/stretchr/objx`
-* `github.com/x448/float16`
-* `go.uber.org/multierr`
-* `go.yaml.in/yaml/v2`
-* `go.yaml.in/yaml/v3`
-* `golang.org/x/net`
-* `golang.org/x/oauth2`
-* `golang.org/x/sync`
-* `golang.org/x/sys`
-* `golang.org/x/term`
-* `golang.org/x/text`
-* `golang.org/x/time`
-* `gomodules.xyz/jsonpatch/v2`
-* `google.golang.org/protobuf`
-* `gopkg.in/evanphx/json-patch.v4`
-* `gopkg.in/inf.v0`
-* `gopkg.in/yaml.v3`
-* `k8s.io/apiextensions-apiserver`
-* `k8s.io/kube-openapi`
-* `sigs.k8s.io/json`
-* `sigs.k8s.io/randfill`
-* `sigs.k8s.io/structured-merge-diff/v6`
-* `sigs.k8s.io/yaml`
-
-#### github.com/aws/aws-sdk-go-v2
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/aws-sdk-go-v2/config
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/aws-sdk-go-v2/credentials
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/aws-sdk-go-v2/service/sts
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/smithy-go
-
-License Identifier: Apache-2.0
-
-
-
-#### github.com/go-logr/logr
-
-License Identifier: Apache-2.0
-
-
-
-
-
-
-
-
-
-#### github.com/micahhausler/aws-iam-policy
-
-License Identifier: MIT
-
-The MIT License (MIT)
-
-Copyright (c) 2023, Micah Hausler
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-
-
-
-#### github.com/spf13/pflag
-
-License Identifier: BSD-3-Clause
-
-Copyright (c) 2012 Alex Ogier. All rights reserved.
-Copyright (c) 2012 The Go Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#### github.com/stretchr/testify
-
-License Identifier: MIT
-
-MIT License
-
-Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-
-#### k8s.io/api
-
-License Identifier: Apache-2.0
-
-#### k8s.io/apimachinery
-
-License Identifier: Apache-2.0
-
-#### k8s.io/client-go
-
-License Identifier: Apache-2.0
-
-
-
-
-
-#### sigs.k8s.io/controller-runtime
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/aws-sdk-go-v2/feature/ec2/imds
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/aws-sdk-go-v2/internal/configsources
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/aws-sdk-go-v2/internal/endpoints/v2
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/aws-sdk-go-v2/internal/ini
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/aws-sdk-go-v2/service/internal/presigned-url
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/aws-sdk-go-v2/service/sso
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/aws-sdk-go-v2/service/ssooidc
-
-License Identifier: Apache-2.0
-
-
-
-
-
-
-
-
-
-#### github.com/evanphx/json-patch
-
-License Identifier: BSD-3-Clause
-
-Copyright (c) 2014, Evan Phoenix
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without 
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-* Neither the name of the Evan Phoenix nor the names of its contributors 
-  may be used to endorse or promote products derived from this software 
-  without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-
-
-
-#### github.com/fxamacker/cbor/v2
-
-License Identifier: MIT
-
-MIT License
-
-Copyright (c) 2019-present Faye Amacker
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-
-
-
-
-
-#### github.com/google/btree
-
-License Identifier: Apache-2.0
-
-#### github.com/google/gnostic-models
-
-License Identifier: Apache-2.0
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#### github.com/stretchr/objx
-
-License Identifier: MIT
-
-The MIT License
-
-Copyright (c) 2014 Stretchr, Inc.
-Copyright (c) 2017-2018 objx contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-#### github.com/x448/float16
-
-License Identifier: MIT
-
-MIT License
-
-Copyright (c) 2019 Montgomery Edwards⁴⁴⁸ and Faye Amacker
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-
-#### go.yaml.in/yaml/v2
-
-License Identifier: Apache-2.0
-
-#### go.yaml.in/yaml/v3
-
-License Identifier: Apache-2.0
-
-
-
-
-
-#### golang.org/x/sync
-
-License Identifier: BSD-3-Clause
-
-Copyright 2009 The Go Authors.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google LLC nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-
-
-
-
-
-
-
-
-
-
-
-#### gopkg.in/evanphx/json-patch.v4
-
-License Identifier: BSD-3-Clause
-
-Copyright (c) 2014, Evan Phoenix
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without 
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-* Neither the name of the Evan Phoenix nor the names of its contributors 
-  may be used to endorse or promote products derived from this software 
-  without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-
-
-
-
-
-
-
-
-
-#### sigs.k8s.io/randfill
-
-License Identifier: Apache-2.0
-
-#### sigs.k8s.io/structured-merge-diff/v6
-
-License Identifier: Apache-2.0
-
-
-
-### github.com/aws/aws-sdk-go-v2
-
-License Identifier: Apache-2.0
-
-Subdependencies:
-* `github.com/aws/smithy-go`
-* `github.com/jmespath/go-jmespath`
 
 ### github.com/aws/aws-sdk-go-v2/service/rds
 

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-22T23:00:16Z"
+  build_date: "2026-06-23T04:51:36Z"
   build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
-  go_version: go1.26.4
+  go_version: go1.26.0
   version: v0.60.0
-api_directory_checksum: 9eb1602bb21828e84682ddeb8ee21a05cfa88e47
+api_directory_checksum: 717487e9722f10dff3e171fccb85bb77bee19301
 api_version: v1alpha1
-aws_sdk_go_version: v1.32.6
+aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: 0c58100856b49a78062ae443d5fc5728e38924a5
+  file_checksum: 887c10f71bc84bfa091f66f4c6d1c011ae35efc8
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/db_cluster.go
+++ b/apis/v1alpha1/db_cluster.go
@@ -53,7 +53,7 @@ type DBClusterSpec struct {
 	// DB cluster during the maintenance window. By default, minor engine upgrades
 	// are applied automatically.
 	//
-	// Valid for Cluster Type: Multi-AZ DB clusters only
+	// Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB cluster
 	AutoMinorVersionUpgrade *bool `json:"autoMinorVersionUpgrade,omitempty"`
 	// A list of Availability Zones (AZs) where you specifically want to create
 	// DB instances in the DB cluster.
@@ -155,7 +155,13 @@ type DBClusterSpec struct {
 	DBSubnetGroupRef  *ackv1alpha1.AWSResourceReferenceWrapper `json:"dbSubnetGroupRef,omitempty"`
 	// Reserved for future use.
 	DBSystemID *string `json:"dbSystemID,omitempty"`
-	// Specifies the mode of Database Insights to enable for the cluster.
+	// The mode of Database Insights to enable for the DB cluster.
+	//
+	// If you set this value to advanced, you must also set the PerformanceInsightsEnabled
+	// parameter to true and the PerformanceInsightsRetentionPeriod parameter to
+	// 465.
+	//
+	// Valid for Cluster Type: Aurora DB clusters only
 	DatabaseInsightsMode *string `json:"databaseInsightsMode,omitempty"`
 	// The name for your database of up to 64 alphanumeric characters. A database
 	// named postgres is always created. If this parameter is specified, an additional
@@ -229,12 +235,6 @@ type DBClusterSpec struct {
 	// (RDS Data API) for running SQL queries on the DB cluster. You can also query
 	// your database from inside the RDS console with the RDS query editor.
 	//
-	// RDS Data API is supported with the following DB clusters:
-	//
-	//   - Aurora PostgreSQL Serverless v2 and provisioned
-	//
-	//   - Aurora PostgreSQL and Aurora MySQL Serverless v1
-	//
 	// For more information, see Using RDS Data API (https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html)
 	// in the Amazon Aurora User Guide.
 	//
@@ -256,7 +256,7 @@ type DBClusterSpec struct {
 	// For more information, see Using Amazon Performance Insights (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html)
 	// in the Amazon RDS User Guide.
 	//
-	// Valid for Cluster Type: Multi-AZ DB clusters only
+	// Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB clusters
 	EnablePerformanceInsights *bool `json:"enablePerformanceInsights,omitempty"`
 	// The database engine to use for this DB cluster.
 	//
@@ -449,7 +449,7 @@ type DBClusterSpec struct {
 	// If MonitoringRoleArn is specified, also set MonitoringInterval to a value
 	// other than 0.
 	//
-	// Valid for Cluster Type: Multi-AZ DB clusters only
+	// Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB clusters
 	//
 	// Valid Values: 0 | 1 | 5 | 10 | 15 | 30 | 60
 	//
@@ -464,8 +464,9 @@ type DBClusterSpec struct {
 	// If MonitoringInterval is set to a value other than 0, supply a MonitoringRoleArn
 	// value.
 	//
-	// Valid for Cluster Type: Multi-AZ DB clusters only
-	MonitoringRoleARN *string `json:"monitoringRoleARN,omitempty"`
+	// Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB clusters
+	MonitoringRoleARN *string                                  `json:"monitoringRoleARN,omitempty"`
+	MonitoringRoleRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"monitoringRoleRef,omitempty"`
 	// The network type of the DB cluster.
 	//
 	// The network type is determined by the DBSubnetGroup specified for the DB
@@ -494,11 +495,12 @@ type DBClusterSpec struct {
 	// Web Services account. Your Amazon Web Services account has a different default
 	// KMS key for each Amazon Web Services Region.
 	//
-	// Valid for Cluster Type: Multi-AZ DB clusters only
-	PerformanceInsightsKMSKeyID *string `json:"performanceInsightsKMSKeyID,omitempty"`
+	// Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB clusters
+	PerformanceInsightsKMSKeyID  *string                                  `json:"performanceInsightsKMSKeyID,omitempty"`
+	PerformanceInsightsKMSKeyRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"performanceInsightsKMSKeyRef,omitempty"`
 	// The number of days to retain Performance Insights data.
 	//
-	// Valid for Cluster Type: Multi-AZ DB clusters only
+	// Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB clusters
 	//
 	// Valid Values:
 	//
@@ -921,7 +923,7 @@ type DBClusterStatus struct {
 	PercentProgress *string `json:"percentProgress,omitempty"`
 	// Indicates whether Performance Insights is enabled for the DB cluster.
 	//
-	// This setting is only for non-Aurora Multi-AZ DB clusters.
+	// This setting is only for Aurora DB clusters and Multi-AZ DB clusters.
 	// +kubebuilder:validation:Optional
 	PerformanceInsightsEnabled *bool `json:"performanceInsightsEnabled,omitempty"`
 	// Contains one or more identifiers of the read replicas associated with this

--- a/apis/v1alpha1/db_instance.go
+++ b/apis/v1alpha1/db_instance.go
@@ -440,7 +440,11 @@ type DBInstanceSpec struct {
 	// Example: mydbsubnetgroup
 	DBSubnetGroupName *string                                  `json:"dbSubnetGroupName,omitempty"`
 	DBSubnetGroupRef  *ackv1alpha1.AWSResourceReferenceWrapper `json:"dbSubnetGroupRef,omitempty"`
-	// Specifies the mode of Database Insights to enable for the instance.
+	// The mode of Database Insights to enable for the DB instance.
+	//
+	// This setting only applies to Amazon Aurora DB instances.
+	//
+	// Currently, this value is inherited from the DB cluster and can't be changed.
 	DatabaseInsightsMode *string `json:"databaseInsightsMode,omitempty"`
 	// Specifies whether the DB instance has deletion protection enabled. The database
 	// can't be deleted when deletion protection is enabled. By default, deletion
@@ -813,7 +817,8 @@ type DBInstanceSpec struct {
 	// a MonitoringRoleArn value.
 	//
 	// This setting doesn't apply to RDS Custom DB instances.
-	MonitoringRoleARN *string `json:"monitoringRoleARN,omitempty"`
+	MonitoringRoleARN *string                                  `json:"monitoringRoleARN,omitempty"`
+	MonitoringRoleRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"monitoringRoleRef,omitempty"`
 	// Specifies whether the DB instance is a Multi-AZ deployment. You can't set
 	// the AvailabilityZone parameter if the DB instance is a Multi-AZ deployment.
 	//
@@ -865,7 +870,8 @@ type DBInstanceSpec struct {
 	// KMS key for each Amazon Web Services Region.
 	//
 	// This setting doesn't apply to RDS Custom DB instances.
-	PerformanceInsightsKMSKeyID *string `json:"performanceInsightsKMSKeyID,omitempty"`
+	PerformanceInsightsKMSKeyID  *string                                  `json:"performanceInsightsKMSKeyID,omitempty"`
+	PerformanceInsightsKMSKeyRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"performanceInsightsKMSKeyRef,omitempty"`
 	// The number of days to retain Performance Insights data.
 	//
 	// This setting doesn't apply to RDS Custom DB instances.

--- a/apis/v1alpha1/db_proxy.go
+++ b/apis/v1alpha1/db_proxy.go
@@ -63,8 +63,8 @@ type DBProxySpec struct {
 	RequireTLS *bool `json:"requireTLS,omitempty"`
 	// The Amazon Resource Name (ARN) of the IAM role that the proxy uses to access
 	// secrets in Amazon Web Services Secrets Manager.
-	// +kubebuilder:validation:Required
-	RoleARN *string `json:"roleARN"`
+	RoleARN *string                                  `json:"roleARN,omitempty"`
+	RoleRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"roleRef,omitempty"`
 	// An optional set of key-value pairs to associate arbitrary data of your choosing
 	// with the proxy.
 	Tags []*Tag `json:"tags,omitempty"`

--- a/apis/v1alpha1/enums.go
+++ b/apis/v1alpha1/enums.go
@@ -70,10 +70,11 @@ const (
 type ClientPasswordAuthType string
 
 const (
-	ClientPasswordAuthType_MYSQL_NATIVE_PASSWORD     ClientPasswordAuthType = "MYSQL_NATIVE_PASSWORD"
-	ClientPasswordAuthType_POSTGRES_MD5              ClientPasswordAuthType = "POSTGRES_MD5"
-	ClientPasswordAuthType_POSTGRES_SCRAM_SHA_256    ClientPasswordAuthType = "POSTGRES_SCRAM_SHA_256"
-	ClientPasswordAuthType_SQL_SERVER_AUTHENTICATION ClientPasswordAuthType = "SQL_SERVER_AUTHENTICATION"
+	ClientPasswordAuthType_MYSQL_CACHING_SHA2_PASSWORD ClientPasswordAuthType = "MYSQL_CACHING_SHA2_PASSWORD"
+	ClientPasswordAuthType_MYSQL_NATIVE_PASSWORD       ClientPasswordAuthType = "MYSQL_NATIVE_PASSWORD"
+	ClientPasswordAuthType_POSTGRES_MD5                ClientPasswordAuthType = "POSTGRES_MD5"
+	ClientPasswordAuthType_POSTGRES_SCRAM_SHA_256      ClientPasswordAuthType = "POSTGRES_SCRAM_SHA_256"
+	ClientPasswordAuthType_SQL_SERVER_AUTHENTICATION   ClientPasswordAuthType = "SQL_SERVER_AUTHENTICATION"
 )
 
 type ClusterScalabilityType string

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -188,6 +188,16 @@ resources:
           resource: Key
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
+      MonitoringRoleARN:
+        references:
+          resource: Role
+          service_name: iam
+          path: Status.ACKResourceMetadata.ARN
+      PerformanceInsightsKMSKeyID:
+        references:
+          resource: Key
+          service_name: kms
+          path: Status.ACKResourceMetadata.ARN
       DBClusterParameterGroupName:
         references:
           resource: DBClusterParameterGroup
@@ -339,6 +349,11 @@ resources:
           resource: Key
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
+      MonitoringRoleARN:
+        references:
+          resource: Role
+          service_name: iam
+          path: Status.ACKResourceMetadata.ARN
       DBParameterGroupName:
         references:
           resource: DBParameterGroup
@@ -377,6 +392,10 @@ resources:
           skip_incomplete_check: {}
         compare:
           is_ignored: true
+        references:
+          resource: Key
+          service_name: kms
+          path: Status.ACKResourceMetadata.ARN
       PerformanceInsightsRetentionPeriod:
         late_initialize:
            skip_incomplete_check: {}
@@ -625,6 +644,11 @@ resources:
     fields:
       Name:
         is_primary_key: true
+      RoleARN:
+        references:
+          resource: Role
+          service_name: iam
+          path: Status.ACKResourceMetadata.ARN
     renames:
       operations:
         CreateDBProxy:

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1832,6 +1832,11 @@ func (in *DBClusterSpec) DeepCopyInto(out *DBClusterSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.MonitoringRoleRef != nil {
+		in, out := &in.MonitoringRoleRef, &out.MonitoringRoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.NetworkType != nil {
 		in, out := &in.NetworkType, &out.NetworkType
 		*out = new(string)
@@ -1846,6 +1851,11 @@ func (in *DBClusterSpec) DeepCopyInto(out *DBClusterSpec) {
 		in, out := &in.PerformanceInsightsKMSKeyID, &out.PerformanceInsightsKMSKeyID
 		*out = new(string)
 		**out = **in
+	}
+	if in.PerformanceInsightsKMSKeyRef != nil {
+		in, out := &in.PerformanceInsightsKMSKeyRef, &out.PerformanceInsightsKMSKeyRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PerformanceInsightsRetentionPeriod != nil {
 		in, out := &in.PerformanceInsightsRetentionPeriod, &out.PerformanceInsightsRetentionPeriod
@@ -3361,6 +3371,11 @@ func (in *DBInstanceSpec) DeepCopyInto(out *DBInstanceSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.MonitoringRoleRef != nil {
+		in, out := &in.MonitoringRoleRef, &out.MonitoringRoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.MultiAZ != nil {
 		in, out := &in.MultiAZ, &out.MultiAZ
 		*out = new(bool)
@@ -3390,6 +3405,11 @@ func (in *DBInstanceSpec) DeepCopyInto(out *DBInstanceSpec) {
 		in, out := &in.PerformanceInsightsKMSKeyID, &out.PerformanceInsightsKMSKeyID
 		*out = new(string)
 		**out = **in
+	}
+	if in.PerformanceInsightsKMSKeyRef != nil {
+		in, out := &in.PerformanceInsightsKMSKeyRef, &out.PerformanceInsightsKMSKeyRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PerformanceInsightsRetentionPeriod != nil {
 		in, out := &in.PerformanceInsightsRetentionPeriod, &out.PerformanceInsightsRetentionPeriod
@@ -4712,6 +4732,11 @@ func (in *DBProxySpec) DeepCopyInto(out *DBProxySpec) {
 		in, out := &in.RoleARN, &out.RoleARN
 		*out = new(string)
 		**out = **in
+	}
+	if in.RoleRef != nil {
+		in, out := &in.RoleRef, &out.RoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
 	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
@@ -68,6 +69,7 @@ func init() {
 	_ = svctypes.AddToScheme(scheme)
 	_ = ackv1alpha1.AddToScheme(scheme)
 	_ = ec2apitypes.AddToScheme(scheme)
+	_ = iamapitypes.AddToScheme(scheme)
 	_ = kmsapitypes.AddToScheme(scheme)
 }
 

--- a/config/crd/bases/rds.services.k8s.aws_dbclusters.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbclusters.yaml
@@ -75,7 +75,7 @@ spec:
                   DB cluster during the maintenance window. By default, minor engine upgrades
                   are applied automatically.
 
-                  Valid for Cluster Type: Multi-AZ DB clusters only
+                  Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB cluster
                 type: boolean
               availabilityZones:
                 description: |-
@@ -136,8 +136,14 @@ spec:
                   Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB clusters
                 type: boolean
               databaseInsightsMode:
-                description: Specifies the mode of Database Insights to enable for
-                  the cluster.
+                description: |-
+                  The mode of Database Insights to enable for the DB cluster.
+
+                  If you set this value to advanced, you must also set the PerformanceInsightsEnabled
+                  parameter to true and the PerformanceInsightsRetentionPeriod parameter to
+                  465.
+
+                  Valid for Cluster Type: Aurora DB clusters only
                 type: string
               databaseName:
                 description: |-
@@ -325,12 +331,6 @@ spec:
                   (RDS Data API) for running SQL queries on the DB cluster. You can also query
                   your database from inside the RDS console with the RDS query editor.
 
-                  RDS Data API is supported with the following DB clusters:
-
-                     * Aurora PostgreSQL Serverless v2 and provisioned
-
-                     * Aurora PostgreSQL and Aurora MySQL Serverless v1
-
                   For more information, see Using RDS Data API (https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html)
                   in the Amazon Aurora User Guide.
 
@@ -356,7 +356,7 @@ spec:
                   For more information, see Using Amazon Performance Insights (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html)
                   in the Amazon RDS User Guide.
 
-                  Valid for Cluster Type: Multi-AZ DB clusters only
+                  Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB clusters
                 type: boolean
               engine:
                 description: |-
@@ -617,7 +617,7 @@ spec:
                   If MonitoringRoleArn is specified, also set MonitoringInterval to a value
                   other than 0.
 
-                  Valid for Cluster Type: Multi-AZ DB clusters only
+                  Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB clusters
 
                   Valid Values: 0 | 1 | 5 | 10 | 15 | 30 | 60
 
@@ -635,8 +635,25 @@ spec:
                   If MonitoringInterval is set to a value other than 0, supply a MonitoringRoleArn
                   value.
 
-                  Valid for Cluster Type: Multi-AZ DB clusters only
+                  Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB clusters
                 type: string
+              monitoringRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               networkType:
                 description: |-
                   The network type of the DB cluster.
@@ -671,13 +688,30 @@ spec:
                   Web Services account. Your Amazon Web Services account has a different default
                   KMS key for each Amazon Web Services Region.
 
-                  Valid for Cluster Type: Multi-AZ DB clusters only
+                  Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB clusters
                 type: string
+              performanceInsightsKMSKeyRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               performanceInsightsRetentionPeriod:
                 description: |-
                   The number of days to retain Performance Insights data.
 
-                  Valid for Cluster Type: Multi-AZ DB clusters only
+                  Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB clusters
 
                   Valid Values:
 
@@ -1387,7 +1421,7 @@ spec:
                 description: |-
                   Indicates whether Performance Insights is enabled for the DB cluster.
 
-                  This setting is only for non-Aurora Multi-AZ DB clusters.
+                  This setting is only for Aurora DB clusters and Multi-AZ DB clusters.
                 type: boolean
               readReplicaIdentifiers:
                 description: |-

--- a/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
@@ -272,8 +272,12 @@ spec:
                   in the Amazon RDS User Guide.
                 type: string
               databaseInsightsMode:
-                description: Specifies the mode of Database Insights to enable for
-                  the instance.
+                description: |-
+                  The mode of Database Insights to enable for the DB instance.
+
+                  This setting only applies to Amazon Aurora DB instances.
+
+                  Currently, this value is inherited from the DB cluster and can't be changed.
                 type: string
               dbClusterIdentifier:
                 description: |-
@@ -993,6 +997,23 @@ spec:
 
                   This setting doesn't apply to RDS Custom DB instances.
                 type: string
+              monitoringRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               multiAZ:
                 description: |-
                   Specifies whether the DB instance is a Multi-AZ deployment. You can't set
@@ -1057,6 +1078,23 @@ spec:
 
                   This setting doesn't apply to RDS Custom DB instances.
                 type: string
+              performanceInsightsKMSKeyRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               performanceInsightsRetentionPeriod:
                 description: |-
                   The number of days to retain Performance Insights data.

--- a/config/crd/bases/rds.services.k8s.aws_dbproxies.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbproxies.yaml
@@ -110,6 +110,23 @@ spec:
                   The Amazon Resource Name (ARN) of the IAM role that the proxy uses to access
                   secrets in Amazon Web Services Secrets Manager.
                 type: string
+              roleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               tags:
                 description: |-
                   An optional set of key-value pairs to associate arbitrary data of your choosing
@@ -145,7 +162,6 @@ spec:
             - auth
             - engineFamily
             - name
-            - roleARN
             - vpcSubnetIDs
             type: object
           status:

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -33,6 +33,14 @@ rules:
   - get
   - list
 - apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - roles
+  - roles/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - kms.services.k8s.aws
   resources:
   - keys

--- a/generator.yaml
+++ b/generator.yaml
@@ -188,6 +188,16 @@ resources:
           resource: Key
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
+      MonitoringRoleARN:
+        references:
+          resource: Role
+          service_name: iam
+          path: Status.ACKResourceMetadata.ARN
+      PerformanceInsightsKMSKeyID:
+        references:
+          resource: Key
+          service_name: kms
+          path: Status.ACKResourceMetadata.ARN
       DBClusterParameterGroupName:
         references:
           resource: DBClusterParameterGroup
@@ -339,6 +349,11 @@ resources:
           resource: Key
           service_name: kms
           path: Status.ACKResourceMetadata.ARN
+      MonitoringRoleARN:
+        references:
+          resource: Role
+          service_name: iam
+          path: Status.ACKResourceMetadata.ARN
       DBParameterGroupName:
         references:
           resource: DBParameterGroup
@@ -377,6 +392,10 @@ resources:
           skip_incomplete_check: {}
         compare:
           is_ignored: true
+        references:
+          resource: Key
+          service_name: kms
+          path: Status.ACKResourceMetadata.ARN
       PerformanceInsightsRetentionPeriod:
         late_initialize:
            skip_incomplete_check: {}
@@ -625,6 +644,11 @@ resources:
     fields:
       Name:
         is_primary_key: true
+      RoleARN:
+        references:
+          resource: Role
+          service_name: iam
+          path: Status.ACKResourceMetadata.ARN
     renames:
       operations:
         CreateDBProxy:

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.0
 
 require (
 	github.com/aws-controllers-k8s/ec2-controller v1.1.2
+	github.com/aws-controllers-k8s/iam-controller v1.7.2
 	github.com/aws-controllers-k8s/kms-controller v1.0.8
 	github.com/aws-controllers-k8s/runtime v0.60.0
 	github.com/aws/aws-sdk-go v1.49.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/aws-controllers-k8s/ec2-controller v1.1.2 h1:Bry62L279S7mJofk0sS4o7T7cK16ydsSrdJ5wh+ZgD0=
 github.com/aws-controllers-k8s/ec2-controller v1.1.2/go.mod h1:XZOZcSk0tzplY+A0dADqD4NK4a8g8Jqwf/Ouv2Sz/eQ=
+github.com/aws-controllers-k8s/iam-controller v1.7.2 h1:voWlgUA8yDTQTGkdKslMydNyY4mXAH8TaRtW4216g0U=
+github.com/aws-controllers-k8s/iam-controller v1.7.2/go.mod h1:GW/KAJdhJ97rhFVJq/8c2iVT4mrA8zi8T4Eu+zhUrqM=
 github.com/aws-controllers-k8s/kms-controller v1.0.8 h1:nDPYQhsgD2s14rEMNmGCwkm+e0Emjo/Usl3is7e9EFk=
 github.com/aws-controllers-k8s/kms-controller v1.0.8/go.mod h1:HjSBjtiljNL1yFzrOizxeQe2+88tW3mHD5fnEGwVYGE=
 github.com/aws-controllers-k8s/runtime v0.60.0 h1:obCtliXzv+HqpVwEHZ388wC7uBDVdGWeuK8DMHcPcIE=

--- a/helm/crds/rds.services.k8s.aws_dbclusters.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbclusters.yaml
@@ -75,7 +75,7 @@ spec:
                   DB cluster during the maintenance window. By default, minor engine upgrades
                   are applied automatically.
 
-                  Valid for Cluster Type: Multi-AZ DB clusters only
+                  Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB cluster
                 type: boolean
               availabilityZones:
                 description: |-
@@ -136,8 +136,14 @@ spec:
                   Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB clusters
                 type: boolean
               databaseInsightsMode:
-                description: Specifies the mode of Database Insights to enable for
-                  the cluster.
+                description: |-
+                  The mode of Database Insights to enable for the DB cluster.
+
+                  If you set this value to advanced, you must also set the PerformanceInsightsEnabled
+                  parameter to true and the PerformanceInsightsRetentionPeriod parameter to
+                  465.
+
+                  Valid for Cluster Type: Aurora DB clusters only
                 type: string
               databaseName:
                 description: |-
@@ -325,12 +331,6 @@ spec:
                   (RDS Data API) for running SQL queries on the DB cluster. You can also query
                   your database from inside the RDS console with the RDS query editor.
 
-                  RDS Data API is supported with the following DB clusters:
-
-                    - Aurora PostgreSQL Serverless v2 and provisioned
-
-                    - Aurora PostgreSQL and Aurora MySQL Serverless v1
-
                   For more information, see Using RDS Data API (https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html)
                   in the Amazon Aurora User Guide.
 
@@ -356,7 +356,7 @@ spec:
                   For more information, see Using Amazon Performance Insights (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.html)
                   in the Amazon RDS User Guide.
 
-                  Valid for Cluster Type: Multi-AZ DB clusters only
+                  Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB clusters
                 type: boolean
               engine:
                 description: |-
@@ -617,7 +617,7 @@ spec:
                   If MonitoringRoleArn is specified, also set MonitoringInterval to a value
                   other than 0.
 
-                  Valid for Cluster Type: Multi-AZ DB clusters only
+                  Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB clusters
 
                   Valid Values: 0 | 1 | 5 | 10 | 15 | 30 | 60
 
@@ -635,8 +635,25 @@ spec:
                   If MonitoringInterval is set to a value other than 0, supply a MonitoringRoleArn
                   value.
 
-                  Valid for Cluster Type: Multi-AZ DB clusters only
+                  Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB clusters
                 type: string
+              monitoringRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               networkType:
                 description: |-
                   The network type of the DB cluster.
@@ -671,13 +688,30 @@ spec:
                   Web Services account. Your Amazon Web Services account has a different default
                   KMS key for each Amazon Web Services Region.
 
-                  Valid for Cluster Type: Multi-AZ DB clusters only
+                  Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB clusters
                 type: string
+              performanceInsightsKMSKeyRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               performanceInsightsRetentionPeriod:
                 description: |-
                   The number of days to retain Performance Insights data.
 
-                  Valid for Cluster Type: Multi-AZ DB clusters only
+                  Valid for Cluster Type: Aurora DB clusters and Multi-AZ DB clusters
 
                   Valid Values:
 
@@ -1387,7 +1421,7 @@ spec:
                 description: |-
                   Indicates whether Performance Insights is enabled for the DB cluster.
 
-                  This setting is only for non-Aurora Multi-AZ DB clusters.
+                  This setting is only for Aurora DB clusters and Multi-AZ DB clusters.
                 type: boolean
               readReplicaIdentifiers:
                 description: |-

--- a/helm/crds/rds.services.k8s.aws_dbinstances.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbinstances.yaml
@@ -272,8 +272,12 @@ spec:
                   in the Amazon RDS User Guide.
                 type: string
               databaseInsightsMode:
-                description: Specifies the mode of Database Insights to enable for
-                  the instance.
+                description: |-
+                  The mode of Database Insights to enable for the DB instance.
+
+                  This setting only applies to Amazon Aurora DB instances.
+
+                  Currently, this value is inherited from the DB cluster and can't be changed.
                 type: string
               dbClusterIdentifier:
                 description: |-
@@ -993,6 +997,23 @@ spec:
 
                   This setting doesn't apply to RDS Custom DB instances.
                 type: string
+              monitoringRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               multiAZ:
                 description: |-
                   Specifies whether the DB instance is a Multi-AZ deployment. You can't set
@@ -1057,6 +1078,23 @@ spec:
 
                   This setting doesn't apply to RDS Custom DB instances.
                 type: string
+              performanceInsightsKMSKeyRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               performanceInsightsRetentionPeriod:
                 description: |-
                   The number of days to retain Performance Insights data.

--- a/helm/crds/rds.services.k8s.aws_dbproxies.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbproxies.yaml
@@ -110,6 +110,23 @@ spec:
                   The Amazon Resource Name (ARN) of the IAM role that the proxy uses to access
                   secrets in Amazon Web Services Secrets Manager.
                 type: string
+              roleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               tags:
                 description: |-
                   An optional set of key-value pairs to associate arbitrary data of your choosing
@@ -145,7 +162,6 @@ spec:
             - auth
             - engineFamily
             - name
-            - roleARN
             - vpcSubnetIDs
             type: object
           status:

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -80,6 +80,14 @@ rules:
   - get
   - list
 - apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - roles
+  - roles/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - kms.services.k8s.aws
   resources:
   - keys

--- a/pkg/resource/db_cluster/delta.go
+++ b/pkg/resource/db_cluster/delta.go
@@ -331,6 +331,9 @@ func newResourceDelta(
 			delta.Add("Spec.MonitoringRoleARN", a.ko.Spec.MonitoringRoleARN, b.ko.Spec.MonitoringRoleARN)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.MonitoringRoleRef, b.ko.Spec.MonitoringRoleRef) {
+		delta.Add("Spec.MonitoringRoleRef", a.ko.Spec.MonitoringRoleRef, b.ko.Spec.MonitoringRoleRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.NetworkType, b.ko.Spec.NetworkType) {
 		delta.Add("Spec.NetworkType", a.ko.Spec.NetworkType, b.ko.Spec.NetworkType)
 	} else if a.ko.Spec.NetworkType != nil && b.ko.Spec.NetworkType != nil {
@@ -351,6 +354,9 @@ func newResourceDelta(
 		if *a.ko.Spec.PerformanceInsightsKMSKeyID != *b.ko.Spec.PerformanceInsightsKMSKeyID {
 			delta.Add("Spec.PerformanceInsightsKMSKeyID", a.ko.Spec.PerformanceInsightsKMSKeyID, b.ko.Spec.PerformanceInsightsKMSKeyID)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.PerformanceInsightsKMSKeyRef, b.ko.Spec.PerformanceInsightsKMSKeyRef) {
+		delta.Add("Spec.PerformanceInsightsKMSKeyRef", a.ko.Spec.PerformanceInsightsKMSKeyRef, b.ko.Spec.PerformanceInsightsKMSKeyRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.PerformanceInsightsRetentionPeriod, b.ko.Spec.PerformanceInsightsRetentionPeriod) {
 		delta.Add("Spec.PerformanceInsightsRetentionPeriod", a.ko.Spec.PerformanceInsightsRetentionPeriod, b.ko.Spec.PerformanceInsightsRetentionPeriod)

--- a/pkg/resource/db_cluster/references.go
+++ b/pkg/resource/db_cluster/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
 	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
@@ -35,6 +36,12 @@ import (
 
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
+// +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
 
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
@@ -63,6 +70,14 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 
 	if ko.Spec.MasterUserSecretKMSKeyRef != nil {
 		ko.Spec.MasterUserSecretKMSKeyID = nil
+	}
+
+	if ko.Spec.MonitoringRoleRef != nil {
+		ko.Spec.MonitoringRoleARN = nil
+	}
+
+	if ko.Spec.PerformanceInsightsKMSKeyRef != nil {
+		ko.Spec.PerformanceInsightsKMSKeyID = nil
 	}
 
 	if len(ko.Spec.VPCSecurityGroupRefs) > 0 {
@@ -112,6 +127,18 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForMonitoringRoleARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForPerformanceInsightsKMSKeyID(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForVPCSecurityGroupIDs(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
@@ -139,6 +166,14 @@ func validateReferenceFields(ko *svcapitypes.DBCluster) error {
 
 	if ko.Spec.MasterUserSecretKMSKeyRef != nil && ko.Spec.MasterUserSecretKMSKeyID != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("MasterUserSecretKMSKeyID", "MasterUserSecretKMSKeyRef")
+	}
+
+	if ko.Spec.MonitoringRoleRef != nil && ko.Spec.MonitoringRoleARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("MonitoringRoleARN", "MonitoringRoleRef")
+	}
+
+	if ko.Spec.PerformanceInsightsKMSKeyRef != nil && ko.Spec.PerformanceInsightsKMSKeyID != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("PerformanceInsightsKMSKeyID", "PerformanceInsightsKMSKeyRef")
 	}
 
 	if len(ko.Spec.VPCSecurityGroupRefs) > 0 && len(ko.Spec.VPCSecurityGroupIDs) > 0 {
@@ -452,6 +487,134 @@ func (rm *resourceManager) resolveReferenceForMasterUserSecretKMSKeyID(
 			return hasReferences, err
 		}
 		ko.Spec.MasterUserSecretKMSKeyID = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// resolveReferenceForMonitoringRoleARN reads the resource referenced
+// from MonitoringRoleRef field and sets the MonitoringRoleARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForMonitoringRoleARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.DBCluster,
+) (hasReferences bool, err error) {
+	if ko.Spec.MonitoringRoleRef != nil && ko.Spec.MonitoringRoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.MonitoringRoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: MonitoringRoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.MonitoringRoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Role looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Role(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *iamapitypes.Role,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Role",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Role",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Role",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Role",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
+	}
+	return nil
+}
+
+// resolveReferenceForPerformanceInsightsKMSKeyID reads the resource referenced
+// from PerformanceInsightsKMSKeyRef field and sets the PerformanceInsightsKMSKeyID
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForPerformanceInsightsKMSKeyID(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.DBCluster,
+) (hasReferences bool, err error) {
+	if ko.Spec.PerformanceInsightsKMSKeyRef != nil && ko.Spec.PerformanceInsightsKMSKeyRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.PerformanceInsightsKMSKeyRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: PerformanceInsightsKMSKeyRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &kmsapitypes.Key{}
+		if err := getReferencedResourceState_Key(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.PerformanceInsightsKMSKeyID = (*string)(obj.Status.ACKResourceMetadata.ARN)
 	}
 
 	return hasReferences, nil

--- a/pkg/resource/db_instance/delta.go
+++ b/pkg/resource/db_instance/delta.go
@@ -258,6 +258,9 @@ func newResourceDelta(
 			delta.Add("Spec.MonitoringRoleARN", a.ko.Spec.MonitoringRoleARN, b.ko.Spec.MonitoringRoleARN)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.MonitoringRoleRef, b.ko.Spec.MonitoringRoleRef) {
+		delta.Add("Spec.MonitoringRoleRef", a.ko.Spec.MonitoringRoleRef, b.ko.Spec.MonitoringRoleRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.MultiAZ, b.ko.Spec.MultiAZ) {
 		delta.Add("Spec.MultiAZ", a.ko.Spec.MultiAZ, b.ko.Spec.MultiAZ)
 	} else if a.ko.Spec.MultiAZ != nil && b.ko.Spec.MultiAZ != nil {
@@ -285,6 +288,9 @@ func newResourceDelta(
 		if *a.ko.Spec.OptionGroupName != *b.ko.Spec.OptionGroupName {
 			delta.Add("Spec.OptionGroupName", a.ko.Spec.OptionGroupName, b.ko.Spec.OptionGroupName)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.PerformanceInsightsKMSKeyRef, b.ko.Spec.PerformanceInsightsKMSKeyRef) {
+		delta.Add("Spec.PerformanceInsightsKMSKeyRef", a.ko.Spec.PerformanceInsightsKMSKeyRef, b.ko.Spec.PerformanceInsightsKMSKeyRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Port, b.ko.Spec.Port) {
 		delta.Add("Spec.Port", a.ko.Spec.Port, b.ko.Spec.Port)

--- a/pkg/resource/db_instance/references.go
+++ b/pkg/resource/db_instance/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
 	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
@@ -35,6 +36,12 @@ import (
 
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
+// +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
 
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
@@ -63,6 +70,14 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 
 	if ko.Spec.MasterUserSecretKMSKeyRef != nil {
 		ko.Spec.MasterUserSecretKMSKeyID = nil
+	}
+
+	if ko.Spec.MonitoringRoleRef != nil {
+		ko.Spec.MonitoringRoleARN = nil
+	}
+
+	if ko.Spec.PerformanceInsightsKMSKeyRef != nil {
+		ko.Spec.PerformanceInsightsKMSKeyID = nil
 	}
 
 	if len(ko.Spec.VPCSecurityGroupRefs) > 0 {
@@ -112,6 +127,18 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForMonitoringRoleARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForPerformanceInsightsKMSKeyID(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForVPCSecurityGroupIDs(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
@@ -139,6 +166,14 @@ func validateReferenceFields(ko *svcapitypes.DBInstance) error {
 
 	if ko.Spec.MasterUserSecretKMSKeyRef != nil && ko.Spec.MasterUserSecretKMSKeyID != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("MasterUserSecretKMSKeyID", "MasterUserSecretKMSKeyRef")
+	}
+
+	if ko.Spec.MonitoringRoleRef != nil && ko.Spec.MonitoringRoleARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("MonitoringRoleARN", "MonitoringRoleRef")
+	}
+
+	if ko.Spec.PerformanceInsightsKMSKeyRef != nil && ko.Spec.PerformanceInsightsKMSKeyID != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("PerformanceInsightsKMSKeyID", "PerformanceInsightsKMSKeyRef")
 	}
 
 	if len(ko.Spec.VPCSecurityGroupRefs) > 0 && len(ko.Spec.VPCSecurityGroupIDs) > 0 {
@@ -452,6 +487,134 @@ func (rm *resourceManager) resolveReferenceForMasterUserSecretKMSKeyID(
 			return hasReferences, err
 		}
 		ko.Spec.MasterUserSecretKMSKeyID = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// resolveReferenceForMonitoringRoleARN reads the resource referenced
+// from MonitoringRoleRef field and sets the MonitoringRoleARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForMonitoringRoleARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.DBInstance,
+) (hasReferences bool, err error) {
+	if ko.Spec.MonitoringRoleRef != nil && ko.Spec.MonitoringRoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.MonitoringRoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: MonitoringRoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.MonitoringRoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Role looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Role(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *iamapitypes.Role,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Role",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Role",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Role",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Role",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
+	}
+	return nil
+}
+
+// resolveReferenceForPerformanceInsightsKMSKeyID reads the resource referenced
+// from PerformanceInsightsKMSKeyRef field and sets the PerformanceInsightsKMSKeyID
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForPerformanceInsightsKMSKeyID(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.DBInstance,
+) (hasReferences bool, err error) {
+	if ko.Spec.PerformanceInsightsKMSKeyRef != nil && ko.Spec.PerformanceInsightsKMSKeyRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.PerformanceInsightsKMSKeyRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: PerformanceInsightsKMSKeyRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &kmsapitypes.Key{}
+		if err := getReferencedResourceState_Key(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.PerformanceInsightsKMSKeyID = (*string)(obj.Status.ACKResourceMetadata.ARN)
 	}
 
 	return hasReferences, nil

--- a/pkg/resource/db_proxy/delta.go
+++ b/pkg/resource/db_proxy/delta.go
@@ -91,6 +91,9 @@ func newResourceDelta(
 			delta.Add("Spec.RoleARN", a.ko.Spec.RoleARN, b.ko.Spec.RoleARN)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.RoleRef, b.ko.Spec.RoleRef) {
+		delta.Add("Spec.RoleRef", a.ko.Spec.RoleRef, b.ko.Spec.RoleRef)
+	}
 	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
 	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
 	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {

--- a/pkg/resource/db_proxy/references.go
+++ b/pkg/resource/db_proxy/references.go
@@ -17,13 +17,23 @@ package db_proxy
 
 import (
 	"context"
+	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
 )
+
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
 
 // ClearResolvedReferences removes any reference values that were made
 // concrete in the spec. It returns a copy of the input AWSResource which
@@ -31,6 +41,10 @@ import (
 // values.
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	if ko.Spec.RoleRef != nil {
+		ko.Spec.RoleARN = nil
+	}
 
 	return &resource{ko}
 }
@@ -47,11 +61,119 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, bool, error) {
-	return res, false, nil
+	ko := rm.concreteResource(res).ko
+
+	resourceHasReferences := false
+	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForRoleARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	return &resource{ko}, resourceHasReferences, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.DBProxy) error {
+
+	if ko.Spec.RoleRef != nil && ko.Spec.RoleARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("RoleARN", "RoleRef")
+	}
+	if ko.Spec.RoleRef == nil && ko.Spec.RoleARN == nil {
+		return ackerr.ResourceReferenceOrIDRequiredFor("RoleARN", "RoleRef")
+	}
+	return nil
+}
+
+// resolveReferenceForRoleARN reads the resource referenced
+// from RoleRef field and sets the RoleARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForRoleARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.DBProxy,
+) (hasReferences bool, err error) {
+	if ko.Spec.RoleRef != nil && ko.Spec.RoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.RoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: RoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.RoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Role looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Role(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *iamapitypes.Role,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Role",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Role",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Role",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Role",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
+	}
 	return nil
 }


### PR DESCRIPTION
Description of changes:
Adds cross-resource references for ARN fields on RDS resources so they can be resolved from other ACK resources via the generated `*Ref` fields:

| Resource | Field | Target |
| --- | --- | --- |
| DBCluster | monitoringRoleARN | iam/Role |
| DBCluster | performanceInsightsKMSKeyID | kms/Key |
| DBInstance | monitoringRoleARN | iam/Role |
| DBInstance | performanceInsightsKMSKeyID | kms/Key |
| DBProxy | roleARN | iam/Role |

These mirror existing reference patterns already in the controller (e.g. `kmsKeyID` -> kms/Key, `iamRoleARN` -> iam/Role).

Note: `optionGroupName` was flagged by the scanner but intentionally skipped — there is no ACK `OptionGroup` resource to reference.

Generated with code-generator `v0.60.0` / runtime `v0.60.0`, `AWS_SDK_GO_VERSION=v1.34.0`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
