### PR TITLE
fix: prevent reconcile loop on DBInstance caused by DatabaseInsightsMode drift

### DIFF
--- a/pkg/resource/db_instance/hooks.go
+++ b/pkg/resource/db_instance/hooks.go
@@ -160,9 +160,11 @@ func customPreCompare(delta *ackcompare.Delta, a *resource, b *resource) {
 				delta.Add("Spec.StorageType", a.ko.Spec.StorageType, b.ko.Spec.StorageType)
 			}
 		}
-		if ackcompare.HasNilDifference(a.ko.Spec.DatabaseInsightsMode, b.ko.Spec.DatabaseInsightsMode) {
-			delta.Add("Spec.DatabaseInsightsMode", a.ko.Spec.DatabaseInsightsMode, b.ko.Spec.DatabaseInsightsMode)
-		} else if a.ko.Spec.DatabaseInsightsMode != nil && b.ko.Spec.DatabaseInsightsMode != nil {
+		// Only compare DatabaseInsightsMode when both are non-nil (user explicitly set it).
+		// When desired is nil (user didn't set it), skip the comparison to avoid a reconcile
+		// loop caused by AWS defaulting to "standard" on every DescribeDBInstances response.
+		// See: https://github.com/aws-controllers-k8s/community/issues/2956
+		if a.ko.Spec.DatabaseInsightsMode != nil && b.ko.Spec.DatabaseInsightsMode != nil {
 			if *a.ko.Spec.DatabaseInsightsMode != *b.ko.Spec.DatabaseInsightsMode {
 				delta.Add("Spec.DatabaseInsightsMode", a.ko.Spec.DatabaseInsightsMode, b.ko.Spec.DatabaseInsightsMode)
 			}


### PR DESCRIPTION
## Description

The `customPreCompare` hook in `hooks.go` compares `DatabaseInsightsMode` using `HasNilDifference`, which triggers a delta on every reconcile because:
- Desired (user's CR): `DatabaseInsightsMode = nil` (user didn't set it)
- Latest (from AWS): `DatabaseInsightsMode = "standard"` (AWS default)

This causes `ModifyDBInstance` to be called every ~31 seconds for every DBInstance resource, even though no actual changes are needed (~750 no-op API calls/hour across 8 instances).

## Root cause

The `generator.yaml` correctly has `compare: is_ignored: true` for `DatabaseInsightsMode`, which excludes it from the auto-generated `delta.go`. However, `customPreCompare` is a separate hand-written hook that runs independently and adds the field back to the delta using `HasNilDifference`.

## Fix

Remove the `HasNilDifference` check — only compare `DatabaseInsightsMode` when **both** desired and latest are non-nil (i.e., user explicitly set the field). This matches the pattern used for `BackupTarget` and `NetworkType` earlier in the same function.

## Evidence

Controller logs (v1.10.1) show only one delta triggering the loop:
```json
{"msg":"desired resource state has changed","kind":"DBInstance","name":"grafana-dev",
 "diff":[{"Path":{"Parts":["Spec","DatabaseInsightsMode"]},"A":null,"B":"standard"}]}
```

CloudTrail: 50 `ModifyDBInstance` calls in 4 minutes, all no-ops with only `applyImmediately: true` + `allowMajorVersionUpgrade: true`.

## Testing
- `go build ./pkg/resource/db_instance/...` compiles clean
- Existing unit tests pass

## Related
- Fixes https://github.com/aws-controllers-k8s/community/issues/2956
- Complementary to #308 (which addresses the separate `AllowMajorVersionUpgrade` override issue)

/kind bug