### PR TITLE
DBInstance prevent EngineVersion delta for minor version differences when AutoMinorVersionUpgrade is true

### DIFF
--- a/pkg/resource/db_instance/delta_test.go
+++ b/pkg/resource/db_instance/delta_test.go
@@ -445,3 +445,114 @@ func TestNewResourceDelta_CustomPreCompare_DBClusterIdentifierSet(t *testing.T) 
 		})
 	}
 }
+
+// TestNewResourceDelta_EngineVersion_AutoMinorVersionUpgrade validates that a
+// difference confined to the engine minor version (same major version) is
+// suppressed when autoMinorVersionUpgrade is enabled (or unset, since the API
+// default is true), but is still detected when it is explicitly disabled or
+// when the major version differs.
+func TestNewResourceDelta_EngineVersion_AutoMinorVersionUpgrade(t *testing.T) {
+	tests := []struct {
+		name            string
+		desired         func() *svcapitypes.DBInstanceSpec
+		latest          func() *svcapitypes.DBInstanceSpec
+		expectDifferent bool
+	}{
+		{
+			name: "minor version drift suppressed when autoMinorVersionUpgrade is unset (defaults to true)",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					EngineVersion: aws.String("14.1"),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					EngineVersion: aws.String("14.2"),
+				}
+			},
+			expectDifferent: false,
+		},
+		{
+			name: "minor version drift suppressed when autoMinorVersionUpgrade is true",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					AutoMinorVersionUpgrade: aws.Bool(true),
+					EngineVersion:           aws.String("14.1"),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					AutoMinorVersionUpgrade: aws.Bool(true),
+					EngineVersion:           aws.String("14.2"),
+				}
+			},
+			expectDifferent: false,
+		},
+		{
+			name: "minor version drift detected when autoMinorVersionUpgrade is false",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					AutoMinorVersionUpgrade: aws.Bool(false),
+					EngineVersion:           aws.String("14.1"),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					AutoMinorVersionUpgrade: aws.Bool(false),
+					EngineVersion:           aws.String("14.2"),
+				}
+			},
+			expectDifferent: true,
+		},
+		{
+			name: "major version difference detected even when autoMinorVersionUpgrade is true",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					AutoMinorVersionUpgrade: aws.Bool(true),
+					EngineVersion:           aws.String("15.2"),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					AutoMinorVersionUpgrade: aws.Bool(true),
+					EngineVersion:           aws.String("14.2"),
+				}
+			},
+			expectDifferent: true,
+		},
+		{
+			name: "major-version-only spec suppressed against preferred minor version",
+			desired: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					AutoMinorVersionUpgrade: aws.Bool(false),
+					EngineVersion:           aws.String("14"),
+				}
+			},
+			latest: func() *svcapitypes.DBInstanceSpec {
+				return &svcapitypes.DBInstanceSpec{
+					AutoMinorVersionUpgrade: aws.Bool(false),
+					EngineVersion:           aws.String("14.2"),
+				}
+			},
+			expectDifferent: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			desired := &resource{
+				ko: &svcapitypes.DBInstance{
+					Spec: *tc.desired(),
+				},
+			}
+			latest := &resource{
+				ko: &svcapitypes.DBInstance{
+					Spec: *tc.latest(),
+				},
+			}
+			delta := newResourceDelta(desired, latest)
+			assert.Equal(t, tc.expectDifferent, delta.DifferentAt("Spec.EngineVersion"),
+				"unexpected Spec.EngineVersion delta result for case %q", tc.name)
+		})
+	}
+}

--- a/pkg/resource/db_instance/hooks.go
+++ b/pkg/resource/db_instance/hooks.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -530,17 +531,53 @@ func (rm *resourceManager) createDBInstanceReadReplica(
 	return &resource{r.ko}, nil
 }
 
+// majorEngineVersionRegexp captures the leading major-version component of an
+// engine version string (e.g. "14" from "14.2").
+var majorEngineVersionRegexp = regexp.MustCompile(`^[0-9]+`)
+
 // RDS will choose preferred engine minor version if only
 // engine major version is provided and controler should not
 // treat them as different, such as spec has 14, status has 14.1
-// controller should treat them as same
+// controller should treat them as same.
+//
+// Additionally, when autoMinorVersionUpgrade is enabled (the API default),
+// RDS may automatically upgrade the instance's minor version. In that case a
+// difference that is limited to the minor version (same major version) should
+// not be treated as drift, otherwise the controller would attempt to "correct"
+// the engine version on every reconcile. See the equivalent handling for
+// DBCluster in pkg/resource/db_cluster.
 func reconcileEngineVersion(
 	a *resource,
 	b *resource,
 ) {
-	if a != nil && b != nil && a.ko.Spec.EngineVersion != nil && b.ko.Spec.EngineVersion != nil && strings.HasPrefix(*b.ko.Spec.EngineVersion, *a.ko.Spec.EngineVersion) {
+	if a == nil || b == nil ||
+		a.ko.Spec.EngineVersion == nil || b.ko.Spec.EngineVersion == nil {
+		return
+	}
+	// RDS chose a preferred minor version for a major-version-only spec.
+	if strings.HasPrefix(*b.ko.Spec.EngineVersion, *a.ko.Spec.EngineVersion) {
+		a.ko.Spec.EngineVersion = b.ko.Spec.EngineVersion
+		return
+	}
+	// autoMinorVersionUpgrade defaults to true to match the RDS API default.
+	autoMinorVersionUpgrade := true
+	if a.ko.Spec.AutoMinorVersionUpgrade != nil {
+		autoMinorVersionUpgrade = *a.ko.Spec.AutoMinorVersionUpgrade
+	}
+	if !requireEngineVersionUpdate(a.ko.Spec.EngineVersion, b.ko.Spec.EngineVersion, autoMinorVersionUpgrade) {
 		a.ko.Spec.EngineVersion = b.ko.Spec.EngineVersion
 	}
+}
+
+// requireEngineVersionUpdate returns true when the desired engine version
+// represents a meaningful change from the latest observed version that the
+// controller must act on. When autoMinorVersionUpgrade is enabled, a
+// difference confined to the minor version (same major version) is left to RDS
+// and not treated as drift.
+func requireEngineVersionUpdate(desiredEngineVersion *string, latestEngineVersion *string, autoMinorVersionUpgrade bool) bool {
+	desiredMajorEngineVersion := majorEngineVersionRegexp.FindString(*desiredEngineVersion)
+	latestMajorEngineVersion := majorEngineVersionRegexp.FindString(*latestEngineVersion)
+	return !autoMinorVersionUpgrade || desiredMajorEngineVersion != latestMajorEngineVersion
 }
 
 // syncTags keeps the resource's tags in sync


### PR DESCRIPTION
Issue #, if available: [2850](https://github.com/aws-controllers-k8s/community/issues/2850)

Description of changes:
Similar to behavior addressed in #279 for DBCluster, the DBInstance resource would detect drift for `Spec.EngineVersion` for minor version differences even if `AutoMinorVersionUpgrade` was set to true. This PR applies a similar fix while maintaining the existing behavior of suppressing diffs minor version diff when only the major version is specified in `Spec.EngineVersion`.

- Update reconcileEngineVersion to suppress engine versions deltas for minor version diffs when  AutoMinorVersionUpgrade is set to true or nil (assumes default value)
- Add test cases to delta_test.go to validate EngineVersion comparison behavior

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
