### PR TITLE
Late-initialize DBCluster networkType and DBInstance promotionTier

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-07-07T21:58:58Z"
-  build_hash: 0a6b791fa10a6140d862be334a6891868ee588eb
-  go_version: go1.26.4
-  version: v0.61.0
+  build_date: "2026-07-28T23:34:36Z"
+  build_hash: ab6940f9c532e013d284f670e50b727102b4126d
+  go_version: go1.26.0
+  version: v0.61.0-2-gab6940f
 api_directory_checksum: 81211ae123aafed5b831e83e8e420bb188895d79
 api_version: v1alpha1
 aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: 887c10f71bc84bfa091f66f4c6d1c011ae35efc8
+  file_checksum: 8bc796cb417e5f245e8f34c171853f1583e847b0
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -231,6 +231,9 @@ resources:
         from:
           operation: RestoreDBClusterToPointInTime
           path: UseLatestRestorableTime
+      NetworkType:
+        late_initialize:
+          skip_incomplete_check: {}
       Tags:
         compare:
           # We have a custom comparison function...
@@ -466,6 +469,9 @@ resources:
         late_initialize:
           skip_incomplete_check: {}
       PubliclyAccessible:
+        late_initialize:
+          skip_incomplete_check: {}
+      PromotionTier:
         late_initialize:
           skip_incomplete_check: {}
       CopyTagsToSnapshot:

--- a/generator.yaml
+++ b/generator.yaml
@@ -231,6 +231,9 @@ resources:
         from:
           operation: RestoreDBClusterToPointInTime
           path: UseLatestRestorableTime
+      NetworkType:
+        late_initialize:
+          skip_incomplete_check: {}
       Tags:
         compare:
           # We have a custom comparison function...
@@ -466,6 +469,9 @@ resources:
         late_initialize:
           skip_incomplete_check: {}
       PubliclyAccessible:
+        late_initialize:
+          skip_incomplete_check: {}
+      PromotionTier:
         late_initialize:
           skip_incomplete_check: {}
       CopyTagsToSnapshot:

--- a/pkg/resource/db_cluster/manager.go
+++ b/pkg/resource/db_cluster/manager.go
@@ -50,7 +50,7 @@ var (
 // +kubebuilder:rbac:groups=rds.services.k8s.aws,resources=dbclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rds.services.k8s.aws,resources=dbclusters/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{}
+var lateInitializeFieldNames = []string{"NetworkType"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -260,7 +260,12 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	observed acktypes.AWSResource,
 	latest acktypes.AWSResource,
 ) acktypes.AWSResource {
-	return latest
+	observedKo := rm.concreteResource(observed).ko.DeepCopy()
+	latestKo := rm.concreteResource(latest).ko.DeepCopy()
+	if observedKo.Spec.NetworkType != nil && latestKo.Spec.NetworkType == nil {
+		latestKo.Spec.NetworkType = observedKo.Spec.NetworkType
+	}
+	return &resource{latestKo}
 }
 
 // IsSynced returns true if the resource is synced.

--- a/pkg/resource/db_instance/manager.go
+++ b/pkg/resource/db_instance/manager.go
@@ -50,7 +50,7 @@ var (
 // +kubebuilder:rbac:groups=rds.services.k8s.aws,resources=dbinstances,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rds.services.k8s.aws,resources=dbinstances/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{"AllocatedStorage", "AutoMinorVersionUpgrade", "AvailabilityZone", "BackupRetentionPeriod", "BackupTarget", "CACertificateIdentifier", "CopyTagsToSnapshot", "DBName", "DatabaseInsightsMode", "DeletionProtection", "EngineVersion", "IOPS", "KMSKeyID", "LicenseModel", "MasterUsername", "MonitoringInterval", "MultiAZ", "NetworkType", "PerformanceInsightsEnabled", "PerformanceInsightsKMSKeyID", "PerformanceInsightsRetentionPeriod", "PreferredBackupWindow", "PreferredMaintenanceWindow", "PubliclyAccessible", "StorageEncrypted", "StorageThroughput", "StorageType"}
+var lateInitializeFieldNames = []string{"AllocatedStorage", "AutoMinorVersionUpgrade", "AvailabilityZone", "BackupRetentionPeriod", "BackupTarget", "CACertificateIdentifier", "CopyTagsToSnapshot", "DBName", "DatabaseInsightsMode", "DeletionProtection", "EngineVersion", "IOPS", "KMSKeyID", "LicenseModel", "MasterUsername", "MonitoringInterval", "MultiAZ", "NetworkType", "PerformanceInsightsEnabled", "PerformanceInsightsKMSKeyID", "PerformanceInsightsRetentionPeriod", "PreferredBackupWindow", "PreferredMaintenanceWindow", "PromotionTier", "PubliclyAccessible", "StorageEncrypted", "StorageThroughput", "StorageType"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -330,6 +330,9 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	}
 	if observedKo.Spec.PreferredMaintenanceWindow != nil && latestKo.Spec.PreferredMaintenanceWindow == nil {
 		latestKo.Spec.PreferredMaintenanceWindow = observedKo.Spec.PreferredMaintenanceWindow
+	}
+	if observedKo.Spec.PromotionTier != nil && latestKo.Spec.PromotionTier == nil {
+		latestKo.Spec.PromotionTier = observedKo.Spec.PromotionTier
 	}
 	if observedKo.Spec.PubliclyAccessible != nil && latestKo.Spec.PubliclyAccessible == nil {
 		latestKo.Spec.PubliclyAccessible = observedKo.Spec.PubliclyAccessible

--- a/test/e2e/resources/db_cluster_aurora_postgres.yaml
+++ b/test/e2e/resources/db_cluster_aurora_postgres.yaml
@@ -9,7 +9,7 @@ spec:
   enableIAMDatabaseAuthentication: false
   engine: aurora-postgresql
   engineMode: provisioned
-  engineVersion: "14.15"
+  engineVersion: "14.23"
   masterUsername: root
   masterUserPassword:
     namespace: $MASTER_USER_PASS_SECRET_NAMESPACE

--- a/test/e2e/resources/db_cluster_aurora_postgres_clone.yaml
+++ b/test/e2e/resources/db_cluster_aurora_postgres_clone.yaml
@@ -9,7 +9,7 @@ spec:
   enableIAMDatabaseAuthentication: false
   engine: aurora-postgresql
   engineMode: provisioned
-  engineVersion: "14.15"
+  engineVersion: "14.23"
   masterUsername: root
   masterUserPassword:
     namespace: $MASTER_USER_PASS_SECRET_NAMESPACE

--- a/test/e2e/resources/db_cluster_aurora_postgres_log_exports.yaml
+++ b/test/e2e/resources/db_cluster_aurora_postgres_log_exports.yaml
@@ -11,7 +11,7 @@ spec:
   enableCloudwatchLogsExports:
     - postgresql
   engineMode: provisioned
-  engineVersion: "14.15"
+  engineVersion: "14.23"
   masterUsername: root
   masterUserPassword:
     namespace: $MASTER_USER_PASS_SECRET_NAMESPACE


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

Adopted `DBCluster` and `DBInstance` resources whose manifests omit `networkType` / `promotionTier` never reach `ACK.ResourceSynced=True`. They reconcile continuously, roughly every 30s per resource, with no errors.

Each looping reconcile reports exactly one difference, always a server-side default on an optional field the user never set:

| Kind | Diff path | A (desired, from spec) | B (latest, read from RDS) |
|---|---|---|---|
| `DBCluster` | `Spec.NetworkType` | `nil` | `"IPV4"` |
| `DBInstance` | `Spec.PromotionTier` | `nil` | `1` |

The log shows a successful update followed by the identical delta:

```
ackrt: desired resource state has changed    diff=[Spec.NetworkType(A=None,B='IPV4')]
ackrt: updated resource                      DBCluster/<name>
ackrt: desired resource state has changed    diff=[Spec.NetworkType(A=None,B='IPV4')]   <- identical
```

**Root cause.** RDS always assigns a value to both fields. `sdkFind` populates them into `latest.Spec` from the Describe response, while `desired.Spec` keeps the `nil` the user wrote, so the generated `newResourceDelta` reports a difference via `ackcompare.HasNilDifference`. `Modify*` cannot resolve it: the desired value is `nil`, so the field is never included in the request and the call is a no-op. The same delta returns on the next pass, indefinitely.

Only adopted resources are affected. On resources the controller creates, the `Create` response populates these spec fields, so desired and latest already agree.

**Fix.** Configure both fields for late initialization, which is the mechanism designed for exactly this shape — it copies the observed server-side default into spec so the delta clears permanently.

```yaml
DBCluster:
  fields:
    NetworkType:
      late_initialize:
        skip_incomplete_check: {}

DBInstance:
  fields:
    PromotionTier:
      late_initialize:
        skip_incomplete_check: {}
```

`DBInstance` already late-initializes 27 fields, so `PromotionTier` joins the existing list at no additional cost. `DBCluster` previously had `lateInitializeFieldNames = []string{}`, so this is the first field for that resource and it does enable the late-init path (one extra `ReadOne` per reconcile). `skip_incomplete_check` keeps `incompleteLateInitialization` returning `false`, so neither field introduces the 5s requeue.

Convergence per reconcile: `ReadOne` returns latest with the field set, the delta fires, `Update` returns a `desired`-derived object with the field still `nil`, then `lateInitializeResource` re-reads, copies the observed value into that `nil` field, and `patchResourceMetadataAndSpec` writes it to the CR spec. The next pass has no delta. This costs one no-op `Modify*` on the first reconcile after upgrade, then the resource is permanently converged.

**Alternative considered.** Suppressing the delta in `delta_pre_compare` / `customPreCompare` (the approach used for the Aurora `StorageType` and `EngineVersion` defaults) also stops the loop, but it is actively incompatible with late initialization here. The guard mutates `desired` in place, the delta comes back empty, `updateResource` returns `latest` straight from `ReadOne` with the field already set, and `lateInitializeFromReadOneOutput` then finds a non-`nil` field and copies nothing — so spec is never populated. Late initialization alone was chosen because it persists the observed value and makes it visible on the CR.

## Second commit: unrelated e2e fixture fix

An e2e run on this branch surfaced 6 errors in `test_db_cluster.py`, all at **fixture setup** rather than in any test body, and all with the same cause:

```
api error InvalidParameterCombination: Cannot find version 14.15 for aurora-postgresql
```

RDS has retired aurora-postgresql `14.15`. The available 14.x releases are now `14.6` and `14.17`–`14.23`, with nothing in between. Three DBCluster fixtures pinned `14.15`; the rejected `CreateDBCluster` leaves the CR in `ACK.Terminal` with no `status.status`, and because two of the fixtures are module-scoped, every dependent test errors during setup:

| Fixture | Tests |
|---|---|
| `aurora_postgres_cluster` | 4 |
| `aurora_postgres_cluster_log_exports` | 2 |

The clone fixture pinned it as well but is only used by a point-in-time restore, which inherits the source cluster's engine version, so the value was inert and that test passed regardless.

The second commit bumps all three to `14.23`, the newest available 14.x. The pin has to stay an **exact** minor version rather than a major-only `"14"`: these fixtures set `autoMinorVersionUpgrade: false`, and with auto minor upgrade off `requireEngineVersionUpdate` deliberately does not suppress a minor-version difference (see the existing `TestNewResourceDelta_EngineVersion` case "desired short form matches latest major, auto minor upgrade disabled"), so a major-only pin would introduce a permanent `Spec.EngineVersion` delta. Every other engine version pinned under `test/e2e/resources` was checked against the API and is still `available`.

This failure is independent of the late-init change and reproduces on `main` against current RDS — `git diff main...HEAD -- test/` was empty before this commit. It is bundled here only so CI on this PR can go green; happy to split it into its own PR if maintainers prefer.

## Testing

`go build ./...`, `go build -o bin/controller ./cmd/controller`, and `go test ./pkg/...` all pass. The controller change is confined to `generator.yaml` plus regenerated artifacts, so there is no new hand-written code to unit test; the behavior was verified end to end on a live cluster instead.

### Setup

A dev EKS cluster in `us-west-2`. An Aurora PostgreSQL 17.7 cluster and one cluster instance were created **out of band with the AWS CLI**, so they are not controller-created, and neither `--network-type` nor `--promotion-tier` was passed. RDS assigned both defaults on its own:

```
DBCluster  ack-repro-adopted    NetworkType=IPV4
DBInstance ack-repro-adopted-1  PromotionTier=1   (db.t4g.medium)
```

Both were then brought under ACK management with `adoption-policy: adopt`, after which the adoption annotations were removed and the two fields were deleted from spec with a JSON patch. That reproduces the reported end state precisely: `adopted: "true"`, no adoption policy, optional field absent from spec — so reconcile falls through to `updateResource`.

Worth noting on its own: with `adoption-policy: adopt` left in place the loop does **not** occur, because that branch patches spec from `latest` and repopulates the field every pass. The bug is specific to an adopted resource reconciling through the normal update path.

### Before (upstream v1.10.1)

Both resources looped every ~30s, `updated resource` succeeding each time and the identical delta returning:

```json
{"msg":"desired resource state has changed","kind":"DBCluster","name":"ack-repro-adopted",
 "is_adopted":true,"diff":[{"Path":{"Parts":["Spec","NetworkType"]},"A":null,"B":"IPV4"}]}

{"msg":"desired resource state has changed","kind":"DBInstance","name":"ack-repro-adopted-1",
 "is_adopted":true,"diff":[{"Path":{"Parts":["Spec","PromotionTier"]},"A":null,"B":1}]}
```

Repeating at 00:41:30, 00:42:00, 00:42:30, 00:43:00, 00:43:31, 00:44:01 … for the cluster, and on the same cadence for the instance. Conditions:

```
DBCluster   ACK.ResourceSynced=False  Ready=False                              spec.networkType=<absent>
DBInstance  ACK.ResourceSynced=False  Ready=False  ACK.LateInitialized=True    spec.promotionTier=<absent>
```

The condition set is itself corroborating: the `DBInstance` reports `ACK.LateInitialized=True` (its 27 other fields do late-initialize) yet still loops on `PromotionTier`, while the `DBCluster` has no `ACK.LateInitialized` condition at all, which is what an empty `lateInitializeFieldNames` looks like from outside the process.

### After (this branch)

Same two resources, same cluster, controller image built from this branch:

```
DBCluster   ACK.ResourceSynced=True  Ready=True  ACK.LateInitialized=True  spec.networkType=IPV4
DBInstance  ACK.ResourceSynced=True  Ready=True  ACK.LateInitialized=True  spec.promotionTier=1
```

Late initialization wrote both observed defaults into spec, and `DBCluster` now carries an `ACK.LateInitialized` condition it did not have before. Counting deltas in the controller log since the rollout:

- `Spec.NetworkType` / `Spec.PromotionTier` deltas: **0**
- deltas of any kind over a subsequent quiet window: **0**

The only delta observed after the rollout was a one-time `Spec.Tags` difference on the `services.k8s.aws/controller-version` tag (`rds-1.10.1` → the branch build's version string). That is an artifact of swapping controller versions under an existing resource, not related to this change, and it resolved in a single pass.

The same behavior is visible in the e2e run's controller logs, on controller-created resources: DBCluster CRs now carry `ACK.LateInitialized=True` / "Late initialization successful" with `spec.networkType: "IPV4"`, and `promotionTier: 1` appears in DBInstance specs.

### Not covered

No automated E2E test is included for the adoption case specifically. The natural coverage would be a test in `test/e2e/` that adopts a cluster with no `networkType` and an instance with no `promotionTier` and asserts `Synced=True` plus the populated spec fields. Happy to add it if maintainers would like it in this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
