### PR TITLE
feat(rds): Add twelve cross-resource references on top-level fields

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-08-04T17:30:04Z"
-  build_hash: db232581a560896c2dc461a244f96d5bf3191ec6
-  go_version: go1.26.5
-  version: v0.62.0
+  build_date: "2026-08-13T16:48:13Z"
+  build_hash: 65d45b2e6c9efd6aca20e0d36826d1e18e4ba2b7
+  go_version: go1.26.0
+  version: v0.62.1
 api_directory_checksum: 81211ae123aafed5b831e83e8e420bb188895d79
 api_version: v1alpha1
 aws_sdk_go_version: v1.34.0

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-08-13T22:05:10Z"
-  build_hash: 3dfc7a1e4135d59e6b1ecf6955ab1df4e829c9b5
+  build_date: "2026-08-13T22:22:49Z"
+  build_hash: 65d45b2e6c9efd6aca20e0d36826d1e18e4ba2b7
   go_version: go1.26.0
-  version: v0.62.1-2-g3dfc7a1-dirty
+  version: v0.62.1
 api_directory_checksum: d99401cf512d4785088e63c42c4039efe8f5c2fe
 api_version: v1alpha1
 aws_sdk_go_version: v1.34.0

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-08-13T16:48:13Z"
+  build_date: "2026-08-13T16:53:34Z"
   build_hash: 65d45b2e6c9efd6aca20e0d36826d1e18e4ba2b7
   go_version: go1.26.0
   version: v0.62.1
-api_directory_checksum: 81211ae123aafed5b831e83e8e420bb188895d79
+api_directory_checksum: 2c13c1b02a7fadc5c9082bad1d8153238c05c117
 api_version: v1alpha1
 aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: 8bc796cb417e5f245e8f34c171853f1583e847b0
+  file_checksum: 77ed7e6d7aa712c72a8871251ad3c46e2c1feee2
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,9 +1,9 @@
 ack_generate_info:
-  build_date: "2026-08-25T20:58:21Z"
-  build_hash: 65d45b2e6c9efd6aca20e0d36826d1e18e4ba2b7
+  build_date: "2026-08-25T21:02:24Z"
+  build_hash: d4aaca5e1dd6acfd81094936dc825ad30d2bbb39
   go_version: go1.26.0
-  version: v0.62.1
-api_directory_checksum: dcd3e71094e55a7524cb2422f1bf69bbd3e03d49
+  version: v0.62.1-4-gd4aaca5
+api_directory_checksum: 2aad9b61dd0449c9d4d098ddc4acf735bbbb5662
 api_version: v1alpha1
 aws_sdk_go_version: v1.34.0
 generator_config_info:

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-08-13T22:22:49Z"
+  build_date: "2026-08-25T20:58:21Z"
   build_hash: 65d45b2e6c9efd6aca20e0d36826d1e18e4ba2b7
   go_version: go1.26.0
   version: v0.62.1
-api_directory_checksum: d99401cf512d4785088e63c42c4039efe8f5c2fe
+api_directory_checksum: dcd3e71094e55a7524cb2422f1bf69bbd3e03d49
 api_version: v1alpha1
 aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: 77ed7e6d7aa712c72a8871251ad3c46e2c1feee2
+  file_checksum: a8694cb579eab93d0308c689eba370bd99a52622
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/db_cluster.go
+++ b/apis/v1alpha1/db_cluster.go
@@ -190,7 +190,8 @@ type DBClusterSpec struct {
 	// The name of the IAM role to use when making API calls to the Directory Service.
 	//
 	// Valid for Cluster Type: Aurora DB clusters only
-	DomainIAMRoleName *string `json:"domainIAMRoleName,omitempty"`
+	DomainIAMRoleName *string                                  `json:"domainIAMRoleName,omitempty"`
+	DomainIAMRoleRef  *ackv1alpha1.AWSResourceReferenceWrapper `json:"domainIAMRoleRef,omitempty"`
 	// The list of log types that need to be enabled for exporting to CloudWatch
 	// Logs.
 	//
@@ -708,7 +709,8 @@ type DBClusterSpec struct {
 	//   - Must match the identifier of an existing DBCluster.
 	//
 	// Valid for: Aurora DB clusters and Multi-AZ DB clusters
-	SourceDBClusterIdentifier *string `json:"sourceDBClusterIdentifier,omitempty"`
+	SourceDBClusterIdentifier    *string                                  `json:"sourceDBClusterIdentifier,omitempty"`
+	SourceDBClusterIdentifierRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"sourceDBClusterIdentifierRef,omitempty"`
 	// SourceRegion is the source region where the resource exists. This is not
 	// sent over the wire and is only used for presigning. This value should always
 	// have the same region as the source ARN.

--- a/apis/v1alpha1/db_cluster.go
+++ b/apis/v1alpha1/db_cluster.go
@@ -190,8 +190,7 @@ type DBClusterSpec struct {
 	// The name of the IAM role to use when making API calls to the Directory Service.
 	//
 	// Valid for Cluster Type: Aurora DB clusters only
-	DomainIAMRoleName *string                                  `json:"domainIAMRoleName,omitempty"`
-	DomainIAMRoleRef  *ackv1alpha1.AWSResourceReferenceWrapper `json:"domainIAMRoleRef,omitempty"`
+	DomainIAMRoleName *string `json:"domainIAMRoleName,omitempty"`
 	// The list of log types that need to be enabled for exporting to CloudWatch
 	// Logs.
 	//

--- a/apis/v1alpha1/db_cluster_endpoint.go
+++ b/apis/v1alpha1/db_cluster_endpoint.go
@@ -51,7 +51,8 @@ type DBClusterEndpointSpec struct {
 	// List of DB instance identifiers that aren't part of the custom endpoint group.
 	// All other eligible instances are reachable through the custom endpoint. This
 	// parameter is relevant only if the list of static members is empty.
-	ExcludedMembers []*string `json:"excludedMembers,omitempty"`
+	ExcludedMembers  []*string                                  `json:"excludedMembers,omitempty"`
+	StaticMemberRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"staticMemberRefs,omitempty"`
 	// List of DB instance identifiers that are part of the custom endpoint group.
 	StaticMembers []*string `json:"staticMembers,omitempty"`
 	// The tags to be assigned to the Amazon RDS resource.

--- a/apis/v1alpha1/db_instance.go
+++ b/apis/v1alpha1/db_instance.go
@@ -227,11 +227,13 @@ type DBInstanceSpec struct {
 	// For the list of permissions required for the IAM role, see Configure IAM
 	// and your VPC (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/custom-setup-orcl.html#custom-setup-orcl.iam-vpc)
 	// in the Amazon RDS User Guide.
-	CustomIAMInstanceProfile *string `json:"customIAMInstanceProfile,omitempty"`
+	CustomIAMInstanceProfile    *string                                  `json:"customIAMInstanceProfile,omitempty"`
+	CustomIAMInstanceProfileRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"customIAMInstanceProfileRef,omitempty"`
 	// The identifier of the DB cluster that this DB instance will belong to.
 	//
 	// This setting doesn't apply to RDS Custom DB instances.
-	DBClusterIdentifier *string `json:"dbClusterIdentifier,omitempty"`
+	DBClusterIdentifier    *string                                  `json:"dbClusterIdentifier,omitempty"`
+	DBClusterIdentifierRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"dbClusterIdentifierRef,omitempty"`
 	// The identifier for the Multi-AZ DB cluster snapshot to restore from.
 	//
 	// For more information on Multi-AZ DB clusters, see Multi-AZ DB cluster deployments
@@ -250,7 +252,8 @@ type DBInstanceSpec struct {
 	//     the DBClusterSnapshotIdentifier must be the ARN of the shared snapshot.
 	//
 	//   - Can't be the identifier of an Aurora DB cluster snapshot.
-	DBClusterSnapshotIdentifier *string `json:"dbClusterSnapshotIdentifier,omitempty"`
+	DBClusterSnapshotIdentifier    *string                                  `json:"dbClusterSnapshotIdentifier,omitempty"`
+	DBClusterSnapshotIdentifierRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"dbClusterSnapshotIdentifierRef,omitempty"`
 	// The compute and memory capacity of the DB instance, for example db.m5.large.
 	// Not all DB instance classes are available in all Amazon Web Services Regions,
 	// or for all database engines. For the full list of DB instance classes, and
@@ -430,7 +433,8 @@ type DBInstanceSpec struct {
 	//
 	//   - If you are restoring from a shared manual DB snapshot, the DBSnapshotIdentifier
 	//     must be the ARN of the shared DB snapshot.
-	DBSnapshotIdentifier *string `json:"dbSnapshotIdentifier,omitempty"`
+	DBSnapshotIdentifier    *string                                  `json:"dbSnapshotIdentifier,omitempty"`
+	DBSnapshotIdentifierRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"dbSnapshotIdentifierRef,omitempty"`
 	// A DB subnet group to associate with this DB instance.
 	//
 	// Constraints:
@@ -478,7 +482,8 @@ type DBInstanceSpec struct {
 	//   - Amazon Aurora (The domain is managed by the DB cluster.)
 	//
 	//   - RDS Custom
-	DomainIAMRoleName *string `json:"domainIAMRoleName,omitempty"`
+	DomainIAMRoleName *string                                  `json:"domainIAMRoleName,omitempty"`
+	DomainIAMRoleRef  *ackv1alpha1.AWSResourceReferenceWrapper `json:"domainIAMRoleRef,omitempty"`
 	// The list of log types to enable for exporting to CloudWatch Logs. For more
 	// information, see Publishing Database Logs to Amazon CloudWatch Logs (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html#USER_LogAccess.Procedural.UploadtoCloudWatch)
 	// in the Amazon RDS User Guide.
@@ -1118,7 +1123,8 @@ type DBInstanceSpec struct {
 	//     see Constructing an ARN for Amazon RDS (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.ARN.html#USER_Tagging.ARN.Constructing)
 	//     in the Amazon RDS User Guide. This doesn't apply to SQL Server or RDS
 	//     Custom, which don't support cross-Region replicas.
-	SourceDBInstanceIdentifier *string `json:"sourceDBInstanceIdentifier,omitempty"`
+	SourceDBInstanceIdentifier    *string                                  `json:"sourceDBInstanceIdentifier,omitempty"`
+	SourceDBInstanceIdentifierRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"sourceDBInstanceIdentifierRef,omitempty"`
 	// SourceRegion is the source region where the resource exists. This is not
 	// sent over the wire and is only used for presigning. This value should always
 	// have the same region as the source ARN.

--- a/apis/v1alpha1/db_instance.go
+++ b/apis/v1alpha1/db_instance.go
@@ -227,8 +227,7 @@ type DBInstanceSpec struct {
 	// For the list of permissions required for the IAM role, see Configure IAM
 	// and your VPC (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/custom-setup-orcl.html#custom-setup-orcl.iam-vpc)
 	// in the Amazon RDS User Guide.
-	CustomIAMInstanceProfile    *string                                  `json:"customIAMInstanceProfile,omitempty"`
-	CustomIAMInstanceProfileRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"customIAMInstanceProfileRef,omitempty"`
+	CustomIAMInstanceProfile *string `json:"customIAMInstanceProfile,omitempty"`
 	// The identifier of the DB cluster that this DB instance will belong to.
 	//
 	// This setting doesn't apply to RDS Custom DB instances.
@@ -252,8 +251,7 @@ type DBInstanceSpec struct {
 	//     the DBClusterSnapshotIdentifier must be the ARN of the shared snapshot.
 	//
 	//   - Can't be the identifier of an Aurora DB cluster snapshot.
-	DBClusterSnapshotIdentifier    *string                                  `json:"dbClusterSnapshotIdentifier,omitempty"`
-	DBClusterSnapshotIdentifierRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"dbClusterSnapshotIdentifierRef,omitempty"`
+	DBClusterSnapshotIdentifier *string `json:"dbClusterSnapshotIdentifier,omitempty"`
 	// The compute and memory capacity of the DB instance, for example db.m5.large.
 	// Not all DB instance classes are available in all Amazon Web Services Regions,
 	// or for all database engines. For the full list of DB instance classes, and
@@ -482,8 +480,7 @@ type DBInstanceSpec struct {
 	//   - Amazon Aurora (The domain is managed by the DB cluster.)
 	//
 	//   - RDS Custom
-	DomainIAMRoleName *string                                  `json:"domainIAMRoleName,omitempty"`
-	DomainIAMRoleRef  *ackv1alpha1.AWSResourceReferenceWrapper `json:"domainIAMRoleRef,omitempty"`
+	DomainIAMRoleName *string `json:"domainIAMRoleName,omitempty"`
 	// The list of log types to enable for exporting to CloudWatch Logs. For more
 	// information, see Publishing Database Logs to Amazon CloudWatch Logs (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_LogAccess.html#USER_LogAccess.Procedural.UploadtoCloudWatch)
 	// in the Amazon RDS User Guide.

--- a/apis/v1alpha1/db_proxy.go
+++ b/apis/v1alpha1/db_proxy.go
@@ -69,10 +69,11 @@ type DBProxySpec struct {
 	// with the proxy.
 	Tags []*Tag `json:"tags,omitempty"`
 	// One or more VPC security group IDs to associate with the new proxy.
-	VPCSecurityGroupIDs []*string `json:"vpcSecurityGroupIDs,omitempty"`
+	VPCSecurityGroupIDs  []*string                                  `json:"vpcSecurityGroupIDs,omitempty"`
+	VPCSecurityGroupRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"vpcSecurityGroupRefs,omitempty"`
 	// One or more VPC subnet IDs to associate with the new proxy.
-	// +kubebuilder:validation:Required
-	VPCSubnetIDs []*string `json:"vpcSubnetIDs"`
+	VPCSubnetIDs  []*string                                  `json:"vpcSubnetIDs,omitempty"`
+	VPCSubnetRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"vpcSubnetRefs,omitempty"`
 }
 
 // DBProxyStatus defines the observed state of DBProxy

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -211,6 +211,11 @@ resources:
           resource: SecurityGroup
           service_name: ec2
           path: Status.ID
+      DomainIAMRoleName:
+        references:
+          resource: Role
+          service_name: iam
+          path: Spec.Name
       SnapshotIdentifier:
         from:
           operation: RestoreDBClusterFromSnapshot
@@ -219,6 +224,9 @@ resources:
         from:
           operation: RestoreDBClusterToPointInTime
           path: SourceDBClusterIdentifier
+        references:
+          resource: DBCluster
+          path: Spec.DBClusterIdentifier
       RestoreType:
         from:
           operation: RestoreDBClusterToPointInTime
@@ -477,15 +485,35 @@ resources:
       CopyTagsToSnapshot:
         late_initialize:
           skip_incomplete_check: {}
+      DBClusterIdentifier:
+        references:
+          resource: DBCluster
+          path: Spec.DBClusterIdentifier
+      DomainIAMRoleName:
+        references:
+          resource: Role
+          service_name: iam
+          path: Spec.Name
+      CustomIAMInstanceProfile:
+        references:
+          resource: InstanceProfile
+          service_name: iam
+          path: Spec.Name
       # Used by restore db instance from db snapshot
       DBSnapshotIdentifier:
         from:
           operation: RestoreDBInstanceFromDBSnapshot
           path: DBSnapshotIdentifier
+        references:
+          resource: DBSnapshot
+          path: Spec.DBSnapshotIdentifier
       DBClusterSnapshotIdentifier:
         from:
           operation: RestoreDBInstanceFromDBSnapshot
           path: DBClusterSnapshotIdentifier
+        references:
+          resource: DBClusterSnapshot
+          path: Spec.DBClusterSnapshotIdentifier
       UseDefaultProcessorFeatures:
         from:
           operation: RestoreDBInstanceFromDBSnapshot
@@ -495,6 +523,9 @@ resources:
         from:
           operation: CreateDBInstanceReadReplica
           path: SourceDBInstanceIdentifier
+        references:
+          resource: DBInstance
+          path: Spec.DBInstanceIdentifier
       DestinationRegion:
         set:
           - ignore: all
@@ -547,6 +578,10 @@ resources:
     fields:
       GlobalClusterIdentifier:
         is_primary_key: true
+      SourceDBClusterIdentifier:
+        references:
+          resource: DBCluster
+          path: Status.ACKResourceMetadata.ARN
 
   DBParameterGroup:
     renames:
@@ -655,6 +690,16 @@ resources:
           resource: Role
           service_name: iam
           path: Status.ACKResourceMetadata.ARN
+      VpcSecurityGroupIds:
+        references:
+          resource: SecurityGroup
+          service_name: ec2
+          path: Status.ID
+      VpcSubnetIds:
+        references:
+          resource: Subnet
+          service_name: ec2
+          path: Status.SubnetID
     renames:
       operations:
         CreateDBProxy:
@@ -736,6 +781,10 @@ resources:
         references:
           resource: DBCluster
           path: Spec.DBClusterIdentifier
+      StaticMembers:
+        references:
+          resource: DBInstance
+          path: Spec.DBInstanceIdentifier
       Tags:
         compare:
           # We have a custom comparison function...

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -211,11 +211,6 @@ resources:
           resource: SecurityGroup
           service_name: ec2
           path: Status.ID
-      DomainIAMRoleName:
-        references:
-          resource: Role
-          service_name: iam
-          path: Spec.Name
       SnapshotIdentifier:
         from:
           operation: RestoreDBClusterFromSnapshot
@@ -489,16 +484,6 @@ resources:
         references:
           resource: DBCluster
           path: Spec.DBClusterIdentifier
-      DomainIAMRoleName:
-        references:
-          resource: Role
-          service_name: iam
-          path: Spec.Name
-      CustomIAMInstanceProfile:
-        references:
-          resource: InstanceProfile
-          service_name: iam
-          path: Spec.Name
       # Used by restore db instance from db snapshot
       DBSnapshotIdentifier:
         from:
@@ -511,9 +496,6 @@ resources:
         from:
           operation: RestoreDBInstanceFromDBSnapshot
           path: DBClusterSnapshotIdentifier
-        references:
-          resource: DBClusterSnapshot
-          path: Spec.DBClusterSnapshotIdentifier
       UseDefaultProcessorFeatures:
         from:
           operation: RestoreDBInstanceFromDBSnapshot

--- a/apis/v1alpha1/global_cluster.go
+++ b/apis/v1alpha1/global_cluster.go
@@ -71,7 +71,8 @@ type GlobalClusterSpec struct {
 	//   - EngineVersion
 	//
 	//   - StorageEncrypted
-	SourceDBClusterIdentifier *string `json:"sourceDBClusterIdentifier,omitempty"`
+	SourceDBClusterIdentifier    *string                                  `json:"sourceDBClusterIdentifier,omitempty"`
+	SourceDBClusterIdentifierRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"sourceDBClusterIdentifierRef,omitempty"`
 	// Specifies whether to enable storage encryption for the new global database
 	// cluster.
 	//

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -17,14 +17,12 @@ package v1alpha1
 
 import (
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
-	"github.com/aws/aws-sdk-go/aws"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Hack to avoid import errors during build...
 var (
 	_ = &metav1.Time{}
-	_ = &aws.JSONValue{}
 	_ = ackv1alpha1.AWSAccountID("")
 )
 

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -723,6 +723,17 @@ func (in *DBClusterEndpointSpec) DeepCopyInto(out *DBClusterEndpointSpec) {
 			}
 		}
 	}
+	if in.StaticMemberRefs != nil {
+		in, out := &in.StaticMemberRefs, &out.StaticMemberRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.StaticMembers != nil {
 		in, out := &in.StaticMembers, &out.StaticMembers
 		*out = make([]*string, len(*in))
@@ -1731,6 +1742,11 @@ func (in *DBClusterSpec) DeepCopyInto(out *DBClusterSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.DomainIAMRoleRef != nil {
+		in, out := &in.DomainIAMRoleRef, &out.DomainIAMRoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.EnableCloudwatchLogsExports != nil {
 		in, out := &in.EnableCloudwatchLogsExports, &out.EnableCloudwatchLogsExports
 		*out = make([]*string, len(*in))
@@ -1920,6 +1936,11 @@ func (in *DBClusterSpec) DeepCopyInto(out *DBClusterSpec) {
 		in, out := &in.SourceDBClusterIdentifier, &out.SourceDBClusterIdentifier
 		*out = new(string)
 		**out = **in
+	}
+	if in.SourceDBClusterIdentifierRef != nil {
+		in, out := &in.SourceDBClusterIdentifierRef, &out.SourceDBClusterIdentifierRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.SourceRegion != nil {
 		in, out := &in.SourceRegion, &out.SourceRegion
@@ -3205,15 +3226,30 @@ func (in *DBInstanceSpec) DeepCopyInto(out *DBInstanceSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.CustomIAMInstanceProfileRef != nil {
+		in, out := &in.CustomIAMInstanceProfileRef, &out.CustomIAMInstanceProfileRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.DBClusterIdentifier != nil {
 		in, out := &in.DBClusterIdentifier, &out.DBClusterIdentifier
 		*out = new(string)
 		**out = **in
 	}
+	if in.DBClusterIdentifierRef != nil {
+		in, out := &in.DBClusterIdentifierRef, &out.DBClusterIdentifierRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.DBClusterSnapshotIdentifier != nil {
 		in, out := &in.DBClusterSnapshotIdentifier, &out.DBClusterSnapshotIdentifier
 		*out = new(string)
 		**out = **in
+	}
+	if in.DBClusterSnapshotIdentifierRef != nil {
+		in, out := &in.DBClusterSnapshotIdentifierRef, &out.DBClusterSnapshotIdentifierRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DBInstanceClass != nil {
 		in, out := &in.DBInstanceClass, &out.DBInstanceClass
@@ -3244,6 +3280,11 @@ func (in *DBInstanceSpec) DeepCopyInto(out *DBInstanceSpec) {
 		in, out := &in.DBSnapshotIdentifier, &out.DBSnapshotIdentifier
 		*out = new(string)
 		**out = **in
+	}
+	if in.DBSnapshotIdentifierRef != nil {
+		in, out := &in.DBSnapshotIdentifierRef, &out.DBSnapshotIdentifierRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.DBSubnetGroupName != nil {
 		in, out := &in.DBSubnetGroupName, &out.DBSubnetGroupName
@@ -3279,6 +3320,11 @@ func (in *DBInstanceSpec) DeepCopyInto(out *DBInstanceSpec) {
 		in, out := &in.DomainIAMRoleName, &out.DomainIAMRoleName
 		*out = new(string)
 		**out = **in
+	}
+	if in.DomainIAMRoleRef != nil {
+		in, out := &in.DomainIAMRoleRef, &out.DomainIAMRoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.EnableCloudwatchLogsExports != nil {
 		in, out := &in.EnableCloudwatchLogsExports, &out.EnableCloudwatchLogsExports
@@ -3466,6 +3512,11 @@ func (in *DBInstanceSpec) DeepCopyInto(out *DBInstanceSpec) {
 		in, out := &in.SourceDBInstanceIdentifier, &out.SourceDBInstanceIdentifier
 		*out = new(string)
 		**out = **in
+	}
+	if in.SourceDBInstanceIdentifierRef != nil {
+		in, out := &in.SourceDBInstanceIdentifierRef, &out.SourceDBInstanceIdentifierRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.SourceRegion != nil {
 		in, out := &in.SourceRegion, &out.SourceRegion
@@ -4760,6 +4811,17 @@ func (in *DBProxySpec) DeepCopyInto(out *DBProxySpec) {
 			}
 		}
 	}
+	if in.VPCSecurityGroupRefs != nil {
+		in, out := &in.VPCSecurityGroupRefs, &out.VPCSecurityGroupRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.VPCSubnetIDs != nil {
 		in, out := &in.VPCSubnetIDs, &out.VPCSubnetIDs
 		*out = make([]*string, len(*in))
@@ -4768,6 +4830,17 @@ func (in *DBProxySpec) DeepCopyInto(out *DBProxySpec) {
 				in, out := &(*in)[i], &(*out)[i]
 				*out = new(string)
 				**out = **in
+			}
+		}
+	}
+	if in.VPCSubnetRefs != nil {
+		in, out := &in.VPCSubnetRefs, &out.VPCSubnetRefs
+		*out = make([]*corev1alpha1.AWSResourceReferenceWrapper, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+				(*in).DeepCopyInto(*out)
 			}
 		}
 	}
@@ -6665,6 +6738,11 @@ func (in *GlobalClusterSpec) DeepCopyInto(out *GlobalClusterSpec) {
 		in, out := &in.SourceDBClusterIdentifier, &out.SourceDBClusterIdentifier
 		*out = new(string)
 		**out = **in
+	}
+	if in.SourceDBClusterIdentifierRef != nil {
+		in, out := &in.SourceDBClusterIdentifierRef, &out.SourceDBClusterIdentifierRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.StorageEncrypted != nil {
 		in, out := &in.StorageEncrypted, &out.StorageEncrypted

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1742,11 +1742,6 @@ func (in *DBClusterSpec) DeepCopyInto(out *DBClusterSpec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.DomainIAMRoleRef != nil {
-		in, out := &in.DomainIAMRoleRef, &out.DomainIAMRoleRef
-		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.EnableCloudwatchLogsExports != nil {
 		in, out := &in.EnableCloudwatchLogsExports, &out.EnableCloudwatchLogsExports
 		*out = make([]*string, len(*in))
@@ -3226,11 +3221,6 @@ func (in *DBInstanceSpec) DeepCopyInto(out *DBInstanceSpec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.CustomIAMInstanceProfileRef != nil {
-		in, out := &in.CustomIAMInstanceProfileRef, &out.CustomIAMInstanceProfileRef
-		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.DBClusterIdentifier != nil {
 		in, out := &in.DBClusterIdentifier, &out.DBClusterIdentifier
 		*out = new(string)
@@ -3245,11 +3235,6 @@ func (in *DBInstanceSpec) DeepCopyInto(out *DBInstanceSpec) {
 		in, out := &in.DBClusterSnapshotIdentifier, &out.DBClusterSnapshotIdentifier
 		*out = new(string)
 		**out = **in
-	}
-	if in.DBClusterSnapshotIdentifierRef != nil {
-		in, out := &in.DBClusterSnapshotIdentifierRef, &out.DBClusterSnapshotIdentifierRef
-		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
-		(*in).DeepCopyInto(*out)
 	}
 	if in.DBInstanceClass != nil {
 		in, out := &in.DBInstanceClass, &out.DBInstanceClass
@@ -3320,11 +3305,6 @@ func (in *DBInstanceSpec) DeepCopyInto(out *DBInstanceSpec) {
 		in, out := &in.DomainIAMRoleName, &out.DomainIAMRoleName
 		*out = new(string)
 		**out = **in
-	}
-	if in.DomainIAMRoleRef != nil {
-		in, out := &in.DomainIAMRoleRef, &out.DomainIAMRoleRef
-		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
-		(*in).DeepCopyInto(*out)
 	}
 	if in.EnableCloudwatchLogsExports != nil {
 		in, out := &in.EnableCloudwatchLogsExports, &out.EnableCloudwatchLogsExports

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,6 +18,8 @@ package main
 import (
 	"context"
 	"os"
+	goruntime "runtime"
+	"runtime/debug"
 
 	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
@@ -62,6 +64,21 @@ var (
 	scheme             = runtime.NewScheme()
 	setupLog           = ctrlrt.Log.WithName("setup")
 )
+
+// depVersion returns the module version of the given dependency import path,
+// as recorded in the binary's build info, or "unknown" if it cannot be found.
+func depVersion(path string) string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	for _, dep := range info.Deps {
+		if dep.Path == path {
+			return dep.Version
+		}
+	}
+	return "unknown"
+}
 
 func init() {
 	_ = clientgoscheme.AddToScheme(scheme)
@@ -158,6 +175,17 @@ func main() {
 	setupLog.Info(
 		"initializing service controller",
 		"aws.service", awsServiceAlias,
+		"version", version.GitVersion,
+	)
+	setupLog.V(1).Info(
+		"build details",
+		"aws.service", awsServiceAlias,
+		"gitCommit", version.GitCommit,
+		"buildDate", version.BuildDate,
+		"goVersion", goruntime.Version(),
+		"ackGenerateVersion", version.ACKGenerateVersion,
+		"ackRuntimeVersion", depVersion("github.com/aws-controllers-k8s/runtime"),
+		"awsSDKGoV2Version", depVersion("github.com/aws/aws-sdk-go-v2"),
 	)
 	sc := ackrt.NewServiceController(
 		awsServiceAlias, awsServiceAPIGroup,

--- a/config/crd/bases/rds.services.k8s.aws_dbclusterendpoints.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbclusterendpoints.yaml
@@ -93,6 +93,25 @@ spec:
                 items:
                   type: string
                 type: array
+              staticMemberRefs:
+                items:
+                  description: "AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference\ntype to provide more user friendly syntax
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                    \ name: my-api"
+                  properties:
+                    from:
+                      description: |-
+                        AWSResourceReference provides all the values necessary to reference another
+                        k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      type: object
+                  type: object
+                type: array
               staticMembers:
                 description: List of DB instance identifiers that are part of the
                   custom endpoint group.

--- a/config/crd/bases/rds.services.k8s.aws_dbclusters.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbclusters.yaml
@@ -279,6 +279,23 @@ spec:
 
                   Valid for Cluster Type: Aurora DB clusters only
                 type: string
+              domainIAMRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               enableCloudwatchLogsExports:
                 description: |-
                   The list of log types that need to be enabled for exporting to CloudWatch
@@ -976,6 +993,23 @@ spec:
 
                   Valid for: Aurora DB clusters and Multi-AZ DB clusters
                 type: string
+              sourceDBClusterIdentifierRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               sourceRegion:
                 description: |-
                   SourceRegion is the source region where the resource exists. This is not

--- a/config/crd/bases/rds.services.k8s.aws_dbclusters.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbclusters.yaml
@@ -279,23 +279,6 @@ spec:
 
                   Valid for Cluster Type: Aurora DB clusters only
                 type: string
-              domainIAMRoleRef:
-                description: "AWSResourceReferenceWrapper provides a wrapper around
-                  *AWSResourceReference\ntype to provide more user friendly syntax
-                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
-                  \ name: my-api"
-                properties:
-                  from:
-                    description: |-
-                      AWSResourceReference provides all the values necessary to reference another
-                      k8s resource for finding the identifier(Id/ARN/Name)
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    type: object
-                type: object
               enableCloudwatchLogsExports:
                 description: |-
                   The list of log types that need to be enabled for exporting to CloudWatch

--- a/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
@@ -271,6 +271,23 @@ spec:
                   and your VPC (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/custom-setup-orcl.html#custom-setup-orcl.iam-vpc)
                   in the Amazon RDS User Guide.
                 type: string
+              customIAMInstanceProfileRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               databaseInsightsMode:
                 description: |-
                   The mode of Database Insights to enable for the DB instance.
@@ -285,6 +302,23 @@ spec:
 
                   This setting doesn't apply to RDS Custom DB instances.
                 type: string
+              dbClusterIdentifierRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               dbClusterSnapshotIdentifier:
                 description: |-
                   The identifier for the Multi-AZ DB cluster snapshot to restore from.
@@ -306,6 +340,23 @@ spec:
 
                      * Can't be the identifier of an Aurora DB cluster snapshot.
                 type: string
+              dbClusterSnapshotIdentifierRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               dbInstanceClass:
                 description: |-
                   The compute and memory capacity of the DB instance, for example db.m5.large.
@@ -510,6 +561,23 @@ spec:
                      * If you are restoring from a shared manual DB snapshot, the DBSnapshotIdentifier
                      must be the ARN of the shared DB snapshot.
                 type: string
+              dbSnapshotIdentifierRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               dbSubnetGroupName:
                 description: |-
                   A DB subnet group to associate with this DB instance.
@@ -578,6 +646,23 @@ spec:
 
                      * RDS Custom
                 type: string
+              domainIAMRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               enableCloudwatchLogsExports:
                 description: |-
                   The list of log types to enable for exporting to CloudWatch Logs. For more
@@ -1418,6 +1503,23 @@ spec:
                      in the Amazon RDS User Guide. This doesn't apply to SQL Server or RDS
                      Custom, which don't support cross-Region replicas.
                 type: string
+              sourceDBInstanceIdentifierRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               sourceRegion:
                 description: |-
                   SourceRegion is the source region where the resource exists. This is not

--- a/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbinstances.yaml
@@ -271,23 +271,6 @@ spec:
                   and your VPC (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/custom-setup-orcl.html#custom-setup-orcl.iam-vpc)
                   in the Amazon RDS User Guide.
                 type: string
-              customIAMInstanceProfileRef:
-                description: "AWSResourceReferenceWrapper provides a wrapper around
-                  *AWSResourceReference\ntype to provide more user friendly syntax
-                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
-                  \ name: my-api"
-                properties:
-                  from:
-                    description: |-
-                      AWSResourceReference provides all the values necessary to reference another
-                      k8s resource for finding the identifier(Id/ARN/Name)
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    type: object
-                type: object
               databaseInsightsMode:
                 description: |-
                   The mode of Database Insights to enable for the DB instance.
@@ -340,23 +323,6 @@ spec:
 
                      * Can't be the identifier of an Aurora DB cluster snapshot.
                 type: string
-              dbClusterSnapshotIdentifierRef:
-                description: "AWSResourceReferenceWrapper provides a wrapper around
-                  *AWSResourceReference\ntype to provide more user friendly syntax
-                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
-                  \ name: my-api"
-                properties:
-                  from:
-                    description: |-
-                      AWSResourceReference provides all the values necessary to reference another
-                      k8s resource for finding the identifier(Id/ARN/Name)
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    type: object
-                type: object
               dbInstanceClass:
                 description: |-
                   The compute and memory capacity of the DB instance, for example db.m5.large.
@@ -646,23 +612,6 @@ spec:
 
                      * RDS Custom
                 type: string
-              domainIAMRoleRef:
-                description: "AWSResourceReferenceWrapper provides a wrapper around
-                  *AWSResourceReference\ntype to provide more user friendly syntax
-                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
-                  \ name: my-api"
-                properties:
-                  from:
-                    description: |-
-                      AWSResourceReference provides all the values necessary to reference another
-                      k8s resource for finding the identifier(Id/ARN/Name)
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    type: object
-                type: object
               enableCloudwatchLogsExports:
                 description: |-
                   The list of log types to enable for exporting to CloudWatch Logs. For more

--- a/config/crd/bases/rds.services.k8s.aws_dbproxies.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_dbproxies.yaml
@@ -152,17 +152,54 @@ spec:
                 items:
                   type: string
                 type: array
+              vpcSecurityGroupRefs:
+                items:
+                  description: "AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference\ntype to provide more user friendly syntax
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                    \ name: my-api"
+                  properties:
+                    from:
+                      description: |-
+                        AWSResourceReference provides all the values necessary to reference another
+                        k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      type: object
+                  type: object
+                type: array
               vpcSubnetIDs:
                 description: One or more VPC subnet IDs to associate with the new
                   proxy.
                 items:
                   type: string
                 type: array
+              vpcSubnetRefs:
+                items:
+                  description: "AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference\ntype to provide more user friendly syntax
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                    \ name: my-api"
+                  properties:
+                    from:
+                      description: |-
+                        AWSResourceReference provides all the values necessary to reference another
+                        k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      type: object
+                  type: object
+                type: array
             required:
             - auth
             - engineFamily
             - name
-            - vpcSubnetIDs
             type: object
           status:
             description: DBProxyStatus defines the observed state of DBProxy

--- a/config/crd/bases/rds.services.k8s.aws_globalclusters.yaml
+++ b/config/crd/bases/rds.services.k8s.aws_globalclusters.yaml
@@ -101,6 +101,23 @@ spec:
 
                      * StorageEncrypted
                 type: string
+              sourceDBClusterIdentifierRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               storageEncrypted:
                 description: |-
                   Specifies whether to enable storage encryption for the new global database

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -35,6 +35,8 @@ rules:
 - apiGroups:
   - iam.services.k8s.aws
   resources:
+  - instanceprofiles
+  - instanceprofiles/status
   - roles
   - roles/status
   verbs:

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -35,8 +35,6 @@ rules:
 - apiGroups:
   - iam.services.k8s.aws
   resources:
-  - instanceprofiles
-  - instanceprofiles/status
   - roles
   - roles/status
   verbs:

--- a/generator.yaml
+++ b/generator.yaml
@@ -211,6 +211,11 @@ resources:
           resource: SecurityGroup
           service_name: ec2
           path: Status.ID
+      DomainIAMRoleName:
+        references:
+          resource: Role
+          service_name: iam
+          path: Spec.Name
       SnapshotIdentifier:
         from:
           operation: RestoreDBClusterFromSnapshot
@@ -219,6 +224,9 @@ resources:
         from:
           operation: RestoreDBClusterToPointInTime
           path: SourceDBClusterIdentifier
+        references:
+          resource: DBCluster
+          path: Spec.DBClusterIdentifier
       RestoreType:
         from:
           operation: RestoreDBClusterToPointInTime
@@ -477,15 +485,35 @@ resources:
       CopyTagsToSnapshot:
         late_initialize:
           skip_incomplete_check: {}
+      DBClusterIdentifier:
+        references:
+          resource: DBCluster
+          path: Spec.DBClusterIdentifier
+      DomainIAMRoleName:
+        references:
+          resource: Role
+          service_name: iam
+          path: Spec.Name
+      CustomIAMInstanceProfile:
+        references:
+          resource: InstanceProfile
+          service_name: iam
+          path: Spec.Name
       # Used by restore db instance from db snapshot
       DBSnapshotIdentifier:
         from:
           operation: RestoreDBInstanceFromDBSnapshot
           path: DBSnapshotIdentifier
+        references:
+          resource: DBSnapshot
+          path: Spec.DBSnapshotIdentifier
       DBClusterSnapshotIdentifier:
         from:
           operation: RestoreDBInstanceFromDBSnapshot
           path: DBClusterSnapshotIdentifier
+        references:
+          resource: DBClusterSnapshot
+          path: Spec.DBClusterSnapshotIdentifier
       UseDefaultProcessorFeatures:
         from:
           operation: RestoreDBInstanceFromDBSnapshot
@@ -495,6 +523,9 @@ resources:
         from:
           operation: CreateDBInstanceReadReplica
           path: SourceDBInstanceIdentifier
+        references:
+          resource: DBInstance
+          path: Spec.DBInstanceIdentifier
       DestinationRegion:
         set:
           - ignore: all
@@ -547,6 +578,10 @@ resources:
     fields:
       GlobalClusterIdentifier:
         is_primary_key: true
+      SourceDBClusterIdentifier:
+        references:
+          resource: DBCluster
+          path: Status.ACKResourceMetadata.ARN
 
   DBParameterGroup:
     renames:
@@ -655,6 +690,16 @@ resources:
           resource: Role
           service_name: iam
           path: Status.ACKResourceMetadata.ARN
+      VpcSecurityGroupIds:
+        references:
+          resource: SecurityGroup
+          service_name: ec2
+          path: Status.ID
+      VpcSubnetIds:
+        references:
+          resource: Subnet
+          service_name: ec2
+          path: Status.SubnetID
     renames:
       operations:
         CreateDBProxy:
@@ -736,6 +781,10 @@ resources:
         references:
           resource: DBCluster
           path: Spec.DBClusterIdentifier
+      StaticMembers:
+        references:
+          resource: DBInstance
+          path: Spec.DBInstanceIdentifier
       Tags:
         compare:
           # We have a custom comparison function...

--- a/generator.yaml
+++ b/generator.yaml
@@ -211,11 +211,6 @@ resources:
           resource: SecurityGroup
           service_name: ec2
           path: Status.ID
-      DomainIAMRoleName:
-        references:
-          resource: Role
-          service_name: iam
-          path: Spec.Name
       SnapshotIdentifier:
         from:
           operation: RestoreDBClusterFromSnapshot
@@ -489,16 +484,6 @@ resources:
         references:
           resource: DBCluster
           path: Spec.DBClusterIdentifier
-      DomainIAMRoleName:
-        references:
-          resource: Role
-          service_name: iam
-          path: Spec.Name
-      CustomIAMInstanceProfile:
-        references:
-          resource: InstanceProfile
-          service_name: iam
-          path: Spec.Name
       # Used by restore db instance from db snapshot
       DBSnapshotIdentifier:
         from:
@@ -511,9 +496,6 @@ resources:
         from:
           operation: RestoreDBInstanceFromDBSnapshot
           path: DBClusterSnapshotIdentifier
-        references:
-          resource: DBClusterSnapshot
-          path: Spec.DBClusterSnapshotIdentifier
       UseDefaultProcessorFeatures:
         from:
           operation: RestoreDBInstanceFromDBSnapshot

--- a/helm/crds/rds.services.k8s.aws_dbclusterendpoints.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbclusterendpoints.yaml
@@ -93,6 +93,25 @@ spec:
                 items:
                   type: string
                 type: array
+              staticMemberRefs:
+                items:
+                  description: "AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference\ntype to provide more user friendly syntax
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                    \ name: my-api"
+                  properties:
+                    from:
+                      description: |-
+                        AWSResourceReference provides all the values necessary to reference another
+                        k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      type: object
+                  type: object
+                type: array
               staticMembers:
                 description: List of DB instance identifiers that are part of the
                   custom endpoint group.

--- a/helm/crds/rds.services.k8s.aws_dbclusters.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbclusters.yaml
@@ -279,6 +279,23 @@ spec:
 
                   Valid for Cluster Type: Aurora DB clusters only
                 type: string
+              domainIAMRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               enableCloudwatchLogsExports:
                 description: |-
                   The list of log types that need to be enabled for exporting to CloudWatch
@@ -976,6 +993,23 @@ spec:
 
                   Valid for: Aurora DB clusters and Multi-AZ DB clusters
                 type: string
+              sourceDBClusterIdentifierRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               sourceRegion:
                 description: |-
                   SourceRegion is the source region where the resource exists. This is not

--- a/helm/crds/rds.services.k8s.aws_dbclusters.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbclusters.yaml
@@ -279,23 +279,6 @@ spec:
 
                   Valid for Cluster Type: Aurora DB clusters only
                 type: string
-              domainIAMRoleRef:
-                description: "AWSResourceReferenceWrapper provides a wrapper around
-                  *AWSResourceReference\ntype to provide more user friendly syntax
-                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
-                  \ name: my-api"
-                properties:
-                  from:
-                    description: |-
-                      AWSResourceReference provides all the values necessary to reference another
-                      k8s resource for finding the identifier(Id/ARN/Name)
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    type: object
-                type: object
               enableCloudwatchLogsExports:
                 description: |-
                   The list of log types that need to be enabled for exporting to CloudWatch

--- a/helm/crds/rds.services.k8s.aws_dbinstances.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbinstances.yaml
@@ -271,6 +271,23 @@ spec:
                   and your VPC (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/custom-setup-orcl.html#custom-setup-orcl.iam-vpc)
                   in the Amazon RDS User Guide.
                 type: string
+              customIAMInstanceProfileRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               databaseInsightsMode:
                 description: |-
                   The mode of Database Insights to enable for the DB instance.
@@ -285,6 +302,23 @@ spec:
 
                   This setting doesn't apply to RDS Custom DB instances.
                 type: string
+              dbClusterIdentifierRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               dbClusterSnapshotIdentifier:
                 description: |-
                   The identifier for the Multi-AZ DB cluster snapshot to restore from.
@@ -306,6 +340,23 @@ spec:
 
                     - Can't be the identifier of an Aurora DB cluster snapshot.
                 type: string
+              dbClusterSnapshotIdentifierRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               dbInstanceClass:
                 description: |-
                   The compute and memory capacity of the DB instance, for example db.m5.large.
@@ -510,6 +561,23 @@ spec:
                     - If you are restoring from a shared manual DB snapshot, the DBSnapshotIdentifier
                       must be the ARN of the shared DB snapshot.
                 type: string
+              dbSnapshotIdentifierRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               dbSubnetGroupName:
                 description: |-
                   A DB subnet group to associate with this DB instance.
@@ -578,6 +646,23 @@ spec:
 
                     - RDS Custom
                 type: string
+              domainIAMRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               enableCloudwatchLogsExports:
                 description: |-
                   The list of log types to enable for exporting to CloudWatch Logs. For more
@@ -1418,6 +1503,23 @@ spec:
                       in the Amazon RDS User Guide. This doesn't apply to SQL Server or RDS
                       Custom, which don't support cross-Region replicas.
                 type: string
+              sourceDBInstanceIdentifierRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               sourceRegion:
                 description: |-
                   SourceRegion is the source region where the resource exists. This is not

--- a/helm/crds/rds.services.k8s.aws_dbinstances.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbinstances.yaml
@@ -271,23 +271,6 @@ spec:
                   and your VPC (https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/custom-setup-orcl.html#custom-setup-orcl.iam-vpc)
                   in the Amazon RDS User Guide.
                 type: string
-              customIAMInstanceProfileRef:
-                description: "AWSResourceReferenceWrapper provides a wrapper around
-                  *AWSResourceReference\ntype to provide more user friendly syntax
-                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
-                  \ name: my-api"
-                properties:
-                  from:
-                    description: |-
-                      AWSResourceReference provides all the values necessary to reference another
-                      k8s resource for finding the identifier(Id/ARN/Name)
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    type: object
-                type: object
               databaseInsightsMode:
                 description: |-
                   The mode of Database Insights to enable for the DB instance.
@@ -340,23 +323,6 @@ spec:
 
                     - Can't be the identifier of an Aurora DB cluster snapshot.
                 type: string
-              dbClusterSnapshotIdentifierRef:
-                description: "AWSResourceReferenceWrapper provides a wrapper around
-                  *AWSResourceReference\ntype to provide more user friendly syntax
-                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
-                  \ name: my-api"
-                properties:
-                  from:
-                    description: |-
-                      AWSResourceReference provides all the values necessary to reference another
-                      k8s resource for finding the identifier(Id/ARN/Name)
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    type: object
-                type: object
               dbInstanceClass:
                 description: |-
                   The compute and memory capacity of the DB instance, for example db.m5.large.
@@ -646,23 +612,6 @@ spec:
 
                     - RDS Custom
                 type: string
-              domainIAMRoleRef:
-                description: "AWSResourceReferenceWrapper provides a wrapper around
-                  *AWSResourceReference\ntype to provide more user friendly syntax
-                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
-                  \ name: my-api"
-                properties:
-                  from:
-                    description: |-
-                      AWSResourceReference provides all the values necessary to reference another
-                      k8s resource for finding the identifier(Id/ARN/Name)
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    type: object
-                type: object
               enableCloudwatchLogsExports:
                 description: |-
                   The list of log types to enable for exporting to CloudWatch Logs. For more

--- a/helm/crds/rds.services.k8s.aws_dbproxies.yaml
+++ b/helm/crds/rds.services.k8s.aws_dbproxies.yaml
@@ -152,17 +152,54 @@ spec:
                 items:
                   type: string
                 type: array
+              vpcSecurityGroupRefs:
+                items:
+                  description: "AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference\ntype to provide more user friendly syntax
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                    \ name: my-api"
+                  properties:
+                    from:
+                      description: |-
+                        AWSResourceReference provides all the values necessary to reference another
+                        k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      type: object
+                  type: object
+                type: array
               vpcSubnetIDs:
                 description: One or more VPC subnet IDs to associate with the new
                   proxy.
                 items:
                   type: string
                 type: array
+              vpcSubnetRefs:
+                items:
+                  description: "AWSResourceReferenceWrapper provides a wrapper around
+                    *AWSResourceReference\ntype to provide more user friendly syntax
+                    for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                    \ name: my-api"
+                  properties:
+                    from:
+                      description: |-
+                        AWSResourceReference provides all the values necessary to reference another
+                        k8s resource for finding the identifier(Id/ARN/Name)
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      type: object
+                  type: object
+                type: array
             required:
             - auth
             - engineFamily
             - name
-            - vpcSubnetIDs
             type: object
           status:
             description: DBProxyStatus defines the observed state of DBProxy

--- a/helm/crds/rds.services.k8s.aws_globalclusters.yaml
+++ b/helm/crds/rds.services.k8s.aws_globalclusters.yaml
@@ -101,6 +101,23 @@ spec:
 
                     - StorageEncrypted
                 type: string
+              sourceDBClusterIdentifierRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               storageEncrypted:
                 description: |-
                   Specifies whether to enable storage encryption for the new global database

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -82,6 +82,8 @@ rules:
 - apiGroups:
   - iam.services.k8s.aws
   resources:
+  - instanceprofiles
+  - instanceprofiles/status
   - roles
   - roles/status
   verbs:

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -82,8 +82,6 @@ rules:
 - apiGroups:
   - iam.services.k8s.aws
   resources:
-  - instanceprofiles
-  - instanceprofiles/status
   - roles
   - roles/status
   verbs:

--- a/pkg/resource/db_cluster/delta.go
+++ b/pkg/resource/db_cluster/delta.go
@@ -206,6 +206,9 @@ func newResourceDelta(
 			delta.Add("Spec.DomainIAMRoleName", a.ko.Spec.DomainIAMRoleName, b.ko.Spec.DomainIAMRoleName)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.DomainIAMRoleRef, b.ko.Spec.DomainIAMRoleRef) {
+		delta.Add("Spec.DomainIAMRoleRef", a.ko.Spec.DomainIAMRoleRef, b.ko.Spec.DomainIAMRoleRef)
+	}
 	if len(a.ko.Spec.EnableCloudwatchLogsExports) != len(b.ko.Spec.EnableCloudwatchLogsExports) {
 		delta.Add("Spec.EnableCloudwatchLogsExports", a.ko.Spec.EnableCloudwatchLogsExports, b.ko.Spec.EnableCloudwatchLogsExports)
 	} else if len(a.ko.Spec.EnableCloudwatchLogsExports) > 0 {
@@ -505,6 +508,9 @@ func newResourceDelta(
 		if *a.ko.Spec.SourceDBClusterIdentifier != *b.ko.Spec.SourceDBClusterIdentifier {
 			delta.Add("Spec.SourceDBClusterIdentifier", a.ko.Spec.SourceDBClusterIdentifier, b.ko.Spec.SourceDBClusterIdentifier)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.SourceDBClusterIdentifierRef, b.ko.Spec.SourceDBClusterIdentifierRef) {
+		delta.Add("Spec.SourceDBClusterIdentifierRef", a.ko.Spec.SourceDBClusterIdentifierRef, b.ko.Spec.SourceDBClusterIdentifierRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.SourceRegion, b.ko.Spec.SourceRegion) {
 		delta.Add("Spec.SourceRegion", a.ko.Spec.SourceRegion, b.ko.Spec.SourceRegion)

--- a/pkg/resource/db_cluster/delta.go
+++ b/pkg/resource/db_cluster/delta.go
@@ -206,9 +206,6 @@ func newResourceDelta(
 			delta.Add("Spec.DomainIAMRoleName", a.ko.Spec.DomainIAMRoleName, b.ko.Spec.DomainIAMRoleName)
 		}
 	}
-	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.DomainIAMRoleRef, b.ko.Spec.DomainIAMRoleRef) {
-		delta.Add("Spec.DomainIAMRoleRef", a.ko.Spec.DomainIAMRoleRef, b.ko.Spec.DomainIAMRoleRef)
-	}
 	if len(a.ko.Spec.EnableCloudwatchLogsExports) != len(b.ko.Spec.EnableCloudwatchLogsExports) {
 		delta.Add("Spec.EnableCloudwatchLogsExports", a.ko.Spec.EnableCloudwatchLogsExports, b.ko.Spec.EnableCloudwatchLogsExports)
 	} else if len(a.ko.Spec.EnableCloudwatchLogsExports) > 0 {

--- a/pkg/resource/db_cluster/references.go
+++ b/pkg/resource/db_cluster/references.go
@@ -34,6 +34,9 @@ import (
 	svcapitypes "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
 )
 
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
+
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
 
@@ -64,6 +67,10 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 		ko.Spec.DBSubnetGroupName = nil
 	}
 
+	if ko.Spec.DomainIAMRoleRef != nil {
+		ko.Spec.DomainIAMRoleName = nil
+	}
+
 	if ko.Spec.KMSKeyRef != nil {
 		ko.Spec.KMSKeyID = nil
 	}
@@ -78,6 +85,10 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 
 	if ko.Spec.PerformanceInsightsKMSKeyRef != nil {
 		ko.Spec.PerformanceInsightsKMSKeyID = nil
+	}
+
+	if ko.Spec.SourceDBClusterIdentifierRef != nil {
+		ko.Spec.SourceDBClusterIdentifier = nil
 	}
 
 	if len(ko.Spec.VPCSecurityGroupRefs) > 0 {
@@ -115,6 +126,12 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForDomainIAMRoleName(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForKMSKeyID(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
@@ -134,6 +151,12 @@ func (rm *resourceManager) ResolveReferences(
 	}
 
 	if fieldHasReferences, err := rm.resolveReferenceForPerformanceInsightsKMSKeyID(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForSourceDBClusterIdentifier(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
@@ -160,6 +183,10 @@ func validateReferenceFields(ko *svcapitypes.DBCluster) error {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("DBSubnetGroupName", "DBSubnetGroupRef")
 	}
 
+	if ko.Spec.DomainIAMRoleRef != nil && ko.Spec.DomainIAMRoleName != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("DomainIAMRoleName", "DomainIAMRoleRef")
+	}
+
 	if ko.Spec.KMSKeyRef != nil && ko.Spec.KMSKeyID != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("KMSKeyID", "KMSKeyRef")
 	}
@@ -174,6 +201,10 @@ func validateReferenceFields(ko *svcapitypes.DBCluster) error {
 
 	if ko.Spec.PerformanceInsightsKMSKeyRef != nil && ko.Spec.PerformanceInsightsKMSKeyID != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("PerformanceInsightsKMSKeyID", "PerformanceInsightsKMSKeyRef")
+	}
+
+	if ko.Spec.SourceDBClusterIdentifierRef != nil && ko.Spec.SourceDBClusterIdentifier != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("SourceDBClusterIdentifier", "SourceDBClusterIdentifierRef")
 	}
 
 	if len(ko.Spec.VPCSecurityGroupRefs) > 0 && len(ko.Spec.VPCSecurityGroupIDs) > 0 {
@@ -364,6 +395,97 @@ func getReferencedResourceState_DBSubnetGroup(
 	return nil
 }
 
+// resolveReferenceForDomainIAMRoleName reads the resource referenced
+// from DomainIAMRoleRef field and sets the DomainIAMRoleName
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForDomainIAMRoleName(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.DBCluster,
+) (hasReferences bool, err error) {
+	if ko.Spec.DomainIAMRoleRef != nil && ko.Spec.DomainIAMRoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.DomainIAMRoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: DomainIAMRoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.DomainIAMRoleName = (*string)(obj.Spec.Name)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Role looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Role(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *iamapitypes.Role,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Role",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Role",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Role",
+			namespace, name)
+	}
+	if obj.Spec.Name == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Role",
+			namespace, name,
+			"Spec.Name")
+	}
+	return nil
+}
+
 // resolveReferenceForKMSKeyID reads the resource referenced
 // from KMSKeyRef field and sets the KMSKeyID
 // from referenced resource. Returns a boolean indicating whether a reference
@@ -529,60 +651,6 @@ func (rm *resourceManager) resolveReferenceForMonitoringRoleARN(
 	return hasReferences, nil
 }
 
-// getReferencedResourceState_Role looks up whether a referenced resource
-// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
-// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
-// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
-func getReferencedResourceState_Role(
-	ctx context.Context,
-	apiReader client.Reader,
-	obj *iamapitypes.Role,
-	name string, // the Kubernetes name of the referenced resource
-	namespace string, // the Kubernetes namespace of the referenced resource
-) error {
-	namespacedName := types.NamespacedName{
-		Namespace: namespace,
-		Name:      name,
-	}
-	err := apiReader.Get(ctx, namespacedName, obj)
-	if err != nil {
-		return err
-	}
-	var refResourceTerminal bool
-	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
-			return ackerr.ResourceReferenceTerminalFor(
-				"Role",
-				namespace, name)
-		}
-	}
-	if refResourceTerminal {
-		return ackerr.ResourceReferenceTerminalFor(
-			"Role",
-			namespace, name)
-	}
-	var refResourceSynced bool
-	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
-			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
-		}
-	}
-	if !refResourceSynced {
-		return ackerr.ResourceReferenceNotSyncedFor(
-			"Role",
-			namespace, name)
-	}
-	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
-		return ackerr.ResourceReferenceMissingTargetFieldFor(
-			"Role",
-			namespace, name,
-			"Status.ACKResourceMetadata.ARN")
-	}
-	return nil
-}
-
 // resolveReferenceForPerformanceInsightsKMSKeyID reads the resource referenced
 // from PerformanceInsightsKMSKeyRef field and sets the PerformanceInsightsKMSKeyID
 // from referenced resource. Returns a boolean indicating whether a reference
@@ -618,6 +686,97 @@ func (rm *resourceManager) resolveReferenceForPerformanceInsightsKMSKeyID(
 	}
 
 	return hasReferences, nil
+}
+
+// resolveReferenceForSourceDBClusterIdentifier reads the resource referenced
+// from SourceDBClusterIdentifierRef field and sets the SourceDBClusterIdentifier
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForSourceDBClusterIdentifier(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.DBCluster,
+) (hasReferences bool, err error) {
+	if ko.Spec.SourceDBClusterIdentifierRef != nil && ko.Spec.SourceDBClusterIdentifierRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.SourceDBClusterIdentifierRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: SourceDBClusterIdentifierRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &svcapitypes.DBCluster{}
+		if err := getReferencedResourceState_DBCluster(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.SourceDBClusterIdentifier = (*string)(obj.Spec.DBClusterIdentifier)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_DBCluster looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_DBCluster(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.DBCluster,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"DBCluster",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"DBCluster",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"DBCluster",
+			namespace, name)
+	}
+	if obj.Spec.DBClusterIdentifier == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"DBCluster",
+			namespace, name,
+			"Spec.DBClusterIdentifier")
+	}
+	return nil
 }
 
 // resolveReferenceForVPCSecurityGroupIDs reads the resource referenced

--- a/pkg/resource/db_cluster/references.go
+++ b/pkg/resource/db_cluster/references.go
@@ -34,9 +34,6 @@ import (
 	svcapitypes "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
 )
 
-// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
-// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
-
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
 
@@ -65,10 +62,6 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 
 	if ko.Spec.DBSubnetGroupRef != nil {
 		ko.Spec.DBSubnetGroupName = nil
-	}
-
-	if ko.Spec.DomainIAMRoleRef != nil {
-		ko.Spec.DomainIAMRoleName = nil
 	}
 
 	if ko.Spec.KMSKeyRef != nil {
@@ -126,12 +119,6 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
-	if fieldHasReferences, err := rm.resolveReferenceForDomainIAMRoleName(ctx, apiReader, ko); err != nil {
-		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
-	} else {
-		resourceHasReferences = resourceHasReferences || fieldHasReferences
-	}
-
 	if fieldHasReferences, err := rm.resolveReferenceForKMSKeyID(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
@@ -181,10 +168,6 @@ func validateReferenceFields(ko *svcapitypes.DBCluster) error {
 
 	if ko.Spec.DBSubnetGroupRef != nil && ko.Spec.DBSubnetGroupName != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("DBSubnetGroupName", "DBSubnetGroupRef")
-	}
-
-	if ko.Spec.DomainIAMRoleRef != nil && ko.Spec.DomainIAMRoleName != nil {
-		return ackerr.ResourceReferenceAndIDNotSupportedFor("DomainIAMRoleName", "DomainIAMRoleRef")
 	}
 
 	if ko.Spec.KMSKeyRef != nil && ko.Spec.KMSKeyID != nil {
@@ -395,97 +378,6 @@ func getReferencedResourceState_DBSubnetGroup(
 	return nil
 }
 
-// resolveReferenceForDomainIAMRoleName reads the resource referenced
-// from DomainIAMRoleRef field and sets the DomainIAMRoleName
-// from referenced resource. Returns a boolean indicating whether a reference
-// contains references, or an error
-func (rm *resourceManager) resolveReferenceForDomainIAMRoleName(
-	ctx context.Context,
-	apiReader client.Reader,
-	ko *svcapitypes.DBCluster,
-) (hasReferences bool, err error) {
-	if ko.Spec.DomainIAMRoleRef != nil && ko.Spec.DomainIAMRoleRef.From != nil {
-		hasReferences = true
-		arr := ko.Spec.DomainIAMRoleRef.From
-		if arr.Name == nil || *arr.Name == "" {
-			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: DomainIAMRoleRef")
-		}
-		namespace, err := ackrt.ResolveCrossNamespaceReference(
-			ctx,
-			rm.cfg.EnableCrossNamespace,
-			&ko.Status.Conditions,
-			ackrt.CrossNamespaceRefKindResource,
-			ko.ObjectMeta.GetNamespace(),
-			arr.Namespace,
-			*arr.Name,
-		)
-		if err != nil {
-			return hasReferences, err
-		}
-		obj := &iamapitypes.Role{}
-		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
-			return hasReferences, err
-		}
-		ko.Spec.DomainIAMRoleName = (*string)(obj.Spec.Name)
-	}
-
-	return hasReferences, nil
-}
-
-// getReferencedResourceState_Role looks up whether a referenced resource
-// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
-// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
-// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
-func getReferencedResourceState_Role(
-	ctx context.Context,
-	apiReader client.Reader,
-	obj *iamapitypes.Role,
-	name string, // the Kubernetes name of the referenced resource
-	namespace string, // the Kubernetes namespace of the referenced resource
-) error {
-	namespacedName := types.NamespacedName{
-		Namespace: namespace,
-		Name:      name,
-	}
-	err := apiReader.Get(ctx, namespacedName, obj)
-	if err != nil {
-		return err
-	}
-	var refResourceTerminal bool
-	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
-			return ackerr.ResourceReferenceTerminalFor(
-				"Role",
-				namespace, name)
-		}
-	}
-	if refResourceTerminal {
-		return ackerr.ResourceReferenceTerminalFor(
-			"Role",
-			namespace, name)
-	}
-	var refResourceSynced bool
-	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
-			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
-		}
-	}
-	if !refResourceSynced {
-		return ackerr.ResourceReferenceNotSyncedFor(
-			"Role",
-			namespace, name)
-	}
-	if obj.Spec.Name == nil {
-		return ackerr.ResourceReferenceMissingTargetFieldFor(
-			"Role",
-			namespace, name,
-			"Spec.Name")
-	}
-	return nil
-}
-
 // resolveReferenceForKMSKeyID reads the resource referenced
 // from KMSKeyRef field and sets the KMSKeyID
 // from referenced resource. Returns a boolean indicating whether a reference
@@ -649,6 +541,60 @@ func (rm *resourceManager) resolveReferenceForMonitoringRoleARN(
 	}
 
 	return hasReferences, nil
+}
+
+// getReferencedResourceState_Role looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Role(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *iamapitypes.Role,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Role",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Role",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Role",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Role",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
+	}
+	return nil
 }
 
 // resolveReferenceForPerformanceInsightsKMSKeyID reads the resource referenced

--- a/pkg/resource/db_cluster_endpoint/delta.go
+++ b/pkg/resource/db_cluster_endpoint/delta.go
@@ -74,6 +74,9 @@ func newResourceDelta(
 			delta.Add("Spec.ExcludedMembers", a.ko.Spec.ExcludedMembers, b.ko.Spec.ExcludedMembers)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.StaticMemberRefs, b.ko.Spec.StaticMemberRefs) {
+		delta.Add("Spec.StaticMemberRefs", a.ko.Spec.StaticMemberRefs, b.ko.Spec.StaticMemberRefs)
+	}
 	if len(a.ko.Spec.StaticMembers) != len(b.ko.Spec.StaticMembers) {
 		delta.Add("Spec.StaticMembers", a.ko.Spec.StaticMembers, b.ko.Spec.StaticMembers)
 	} else if len(a.ko.Spec.StaticMembers) > 0 {

--- a/pkg/resource/db_cluster_endpoint/references.go
+++ b/pkg/resource/db_cluster_endpoint/references.go
@@ -42,6 +42,10 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 		ko.Spec.DBClusterIdentifier = nil
 	}
 
+	if len(ko.Spec.StaticMemberRefs) > 0 {
+		ko.Spec.StaticMembers = nil
+	}
+
 	return &resource{ko}
 }
 
@@ -67,6 +71,12 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForStaticMembers(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	return &resource{ko}, resourceHasReferences, err
 }
 
@@ -79,6 +89,10 @@ func validateReferenceFields(ko *svcapitypes.DBClusterEndpoint) error {
 	}
 	if ko.Spec.DBClusterIdentifierRef == nil && ko.Spec.DBClusterIdentifier == nil {
 		return ackerr.ResourceReferenceOrIDRequiredFor("DBClusterIdentifier", "DBClusterIdentifierRef")
+	}
+
+	if len(ko.Spec.StaticMemberRefs) > 0 && len(ko.Spec.StaticMembers) > 0 {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("StaticMembers", "StaticMemberRefs")
 	}
 	return nil
 }
@@ -170,6 +184,102 @@ func getReferencedResourceState_DBCluster(
 			"DBCluster",
 			namespace, name,
 			"Spec.DBClusterIdentifier")
+	}
+	return nil
+}
+
+// resolveReferenceForStaticMembers reads the resource referenced
+// from StaticMemberRefs field and sets the StaticMembers
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForStaticMembers(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.DBClusterEndpoint,
+) (hasReferences bool, err error) {
+	for _, f0iter := range ko.Spec.StaticMemberRefs {
+		if f0iter != nil && f0iter.From != nil {
+			hasReferences = true
+			arr := f0iter.From
+			if arr.Name == nil || *arr.Name == "" {
+				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: StaticMemberRefs")
+			}
+			namespace, err := ackrt.ResolveCrossNamespaceReference(
+				ctx,
+				rm.cfg.EnableCrossNamespace,
+				&ko.Status.Conditions,
+				ackrt.CrossNamespaceRefKindResource,
+				ko.ObjectMeta.GetNamespace(),
+				arr.Namespace,
+				*arr.Name,
+			)
+			if err != nil {
+				return hasReferences, err
+			}
+			obj := &svcapitypes.DBInstance{}
+			if err := getReferencedResourceState_DBInstance(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+				return hasReferences, err
+			}
+			if ko.Spec.StaticMembers == nil {
+				ko.Spec.StaticMembers = make([]*string, 0, 1)
+			}
+			ko.Spec.StaticMembers = append(ko.Spec.StaticMembers, (*string)(obj.Spec.DBInstanceIdentifier))
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_DBInstance looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_DBInstance(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.DBInstance,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"DBInstance",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"DBInstance",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"DBInstance",
+			namespace, name)
+	}
+	if obj.Spec.DBInstanceIdentifier == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"DBInstance",
+			namespace, name,
+			"Spec.DBInstanceIdentifier")
 	}
 	return nil
 }

--- a/pkg/resource/db_instance/delta.go
+++ b/pkg/resource/db_instance/delta.go
@@ -92,6 +92,9 @@ func newResourceDelta(
 			delta.Add("Spec.CustomIAMInstanceProfile", a.ko.Spec.CustomIAMInstanceProfile, b.ko.Spec.CustomIAMInstanceProfile)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.CustomIAMInstanceProfileRef, b.ko.Spec.CustomIAMInstanceProfileRef) {
+		delta.Add("Spec.CustomIAMInstanceProfileRef", a.ko.Spec.CustomIAMInstanceProfileRef, b.ko.Spec.CustomIAMInstanceProfileRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.DBClusterIdentifier, b.ko.Spec.DBClusterIdentifier) {
 		delta.Add("Spec.DBClusterIdentifier", a.ko.Spec.DBClusterIdentifier, b.ko.Spec.DBClusterIdentifier)
 	} else if a.ko.Spec.DBClusterIdentifier != nil && b.ko.Spec.DBClusterIdentifier != nil {
@@ -99,12 +102,18 @@ func newResourceDelta(
 			delta.Add("Spec.DBClusterIdentifier", a.ko.Spec.DBClusterIdentifier, b.ko.Spec.DBClusterIdentifier)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.DBClusterIdentifierRef, b.ko.Spec.DBClusterIdentifierRef) {
+		delta.Add("Spec.DBClusterIdentifierRef", a.ko.Spec.DBClusterIdentifierRef, b.ko.Spec.DBClusterIdentifierRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.DBClusterSnapshotIdentifier, b.ko.Spec.DBClusterSnapshotIdentifier) {
 		delta.Add("Spec.DBClusterSnapshotIdentifier", a.ko.Spec.DBClusterSnapshotIdentifier, b.ko.Spec.DBClusterSnapshotIdentifier)
 	} else if a.ko.Spec.DBClusterSnapshotIdentifier != nil && b.ko.Spec.DBClusterSnapshotIdentifier != nil {
 		if *a.ko.Spec.DBClusterSnapshotIdentifier != *b.ko.Spec.DBClusterSnapshotIdentifier {
 			delta.Add("Spec.DBClusterSnapshotIdentifier", a.ko.Spec.DBClusterSnapshotIdentifier, b.ko.Spec.DBClusterSnapshotIdentifier)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.DBClusterSnapshotIdentifierRef, b.ko.Spec.DBClusterSnapshotIdentifierRef) {
+		delta.Add("Spec.DBClusterSnapshotIdentifierRef", a.ko.Spec.DBClusterSnapshotIdentifierRef, b.ko.Spec.DBClusterSnapshotIdentifierRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.DBInstanceClass, b.ko.Spec.DBInstanceClass) {
 		delta.Add("Spec.DBInstanceClass", a.ko.Spec.DBInstanceClass, b.ko.Spec.DBInstanceClass)
@@ -137,6 +146,9 @@ func newResourceDelta(
 			delta.Add("Spec.DBSnapshotIdentifier", a.ko.Spec.DBSnapshotIdentifier, b.ko.Spec.DBSnapshotIdentifier)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.DBSnapshotIdentifierRef, b.ko.Spec.DBSnapshotIdentifierRef) {
+		delta.Add("Spec.DBSnapshotIdentifierRef", a.ko.Spec.DBSnapshotIdentifierRef, b.ko.Spec.DBSnapshotIdentifierRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.DBSubnetGroupName, b.ko.Spec.DBSubnetGroupName) {
 		delta.Add("Spec.DBSubnetGroupName", a.ko.Spec.DBSubnetGroupName, b.ko.Spec.DBSubnetGroupName)
 	} else if a.ko.Spec.DBSubnetGroupName != nil && b.ko.Spec.DBSubnetGroupName != nil {
@@ -167,6 +179,9 @@ func newResourceDelta(
 		if *a.ko.Spec.DomainIAMRoleName != *b.ko.Spec.DomainIAMRoleName {
 			delta.Add("Spec.DomainIAMRoleName", a.ko.Spec.DomainIAMRoleName, b.ko.Spec.DomainIAMRoleName)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.DomainIAMRoleRef, b.ko.Spec.DomainIAMRoleRef) {
+		delta.Add("Spec.DomainIAMRoleRef", a.ko.Spec.DomainIAMRoleRef, b.ko.Spec.DomainIAMRoleRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.EnableCustomerOwnedIP, b.ko.Spec.EnableCustomerOwnedIP) {
 		delta.Add("Spec.EnableCustomerOwnedIP", a.ko.Spec.EnableCustomerOwnedIP, b.ko.Spec.EnableCustomerOwnedIP)
@@ -354,6 +369,9 @@ func newResourceDelta(
 		if *a.ko.Spec.SourceDBInstanceIdentifier != *b.ko.Spec.SourceDBInstanceIdentifier {
 			delta.Add("Spec.SourceDBInstanceIdentifier", a.ko.Spec.SourceDBInstanceIdentifier, b.ko.Spec.SourceDBInstanceIdentifier)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.SourceDBInstanceIdentifierRef, b.ko.Spec.SourceDBInstanceIdentifierRef) {
+		delta.Add("Spec.SourceDBInstanceIdentifierRef", a.ko.Spec.SourceDBInstanceIdentifierRef, b.ko.Spec.SourceDBInstanceIdentifierRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.SourceRegion, b.ko.Spec.SourceRegion) {
 		delta.Add("Spec.SourceRegion", a.ko.Spec.SourceRegion, b.ko.Spec.SourceRegion)

--- a/pkg/resource/db_instance/delta.go
+++ b/pkg/resource/db_instance/delta.go
@@ -92,9 +92,6 @@ func newResourceDelta(
 			delta.Add("Spec.CustomIAMInstanceProfile", a.ko.Spec.CustomIAMInstanceProfile, b.ko.Spec.CustomIAMInstanceProfile)
 		}
 	}
-	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.CustomIAMInstanceProfileRef, b.ko.Spec.CustomIAMInstanceProfileRef) {
-		delta.Add("Spec.CustomIAMInstanceProfileRef", a.ko.Spec.CustomIAMInstanceProfileRef, b.ko.Spec.CustomIAMInstanceProfileRef)
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.DBClusterIdentifier, b.ko.Spec.DBClusterIdentifier) {
 		delta.Add("Spec.DBClusterIdentifier", a.ko.Spec.DBClusterIdentifier, b.ko.Spec.DBClusterIdentifier)
 	} else if a.ko.Spec.DBClusterIdentifier != nil && b.ko.Spec.DBClusterIdentifier != nil {
@@ -111,9 +108,6 @@ func newResourceDelta(
 		if *a.ko.Spec.DBClusterSnapshotIdentifier != *b.ko.Spec.DBClusterSnapshotIdentifier {
 			delta.Add("Spec.DBClusterSnapshotIdentifier", a.ko.Spec.DBClusterSnapshotIdentifier, b.ko.Spec.DBClusterSnapshotIdentifier)
 		}
-	}
-	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.DBClusterSnapshotIdentifierRef, b.ko.Spec.DBClusterSnapshotIdentifierRef) {
-		delta.Add("Spec.DBClusterSnapshotIdentifierRef", a.ko.Spec.DBClusterSnapshotIdentifierRef, b.ko.Spec.DBClusterSnapshotIdentifierRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.DBInstanceClass, b.ko.Spec.DBInstanceClass) {
 		delta.Add("Spec.DBInstanceClass", a.ko.Spec.DBInstanceClass, b.ko.Spec.DBInstanceClass)
@@ -179,9 +173,6 @@ func newResourceDelta(
 		if *a.ko.Spec.DomainIAMRoleName != *b.ko.Spec.DomainIAMRoleName {
 			delta.Add("Spec.DomainIAMRoleName", a.ko.Spec.DomainIAMRoleName, b.ko.Spec.DomainIAMRoleName)
 		}
-	}
-	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.DomainIAMRoleRef, b.ko.Spec.DomainIAMRoleRef) {
-		delta.Add("Spec.DomainIAMRoleRef", a.ko.Spec.DomainIAMRoleRef, b.ko.Spec.DomainIAMRoleRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.EnableCustomerOwnedIP, b.ko.Spec.EnableCustomerOwnedIP) {
 		delta.Add("Spec.EnableCustomerOwnedIP", a.ko.Spec.EnableCustomerOwnedIP, b.ko.Spec.EnableCustomerOwnedIP)

--- a/pkg/resource/db_instance/references.go
+++ b/pkg/resource/db_instance/references.go
@@ -34,6 +34,12 @@ import (
 	svcapitypes "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
 )
 
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=instanceprofiles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=instanceprofiles/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
+
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
 
@@ -56,12 +62,32 @@ import (
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
 
+	if ko.Spec.CustomIAMInstanceProfileRef != nil {
+		ko.Spec.CustomIAMInstanceProfile = nil
+	}
+
+	if ko.Spec.DBClusterIdentifierRef != nil {
+		ko.Spec.DBClusterIdentifier = nil
+	}
+
+	if ko.Spec.DBClusterSnapshotIdentifierRef != nil {
+		ko.Spec.DBClusterSnapshotIdentifier = nil
+	}
+
 	if ko.Spec.DBParameterGroupRef != nil {
 		ko.Spec.DBParameterGroupName = nil
 	}
 
+	if ko.Spec.DBSnapshotIdentifierRef != nil {
+		ko.Spec.DBSnapshotIdentifier = nil
+	}
+
 	if ko.Spec.DBSubnetGroupRef != nil {
 		ko.Spec.DBSubnetGroupName = nil
+	}
+
+	if ko.Spec.DomainIAMRoleRef != nil {
+		ko.Spec.DomainIAMRoleName = nil
 	}
 
 	if ko.Spec.KMSKeyRef != nil {
@@ -78,6 +104,10 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 
 	if ko.Spec.PerformanceInsightsKMSKeyRef != nil {
 		ko.Spec.PerformanceInsightsKMSKeyID = nil
+	}
+
+	if ko.Spec.SourceDBInstanceIdentifierRef != nil {
+		ko.Spec.SourceDBInstanceIdentifier = nil
 	}
 
 	if len(ko.Spec.VPCSecurityGroupRefs) > 0 {
@@ -103,13 +133,43 @@ func (rm *resourceManager) ResolveReferences(
 
 	resourceHasReferences := false
 	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForCustomIAMInstanceProfile(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForDBClusterIdentifier(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForDBClusterSnapshotIdentifier(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForDBParameterGroupName(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForDBSnapshotIdentifier(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForDBSubnetGroupName(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForDomainIAMRoleName(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
@@ -139,6 +199,12 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForSourceDBInstanceIdentifier(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForVPCSecurityGroupIDs(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
@@ -152,12 +218,32 @@ func (rm *resourceManager) ResolveReferences(
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.DBInstance) error {
 
+	if ko.Spec.CustomIAMInstanceProfileRef != nil && ko.Spec.CustomIAMInstanceProfile != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("CustomIAMInstanceProfile", "CustomIAMInstanceProfileRef")
+	}
+
+	if ko.Spec.DBClusterIdentifierRef != nil && ko.Spec.DBClusterIdentifier != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("DBClusterIdentifier", "DBClusterIdentifierRef")
+	}
+
+	if ko.Spec.DBClusterSnapshotIdentifierRef != nil && ko.Spec.DBClusterSnapshotIdentifier != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("DBClusterSnapshotIdentifier", "DBClusterSnapshotIdentifierRef")
+	}
+
 	if ko.Spec.DBParameterGroupRef != nil && ko.Spec.DBParameterGroupName != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("DBParameterGroupName", "DBParameterGroupRef")
 	}
 
+	if ko.Spec.DBSnapshotIdentifierRef != nil && ko.Spec.DBSnapshotIdentifier != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("DBSnapshotIdentifier", "DBSnapshotIdentifierRef")
+	}
+
 	if ko.Spec.DBSubnetGroupRef != nil && ko.Spec.DBSubnetGroupName != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("DBSubnetGroupName", "DBSubnetGroupRef")
+	}
+
+	if ko.Spec.DomainIAMRoleRef != nil && ko.Spec.DomainIAMRoleName != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("DomainIAMRoleName", "DomainIAMRoleRef")
 	}
 
 	if ko.Spec.KMSKeyRef != nil && ko.Spec.KMSKeyID != nil {
@@ -176,8 +262,285 @@ func validateReferenceFields(ko *svcapitypes.DBInstance) error {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("PerformanceInsightsKMSKeyID", "PerformanceInsightsKMSKeyRef")
 	}
 
+	if ko.Spec.SourceDBInstanceIdentifierRef != nil && ko.Spec.SourceDBInstanceIdentifier != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("SourceDBInstanceIdentifier", "SourceDBInstanceIdentifierRef")
+	}
+
 	if len(ko.Spec.VPCSecurityGroupRefs) > 0 && len(ko.Spec.VPCSecurityGroupIDs) > 0 {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("VPCSecurityGroupIDs", "VPCSecurityGroupRefs")
+	}
+	return nil
+}
+
+// resolveReferenceForCustomIAMInstanceProfile reads the resource referenced
+// from CustomIAMInstanceProfileRef field and sets the CustomIAMInstanceProfile
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForCustomIAMInstanceProfile(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.DBInstance,
+) (hasReferences bool, err error) {
+	if ko.Spec.CustomIAMInstanceProfileRef != nil && ko.Spec.CustomIAMInstanceProfileRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.CustomIAMInstanceProfileRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: CustomIAMInstanceProfileRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.InstanceProfile{}
+		if err := getReferencedResourceState_InstanceProfile(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.CustomIAMInstanceProfile = (*string)(obj.Spec.Name)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_InstanceProfile looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_InstanceProfile(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *iamapitypes.InstanceProfile,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"InstanceProfile",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"InstanceProfile",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"InstanceProfile",
+			namespace, name)
+	}
+	if obj.Spec.Name == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"InstanceProfile",
+			namespace, name,
+			"Spec.Name")
+	}
+	return nil
+}
+
+// resolveReferenceForDBClusterIdentifier reads the resource referenced
+// from DBClusterIdentifierRef field and sets the DBClusterIdentifier
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForDBClusterIdentifier(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.DBInstance,
+) (hasReferences bool, err error) {
+	if ko.Spec.DBClusterIdentifierRef != nil && ko.Spec.DBClusterIdentifierRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.DBClusterIdentifierRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: DBClusterIdentifierRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &svcapitypes.DBCluster{}
+		if err := getReferencedResourceState_DBCluster(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.DBClusterIdentifier = (*string)(obj.Spec.DBClusterIdentifier)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_DBCluster looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_DBCluster(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.DBCluster,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"DBCluster",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"DBCluster",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"DBCluster",
+			namespace, name)
+	}
+	if obj.Spec.DBClusterIdentifier == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"DBCluster",
+			namespace, name,
+			"Spec.DBClusterIdentifier")
+	}
+	return nil
+}
+
+// resolveReferenceForDBClusterSnapshotIdentifier reads the resource referenced
+// from DBClusterSnapshotIdentifierRef field and sets the DBClusterSnapshotIdentifier
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForDBClusterSnapshotIdentifier(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.DBInstance,
+) (hasReferences bool, err error) {
+	if ko.Spec.DBClusterSnapshotIdentifierRef != nil && ko.Spec.DBClusterSnapshotIdentifierRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.DBClusterSnapshotIdentifierRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: DBClusterSnapshotIdentifierRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &svcapitypes.DBClusterSnapshot{}
+		if err := getReferencedResourceState_DBClusterSnapshot(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.DBClusterSnapshotIdentifier = (*string)(obj.Spec.DBClusterSnapshotIdentifier)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_DBClusterSnapshot looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_DBClusterSnapshot(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.DBClusterSnapshot,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"DBClusterSnapshot",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"DBClusterSnapshot",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"DBClusterSnapshot",
+			namespace, name)
+	}
+	if obj.Spec.DBClusterSnapshotIdentifier == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"DBClusterSnapshot",
+			namespace, name,
+			"Spec.DBClusterSnapshotIdentifier")
 	}
 	return nil
 }
@@ -273,6 +636,97 @@ func getReferencedResourceState_DBParameterGroup(
 	return nil
 }
 
+// resolveReferenceForDBSnapshotIdentifier reads the resource referenced
+// from DBSnapshotIdentifierRef field and sets the DBSnapshotIdentifier
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForDBSnapshotIdentifier(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.DBInstance,
+) (hasReferences bool, err error) {
+	if ko.Spec.DBSnapshotIdentifierRef != nil && ko.Spec.DBSnapshotIdentifierRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.DBSnapshotIdentifierRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: DBSnapshotIdentifierRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &svcapitypes.DBSnapshot{}
+		if err := getReferencedResourceState_DBSnapshot(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.DBSnapshotIdentifier = (*string)(obj.Spec.DBSnapshotIdentifier)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_DBSnapshot looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_DBSnapshot(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.DBSnapshot,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"DBSnapshot",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"DBSnapshot",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"DBSnapshot",
+			namespace, name)
+	}
+	if obj.Spec.DBSnapshotIdentifier == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"DBSnapshot",
+			namespace, name,
+			"Spec.DBSnapshotIdentifier")
+	}
+	return nil
+}
+
 // resolveReferenceForDBSubnetGroupName reads the resource referenced
 // from DBSubnetGroupRef field and sets the DBSubnetGroupName
 // from referenced resource. Returns a boolean indicating whether a reference
@@ -358,6 +812,97 @@ func getReferencedResourceState_DBSubnetGroup(
 	if obj.Spec.Name == nil {
 		return ackerr.ResourceReferenceMissingTargetFieldFor(
 			"DBSubnetGroup",
+			namespace, name,
+			"Spec.Name")
+	}
+	return nil
+}
+
+// resolveReferenceForDomainIAMRoleName reads the resource referenced
+// from DomainIAMRoleRef field and sets the DomainIAMRoleName
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForDomainIAMRoleName(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.DBInstance,
+) (hasReferences bool, err error) {
+	if ko.Spec.DomainIAMRoleRef != nil && ko.Spec.DomainIAMRoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.DomainIAMRoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: DomainIAMRoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.DomainIAMRoleName = (*string)(obj.Spec.Name)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Role looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Role(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *iamapitypes.Role,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Role",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Role",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Role",
+			namespace, name)
+	}
+	if obj.Spec.Name == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Role",
 			namespace, name,
 			"Spec.Name")
 	}
@@ -529,60 +1074,6 @@ func (rm *resourceManager) resolveReferenceForMonitoringRoleARN(
 	return hasReferences, nil
 }
 
-// getReferencedResourceState_Role looks up whether a referenced resource
-// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
-// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
-// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
-func getReferencedResourceState_Role(
-	ctx context.Context,
-	apiReader client.Reader,
-	obj *iamapitypes.Role,
-	name string, // the Kubernetes name of the referenced resource
-	namespace string, // the Kubernetes namespace of the referenced resource
-) error {
-	namespacedName := types.NamespacedName{
-		Namespace: namespace,
-		Name:      name,
-	}
-	err := apiReader.Get(ctx, namespacedName, obj)
-	if err != nil {
-		return err
-	}
-	var refResourceTerminal bool
-	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
-			return ackerr.ResourceReferenceTerminalFor(
-				"Role",
-				namespace, name)
-		}
-	}
-	if refResourceTerminal {
-		return ackerr.ResourceReferenceTerminalFor(
-			"Role",
-			namespace, name)
-	}
-	var refResourceSynced bool
-	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
-			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
-		}
-	}
-	if !refResourceSynced {
-		return ackerr.ResourceReferenceNotSyncedFor(
-			"Role",
-			namespace, name)
-	}
-	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
-		return ackerr.ResourceReferenceMissingTargetFieldFor(
-			"Role",
-			namespace, name,
-			"Status.ACKResourceMetadata.ARN")
-	}
-	return nil
-}
-
 // resolveReferenceForPerformanceInsightsKMSKeyID reads the resource referenced
 // from PerformanceInsightsKMSKeyRef field and sets the PerformanceInsightsKMSKeyID
 // from referenced resource. Returns a boolean indicating whether a reference
@@ -618,6 +1109,97 @@ func (rm *resourceManager) resolveReferenceForPerformanceInsightsKMSKeyID(
 	}
 
 	return hasReferences, nil
+}
+
+// resolveReferenceForSourceDBInstanceIdentifier reads the resource referenced
+// from SourceDBInstanceIdentifierRef field and sets the SourceDBInstanceIdentifier
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForSourceDBInstanceIdentifier(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.DBInstance,
+) (hasReferences bool, err error) {
+	if ko.Spec.SourceDBInstanceIdentifierRef != nil && ko.Spec.SourceDBInstanceIdentifierRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.SourceDBInstanceIdentifierRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: SourceDBInstanceIdentifierRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &svcapitypes.DBInstance{}
+		if err := getReferencedResourceState_DBInstance(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.SourceDBInstanceIdentifier = (*string)(obj.Spec.DBInstanceIdentifier)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_DBInstance looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_DBInstance(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.DBInstance,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"DBInstance",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"DBInstance",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"DBInstance",
+			namespace, name)
+	}
+	if obj.Spec.DBInstanceIdentifier == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"DBInstance",
+			namespace, name,
+			"Spec.DBInstanceIdentifier")
+	}
+	return nil
 }
 
 // resolveReferenceForVPCSecurityGroupIDs reads the resource referenced

--- a/pkg/resource/db_instance/references.go
+++ b/pkg/resource/db_instance/references.go
@@ -34,12 +34,6 @@ import (
 	svcapitypes "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
 )
 
-// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=instanceprofiles,verbs=get;list
-// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=instanceprofiles/status,verbs=get;list
-
-// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
-// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
-
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
 
@@ -62,16 +56,8 @@ import (
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
 
-	if ko.Spec.CustomIAMInstanceProfileRef != nil {
-		ko.Spec.CustomIAMInstanceProfile = nil
-	}
-
 	if ko.Spec.DBClusterIdentifierRef != nil {
 		ko.Spec.DBClusterIdentifier = nil
-	}
-
-	if ko.Spec.DBClusterSnapshotIdentifierRef != nil {
-		ko.Spec.DBClusterSnapshotIdentifier = nil
 	}
 
 	if ko.Spec.DBParameterGroupRef != nil {
@@ -84,10 +70,6 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 
 	if ko.Spec.DBSubnetGroupRef != nil {
 		ko.Spec.DBSubnetGroupName = nil
-	}
-
-	if ko.Spec.DomainIAMRoleRef != nil {
-		ko.Spec.DomainIAMRoleName = nil
 	}
 
 	if ko.Spec.KMSKeyRef != nil {
@@ -133,19 +115,7 @@ func (rm *resourceManager) ResolveReferences(
 
 	resourceHasReferences := false
 	err := validateReferenceFields(ko)
-	if fieldHasReferences, err := rm.resolveReferenceForCustomIAMInstanceProfile(ctx, apiReader, ko); err != nil {
-		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
-	} else {
-		resourceHasReferences = resourceHasReferences || fieldHasReferences
-	}
-
 	if fieldHasReferences, err := rm.resolveReferenceForDBClusterIdentifier(ctx, apiReader, ko); err != nil {
-		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
-	} else {
-		resourceHasReferences = resourceHasReferences || fieldHasReferences
-	}
-
-	if fieldHasReferences, err := rm.resolveReferenceForDBClusterSnapshotIdentifier(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
@@ -164,12 +134,6 @@ func (rm *resourceManager) ResolveReferences(
 	}
 
 	if fieldHasReferences, err := rm.resolveReferenceForDBSubnetGroupName(ctx, apiReader, ko); err != nil {
-		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
-	} else {
-		resourceHasReferences = resourceHasReferences || fieldHasReferences
-	}
-
-	if fieldHasReferences, err := rm.resolveReferenceForDomainIAMRoleName(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
@@ -218,16 +182,8 @@ func (rm *resourceManager) ResolveReferences(
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.DBInstance) error {
 
-	if ko.Spec.CustomIAMInstanceProfileRef != nil && ko.Spec.CustomIAMInstanceProfile != nil {
-		return ackerr.ResourceReferenceAndIDNotSupportedFor("CustomIAMInstanceProfile", "CustomIAMInstanceProfileRef")
-	}
-
 	if ko.Spec.DBClusterIdentifierRef != nil && ko.Spec.DBClusterIdentifier != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("DBClusterIdentifier", "DBClusterIdentifierRef")
-	}
-
-	if ko.Spec.DBClusterSnapshotIdentifierRef != nil && ko.Spec.DBClusterSnapshotIdentifier != nil {
-		return ackerr.ResourceReferenceAndIDNotSupportedFor("DBClusterSnapshotIdentifier", "DBClusterSnapshotIdentifierRef")
 	}
 
 	if ko.Spec.DBParameterGroupRef != nil && ko.Spec.DBParameterGroupName != nil {
@@ -240,10 +196,6 @@ func validateReferenceFields(ko *svcapitypes.DBInstance) error {
 
 	if ko.Spec.DBSubnetGroupRef != nil && ko.Spec.DBSubnetGroupName != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("DBSubnetGroupName", "DBSubnetGroupRef")
-	}
-
-	if ko.Spec.DomainIAMRoleRef != nil && ko.Spec.DomainIAMRoleName != nil {
-		return ackerr.ResourceReferenceAndIDNotSupportedFor("DomainIAMRoleName", "DomainIAMRoleRef")
 	}
 
 	if ko.Spec.KMSKeyRef != nil && ko.Spec.KMSKeyID != nil {
@@ -268,97 +220,6 @@ func validateReferenceFields(ko *svcapitypes.DBInstance) error {
 
 	if len(ko.Spec.VPCSecurityGroupRefs) > 0 && len(ko.Spec.VPCSecurityGroupIDs) > 0 {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("VPCSecurityGroupIDs", "VPCSecurityGroupRefs")
-	}
-	return nil
-}
-
-// resolveReferenceForCustomIAMInstanceProfile reads the resource referenced
-// from CustomIAMInstanceProfileRef field and sets the CustomIAMInstanceProfile
-// from referenced resource. Returns a boolean indicating whether a reference
-// contains references, or an error
-func (rm *resourceManager) resolveReferenceForCustomIAMInstanceProfile(
-	ctx context.Context,
-	apiReader client.Reader,
-	ko *svcapitypes.DBInstance,
-) (hasReferences bool, err error) {
-	if ko.Spec.CustomIAMInstanceProfileRef != nil && ko.Spec.CustomIAMInstanceProfileRef.From != nil {
-		hasReferences = true
-		arr := ko.Spec.CustomIAMInstanceProfileRef.From
-		if arr.Name == nil || *arr.Name == "" {
-			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: CustomIAMInstanceProfileRef")
-		}
-		namespace, err := ackrt.ResolveCrossNamespaceReference(
-			ctx,
-			rm.cfg.EnableCrossNamespace,
-			&ko.Status.Conditions,
-			ackrt.CrossNamespaceRefKindResource,
-			ko.ObjectMeta.GetNamespace(),
-			arr.Namespace,
-			*arr.Name,
-		)
-		if err != nil {
-			return hasReferences, err
-		}
-		obj := &iamapitypes.InstanceProfile{}
-		if err := getReferencedResourceState_InstanceProfile(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
-			return hasReferences, err
-		}
-		ko.Spec.CustomIAMInstanceProfile = (*string)(obj.Spec.Name)
-	}
-
-	return hasReferences, nil
-}
-
-// getReferencedResourceState_InstanceProfile looks up whether a referenced resource
-// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
-// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
-// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
-func getReferencedResourceState_InstanceProfile(
-	ctx context.Context,
-	apiReader client.Reader,
-	obj *iamapitypes.InstanceProfile,
-	name string, // the Kubernetes name of the referenced resource
-	namespace string, // the Kubernetes namespace of the referenced resource
-) error {
-	namespacedName := types.NamespacedName{
-		Namespace: namespace,
-		Name:      name,
-	}
-	err := apiReader.Get(ctx, namespacedName, obj)
-	if err != nil {
-		return err
-	}
-	var refResourceTerminal bool
-	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
-			return ackerr.ResourceReferenceTerminalFor(
-				"InstanceProfile",
-				namespace, name)
-		}
-	}
-	if refResourceTerminal {
-		return ackerr.ResourceReferenceTerminalFor(
-			"InstanceProfile",
-			namespace, name)
-	}
-	var refResourceSynced bool
-	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
-			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
-		}
-	}
-	if !refResourceSynced {
-		return ackerr.ResourceReferenceNotSyncedFor(
-			"InstanceProfile",
-			namespace, name)
-	}
-	if obj.Spec.Name == nil {
-		return ackerr.ResourceReferenceMissingTargetFieldFor(
-			"InstanceProfile",
-			namespace, name,
-			"Spec.Name")
 	}
 	return nil
 }
@@ -450,97 +311,6 @@ func getReferencedResourceState_DBCluster(
 			"DBCluster",
 			namespace, name,
 			"Spec.DBClusterIdentifier")
-	}
-	return nil
-}
-
-// resolveReferenceForDBClusterSnapshotIdentifier reads the resource referenced
-// from DBClusterSnapshotIdentifierRef field and sets the DBClusterSnapshotIdentifier
-// from referenced resource. Returns a boolean indicating whether a reference
-// contains references, or an error
-func (rm *resourceManager) resolveReferenceForDBClusterSnapshotIdentifier(
-	ctx context.Context,
-	apiReader client.Reader,
-	ko *svcapitypes.DBInstance,
-) (hasReferences bool, err error) {
-	if ko.Spec.DBClusterSnapshotIdentifierRef != nil && ko.Spec.DBClusterSnapshotIdentifierRef.From != nil {
-		hasReferences = true
-		arr := ko.Spec.DBClusterSnapshotIdentifierRef.From
-		if arr.Name == nil || *arr.Name == "" {
-			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: DBClusterSnapshotIdentifierRef")
-		}
-		namespace, err := ackrt.ResolveCrossNamespaceReference(
-			ctx,
-			rm.cfg.EnableCrossNamespace,
-			&ko.Status.Conditions,
-			ackrt.CrossNamespaceRefKindResource,
-			ko.ObjectMeta.GetNamespace(),
-			arr.Namespace,
-			*arr.Name,
-		)
-		if err != nil {
-			return hasReferences, err
-		}
-		obj := &svcapitypes.DBClusterSnapshot{}
-		if err := getReferencedResourceState_DBClusterSnapshot(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
-			return hasReferences, err
-		}
-		ko.Spec.DBClusterSnapshotIdentifier = (*string)(obj.Spec.DBClusterSnapshotIdentifier)
-	}
-
-	return hasReferences, nil
-}
-
-// getReferencedResourceState_DBClusterSnapshot looks up whether a referenced resource
-// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
-// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
-// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
-func getReferencedResourceState_DBClusterSnapshot(
-	ctx context.Context,
-	apiReader client.Reader,
-	obj *svcapitypes.DBClusterSnapshot,
-	name string, // the Kubernetes name of the referenced resource
-	namespace string, // the Kubernetes namespace of the referenced resource
-) error {
-	namespacedName := types.NamespacedName{
-		Namespace: namespace,
-		Name:      name,
-	}
-	err := apiReader.Get(ctx, namespacedName, obj)
-	if err != nil {
-		return err
-	}
-	var refResourceTerminal bool
-	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
-			return ackerr.ResourceReferenceTerminalFor(
-				"DBClusterSnapshot",
-				namespace, name)
-		}
-	}
-	if refResourceTerminal {
-		return ackerr.ResourceReferenceTerminalFor(
-			"DBClusterSnapshot",
-			namespace, name)
-	}
-	var refResourceSynced bool
-	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
-			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
-		}
-	}
-	if !refResourceSynced {
-		return ackerr.ResourceReferenceNotSyncedFor(
-			"DBClusterSnapshot",
-			namespace, name)
-	}
-	if obj.Spec.DBClusterSnapshotIdentifier == nil {
-		return ackerr.ResourceReferenceMissingTargetFieldFor(
-			"DBClusterSnapshot",
-			namespace, name,
-			"Spec.DBClusterSnapshotIdentifier")
 	}
 	return nil
 }
@@ -818,97 +588,6 @@ func getReferencedResourceState_DBSubnetGroup(
 	return nil
 }
 
-// resolveReferenceForDomainIAMRoleName reads the resource referenced
-// from DomainIAMRoleRef field and sets the DomainIAMRoleName
-// from referenced resource. Returns a boolean indicating whether a reference
-// contains references, or an error
-func (rm *resourceManager) resolveReferenceForDomainIAMRoleName(
-	ctx context.Context,
-	apiReader client.Reader,
-	ko *svcapitypes.DBInstance,
-) (hasReferences bool, err error) {
-	if ko.Spec.DomainIAMRoleRef != nil && ko.Spec.DomainIAMRoleRef.From != nil {
-		hasReferences = true
-		arr := ko.Spec.DomainIAMRoleRef.From
-		if arr.Name == nil || *arr.Name == "" {
-			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: DomainIAMRoleRef")
-		}
-		namespace, err := ackrt.ResolveCrossNamespaceReference(
-			ctx,
-			rm.cfg.EnableCrossNamespace,
-			&ko.Status.Conditions,
-			ackrt.CrossNamespaceRefKindResource,
-			ko.ObjectMeta.GetNamespace(),
-			arr.Namespace,
-			*arr.Name,
-		)
-		if err != nil {
-			return hasReferences, err
-		}
-		obj := &iamapitypes.Role{}
-		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
-			return hasReferences, err
-		}
-		ko.Spec.DomainIAMRoleName = (*string)(obj.Spec.Name)
-	}
-
-	return hasReferences, nil
-}
-
-// getReferencedResourceState_Role looks up whether a referenced resource
-// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
-// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
-// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
-func getReferencedResourceState_Role(
-	ctx context.Context,
-	apiReader client.Reader,
-	obj *iamapitypes.Role,
-	name string, // the Kubernetes name of the referenced resource
-	namespace string, // the Kubernetes namespace of the referenced resource
-) error {
-	namespacedName := types.NamespacedName{
-		Namespace: namespace,
-		Name:      name,
-	}
-	err := apiReader.Get(ctx, namespacedName, obj)
-	if err != nil {
-		return err
-	}
-	var refResourceTerminal bool
-	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
-			return ackerr.ResourceReferenceTerminalFor(
-				"Role",
-				namespace, name)
-		}
-	}
-	if refResourceTerminal {
-		return ackerr.ResourceReferenceTerminalFor(
-			"Role",
-			namespace, name)
-	}
-	var refResourceSynced bool
-	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
-			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
-		}
-	}
-	if !refResourceSynced {
-		return ackerr.ResourceReferenceNotSyncedFor(
-			"Role",
-			namespace, name)
-	}
-	if obj.Spec.Name == nil {
-		return ackerr.ResourceReferenceMissingTargetFieldFor(
-			"Role",
-			namespace, name,
-			"Spec.Name")
-	}
-	return nil
-}
-
 // resolveReferenceForKMSKeyID reads the resource referenced
 // from KMSKeyRef field and sets the KMSKeyID
 // from referenced resource. Returns a boolean indicating whether a reference
@@ -1072,6 +751,60 @@ func (rm *resourceManager) resolveReferenceForMonitoringRoleARN(
 	}
 
 	return hasReferences, nil
+}
+
+// getReferencedResourceState_Role looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Role(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *iamapitypes.Role,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Role",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Role",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Role",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Role",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
+	}
+	return nil
 }
 
 // resolveReferenceForPerformanceInsightsKMSKeyID reads the resource referenced

--- a/pkg/resource/db_proxy/delta.go
+++ b/pkg/resource/db_proxy/delta.go
@@ -106,12 +106,18 @@ func newResourceDelta(
 			delta.Add("Spec.VPCSecurityGroupIDs", a.ko.Spec.VPCSecurityGroupIDs, b.ko.Spec.VPCSecurityGroupIDs)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.VPCSecurityGroupRefs, b.ko.Spec.VPCSecurityGroupRefs) {
+		delta.Add("Spec.VPCSecurityGroupRefs", a.ko.Spec.VPCSecurityGroupRefs, b.ko.Spec.VPCSecurityGroupRefs)
+	}
 	if len(a.ko.Spec.VPCSubnetIDs) != len(b.ko.Spec.VPCSubnetIDs) {
 		delta.Add("Spec.VPCSubnetIDs", a.ko.Spec.VPCSubnetIDs, b.ko.Spec.VPCSubnetIDs)
 	} else if len(a.ko.Spec.VPCSubnetIDs) > 0 {
 		if !ackcompare.SliceStringPEqual(a.ko.Spec.VPCSubnetIDs, b.ko.Spec.VPCSubnetIDs) {
 			delta.Add("Spec.VPCSubnetIDs", a.ko.Spec.VPCSubnetIDs, b.ko.Spec.VPCSubnetIDs)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.VPCSubnetRefs, b.ko.Spec.VPCSubnetRefs) {
+		delta.Add("Spec.VPCSubnetRefs", a.ko.Spec.VPCSubnetRefs, b.ko.Spec.VPCSubnetRefs)
 	}
 
 	return delta

--- a/pkg/resource/db_proxy/references.go
+++ b/pkg/resource/db_proxy/references.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ec2apitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
@@ -35,6 +36,12 @@ import (
 // +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
 // +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
 
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups,verbs=get;list
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets,verbs=get;list
+// +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=subnets/status,verbs=get;list
+
 // ClearResolvedReferences removes any reference values that were made
 // concrete in the spec. It returns a copy of the input AWSResource which
 // contains the original *Ref values, but none of their respective concrete
@@ -44,6 +51,14 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 
 	if ko.Spec.RoleRef != nil {
 		ko.Spec.RoleARN = nil
+	}
+
+	if len(ko.Spec.VPCSecurityGroupRefs) > 0 {
+		ko.Spec.VPCSecurityGroupIDs = nil
+	}
+
+	if len(ko.Spec.VPCSubnetRefs) > 0 {
+		ko.Spec.VPCSubnetIDs = nil
 	}
 
 	return &resource{ko}
@@ -71,6 +86,18 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForVPCSecurityGroupIDs(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForVPCSubnetIDs(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	return &resource{ko}, resourceHasReferences, err
 }
 
@@ -83,6 +110,17 @@ func validateReferenceFields(ko *svcapitypes.DBProxy) error {
 	}
 	if ko.Spec.RoleRef == nil && ko.Spec.RoleARN == nil {
 		return ackerr.ResourceReferenceOrIDRequiredFor("RoleARN", "RoleRef")
+	}
+
+	if len(ko.Spec.VPCSecurityGroupRefs) > 0 && len(ko.Spec.VPCSecurityGroupIDs) > 0 {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("VPCSecurityGroupIDs", "VPCSecurityGroupRefs")
+	}
+
+	if len(ko.Spec.VPCSubnetRefs) > 0 && len(ko.Spec.VPCSubnetIDs) > 0 {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("VPCSubnetIDs", "VPCSubnetRefs")
+	}
+	if len(ko.Spec.VPCSubnetRefs) == 0 && len(ko.Spec.VPCSubnetIDs) == 0 {
+		return ackerr.ResourceReferenceOrIDRequiredFor("VPCSubnetIDs", "VPCSubnetRefs")
 	}
 	return nil
 }
@@ -174,6 +212,198 @@ func getReferencedResourceState_Role(
 			"Role",
 			namespace, name,
 			"Status.ACKResourceMetadata.ARN")
+	}
+	return nil
+}
+
+// resolveReferenceForVPCSecurityGroupIDs reads the resource referenced
+// from VPCSecurityGroupRefs field and sets the VPCSecurityGroupIDs
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForVPCSecurityGroupIDs(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.DBProxy,
+) (hasReferences bool, err error) {
+	for _, f0iter := range ko.Spec.VPCSecurityGroupRefs {
+		if f0iter != nil && f0iter.From != nil {
+			hasReferences = true
+			arr := f0iter.From
+			if arr.Name == nil || *arr.Name == "" {
+				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: VPCSecurityGroupRefs")
+			}
+			namespace, err := ackrt.ResolveCrossNamespaceReference(
+				ctx,
+				rm.cfg.EnableCrossNamespace,
+				&ko.Status.Conditions,
+				ackrt.CrossNamespaceRefKindResource,
+				ko.ObjectMeta.GetNamespace(),
+				arr.Namespace,
+				*arr.Name,
+			)
+			if err != nil {
+				return hasReferences, err
+			}
+			obj := &ec2apitypes.SecurityGroup{}
+			if err := getReferencedResourceState_SecurityGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+				return hasReferences, err
+			}
+			if ko.Spec.VPCSecurityGroupIDs == nil {
+				ko.Spec.VPCSecurityGroupIDs = make([]*string, 0, 1)
+			}
+			ko.Spec.VPCSecurityGroupIDs = append(ko.Spec.VPCSecurityGroupIDs, (*string)(obj.Status.ID))
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_SecurityGroup looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_SecurityGroup(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *ec2apitypes.SecurityGroup,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"SecurityGroup",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"SecurityGroup",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"SecurityGroup",
+			namespace, name)
+	}
+	if obj.Status.ID == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"SecurityGroup",
+			namespace, name,
+			"Status.ID")
+	}
+	return nil
+}
+
+// resolveReferenceForVPCSubnetIDs reads the resource referenced
+// from VPCSubnetRefs field and sets the VPCSubnetIDs
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForVPCSubnetIDs(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.DBProxy,
+) (hasReferences bool, err error) {
+	for _, f0iter := range ko.Spec.VPCSubnetRefs {
+		if f0iter != nil && f0iter.From != nil {
+			hasReferences = true
+			arr := f0iter.From
+			if arr.Name == nil || *arr.Name == "" {
+				return hasReferences, fmt.Errorf("provided resource reference is nil or empty: VPCSubnetRefs")
+			}
+			namespace, err := ackrt.ResolveCrossNamespaceReference(
+				ctx,
+				rm.cfg.EnableCrossNamespace,
+				&ko.Status.Conditions,
+				ackrt.CrossNamespaceRefKindResource,
+				ko.ObjectMeta.GetNamespace(),
+				arr.Namespace,
+				*arr.Name,
+			)
+			if err != nil {
+				return hasReferences, err
+			}
+			obj := &ec2apitypes.Subnet{}
+			if err := getReferencedResourceState_Subnet(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+				return hasReferences, err
+			}
+			if ko.Spec.VPCSubnetIDs == nil {
+				ko.Spec.VPCSubnetIDs = make([]*string, 0, 1)
+			}
+			ko.Spec.VPCSubnetIDs = append(ko.Spec.VPCSubnetIDs, (*string)(obj.Status.SubnetID))
+		}
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Subnet looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Subnet(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *ec2apitypes.Subnet,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Subnet",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Subnet",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Subnet",
+			namespace, name)
+	}
+	if obj.Status.SubnetID == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Subnet",
+			namespace, name,
+			"Status.SubnetID")
 	}
 	return nil
 }

--- a/pkg/resource/global_cluster/delta.go
+++ b/pkg/resource/global_cluster/delta.go
@@ -20,6 +20,7 @@ import (
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
+	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 // Hack to avoid import errors during build...
@@ -82,6 +83,9 @@ func newResourceDelta(
 		if *a.ko.Spec.SourceDBClusterIdentifier != *b.ko.Spec.SourceDBClusterIdentifier {
 			delta.Add("Spec.SourceDBClusterIdentifier", a.ko.Spec.SourceDBClusterIdentifier, b.ko.Spec.SourceDBClusterIdentifier)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.SourceDBClusterIdentifierRef, b.ko.Spec.SourceDBClusterIdentifierRef) {
+		delta.Add("Spec.SourceDBClusterIdentifierRef", a.ko.Spec.SourceDBClusterIdentifierRef, b.ko.Spec.SourceDBClusterIdentifierRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.StorageEncrypted, b.ko.Spec.StorageEncrypted) {
 		delta.Add("Spec.StorageEncrypted", a.ko.Spec.StorageEncrypted, b.ko.Spec.StorageEncrypted)

--- a/pkg/resource/global_cluster/references.go
+++ b/pkg/resource/global_cluster/references.go
@@ -17,9 +17,15 @@ package global_cluster
 
 import (
 	"context"
+	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/rds-controller/apis/v1alpha1"
@@ -31,6 +37,10 @@ import (
 // values.
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	if ko.Spec.SourceDBClusterIdentifierRef != nil {
+		ko.Spec.SourceDBClusterIdentifier = nil
+	}
 
 	return &resource{ko}
 }
@@ -47,11 +57,116 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, bool, error) {
-	return res, false, nil
+	ko := rm.concreteResource(res).ko
+
+	resourceHasReferences := false
+	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForSourceDBClusterIdentifier(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	return &resource{ko}, resourceHasReferences, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.GlobalCluster) error {
+
+	if ko.Spec.SourceDBClusterIdentifierRef != nil && ko.Spec.SourceDBClusterIdentifier != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("SourceDBClusterIdentifier", "SourceDBClusterIdentifierRef")
+	}
+	return nil
+}
+
+// resolveReferenceForSourceDBClusterIdentifier reads the resource referenced
+// from SourceDBClusterIdentifierRef field and sets the SourceDBClusterIdentifier
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForSourceDBClusterIdentifier(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.GlobalCluster,
+) (hasReferences bool, err error) {
+	if ko.Spec.SourceDBClusterIdentifierRef != nil && ko.Spec.SourceDBClusterIdentifierRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.SourceDBClusterIdentifierRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: SourceDBClusterIdentifierRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &svcapitypes.DBCluster{}
+		if err := getReferencedResourceState_DBCluster(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.SourceDBClusterIdentifier = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_DBCluster looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_DBCluster(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.DBCluster,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"DBCluster",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"DBCluster",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"DBCluster",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"DBCluster",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
+	}
 	return nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -27,6 +27,6 @@ var (
 // that generated this controller's code. They are baked in at code-generation
 // time and are immutable for the life of the generated code.
 const (
-	ACKGenerateVersion   = "v0.62.1-2-g3dfc7a1-dirty"
-	ACKGenerateBuildDate = "2026-08-13T22:05:10Z"
+	ACKGenerateVersion   = "v0.62.1"
+	ACKGenerateBuildDate = "2026-08-13T22:22:49Z"
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -28,5 +28,5 @@ var (
 // time and are immutable for the life of the generated code.
 const (
 	ACKGenerateVersion   = "v0.62.1"
-	ACKGenerateBuildDate = "2026-08-13T16:48:13Z"
+	ACKGenerateBuildDate = "2026-08-13T16:53:34Z"
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -15,8 +15,18 @@
 
 package version
 
+// GitVersion, GitCommit, and BuildDate describe the service controller build
+// and are injected at controller build time via -ldflags.
 var (
 	GitVersion string
 	GitCommit  string
 	BuildDate  string
+)
+
+// ACKGenerateVersion and ACKGenerateBuildDate identify the ack-generate build
+// that generated this controller's code. They are baked in at code-generation
+// time and are immutable for the life of the generated code.
+const (
+	ACKGenerateVersion   = "v0.62.1"
+	ACKGenerateBuildDate = "2026-08-13T16:48:13Z"
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -28,5 +28,5 @@ var (
 // time and are immutable for the life of the generated code.
 const (
 	ACKGenerateVersion   = "v0.62.1"
-	ACKGenerateBuildDate = "2026-08-13T22:22:49Z"
+	ACKGenerateBuildDate = "2026-08-25T20:58:21Z"
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -27,6 +27,6 @@ var (
 // that generated this controller's code. They are baked in at code-generation
 // time and are immutable for the life of the generated code.
 const (
-	ACKGenerateVersion   = "v0.62.1"
-	ACKGenerateBuildDate = "2026-08-25T20:58:21Z"
+	ACKGenerateVersion   = "v0.62.1-4-gd4aaca5"
+	ACKGenerateBuildDate = "2026-08-25T21:02:24Z"
 )


### PR DESCRIPTION
Adds cross-resource references to 8 top-level fields on `DBCluster`, `DBClusterEndpoint`, `DBInstance`, `DBProxy` and `GlobalCluster` in `rds-controller`.

Every field here is a **top-level** spec field (not nested in a struct or list) whose target Kind is confirmed ACK-managed, and **every one was verified on a live cluster**. None needs `set: ignore`, `late_initialize`, or `skip_resource_state_validations`.

### Fields Added

| # | Field (`generator.yaml` path) | Target | `path` |
| --- | --- | --- | --- |
| 1 | `DBCluster.SourceDBClusterIdentifier` | `DBCluster` (same-service) | `Spec.DBClusterIdentifier` |
| 2 | `DBInstance.DBClusterIdentifier` | `DBCluster` (same-service) | `Spec.DBClusterIdentifier` |
| 3 | `DBInstance.SourceDBInstanceIdentifier` | `DBInstance` (same-service) | `Spec.DBInstanceIdentifier` |
| 4 | `DBInstance.DBSnapshotIdentifier` | `DBSnapshot` (same-service) | `Spec.DBSnapshotIdentifier` |
| 5 | `DBClusterEndpoint.StaticMembers` | `DBInstance` (same-service) | `Spec.DBInstanceIdentifier` |
| 6 | `DBProxy.VpcSecurityGroupIds` | ec2 `SecurityGroup` | `Status.ID` |
| 7 | `DBProxy.VpcSubnetIds` | ec2 `Subnet` | `Status.SubnetID` |
| 8 | `GlobalCluster.SourceDBClusterIdentifier` | `DBCluster` (same-service) | `Status.ACKResourceMetadata.ARN` |

### Notes

- `DBInstance.dbClusterIdentifier` is the most user-visible of these: it is the parent link for every Aurora instance, so creating a cluster and its instances in one manifest no longer needs a hardcoded identifier.
- Three of these fields carry a pre-existing `from:` block because they are sourced from a non-Create operation (`RestoreDBClusterToPointInTime`, `CreateDBInstanceReadReplica`, `RestoreDBInstanceFromDBSnapshot`). The `references` block coexists with `from:`, and all three resolved and synced on a live cluster — this had been an open question about the generator and is now settled empirically.
- **Deliberate partial coverage.** The source and snapshot identifier fields also accept an ARN for cross-region or shared resources, which a reference cannot serve since the target CR is not in this cluster. The concrete field stays usable for those cases.
- `GlobalCluster.sourceDBClusterIdentifier` is the reverse edge of `DBCluster.globalClusterIdentifier`, which is left **unconfigured deliberately** so the pair cannot deadlock. Whichever direction is wired second owns that decision.

### Verification

Deployed this branch to a dev EKS cluster (`us-west-2`) with `ack-workspace deploy rds --resync-period 60` and exercised every reference against real AWS resources. The controller image under test was built from this branch.

This is the **lightweight** check: the reference resolves and the resource reaches `Synced`. It is deliberately not the full pass matrix — no multi-resync delta count and no reference-preservation check.

| # | Reference | RefsResolved | Synced | Concrete absent | `*Ref` present | Result |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | `DBCluster.sourceDBClusterIdentifierRef` | ✅ | ✅ | ✅ | ✅ | **PASS** |
| 2 | `DBInstance.dbClusterIdentifierRef` | ✅ | ✅ | ✅ | ✅ | **PASS** |
| 3 | `DBInstance.sourceDBInstanceIdentifierRef` | ✅ | ✅ | ✅ | ✅ | **PASS** |
| 4 | `DBInstance.dbSnapshotIdentifierRef` | ✅ | ✅ | ✅ | ✅ | **PASS** |
| 5 | `DBClusterEndpoint.staticMemberRefs` | ✅ | ✅ | ✅ | ✅ | **PASS** |
| 6 | `DBProxy.vpcSecurityGroupRefs` | ✅ | ✅ | ✅ | ✅ | **PASS** |
| 7 | `DBProxy.vpcSubnetRefs` | ✅ | ✅ | ✅ | ✅ | **PASS** |
| 8 | `GlobalCluster.sourceDBClusterIdentifierRef` | ✅ | ✅ | ✅ | ✅ | **PASS** |

**Summary: 8 PASS of 8.**

- `DBCluster.sourceDBClusterIdentifierRef` — point-in-time restore into a new cluster from the referenced source
- `DBInstance.dbClusterIdentifierRef` — Aurora instance created into the referenced cluster
- `DBInstance.sourceDBInstanceIdentifierRef` — read replica created from the referenced instance
- `DBInstance.dbSnapshotIdentifierRef` — instance restored from the referenced snapshot
- `DBClusterEndpoint.staticMemberRefs` — endpoint created with the referenced instance as a static member
- `DBProxy.vpcSecurityGroupRefs` — resolved to the ACK-managed security group id
- `DBProxy.vpcSubnetRefs` — resolved to both ACK-managed subnet ids
- `GlobalCluster.sourceDBClusterIdentifierRef` — global cluster created with the referenced cluster as its member

AWS-side confirmation that each resolved value actually reached the API, rather than just that resolution reported success:

```
$ aws rds describe-db-clusters --db-cluster-identifier reftest-aurora-pitr
{"Id": "reftest-aurora-pitr", "Status": "available"}       # restored from reftest-aurora

$ aws rds describe-global-clusters --global-cluster-identifier reftest-globalcluster
{"Status": "available",
 "Members": ["arn:aws:rds:us-west-2:...:cluster:reftest-aurora-pitr"]}   # the resolved ARN

$ aws rds describe-db-instances --db-instance-identifier reftest-mysql-replica
{"Id": "reftest-mysql-replica", "Source": "reftest-mysql", "Status": "available"}
```

The `Members` and `Source` values are the resolved reference targets; neither was ever supplied literally.

### Scope: four references were removed from this PR

An earlier revision of this PR carried 12 references. The four that on-cluster testing could not verify have been **removed** rather than shipped unverified, so what remains is exactly what was proven to work:

| Removed field | Why |
| --- | --- |
| `DBCluster.DomainIAMRoleName` | Needs an AWS Directory Service directory, and the paired `domain` field has no ACK controller behind it, so the reference could only ever cover half the pairing. |
| `DBInstance.DomainIAMRoleName` | Same Directory Service dependency. |
| `DBInstance.CustomIAMInstanceProfile` | RDS Custom only, which needs a custom engine version built from a customer-supplied AMI. |
| `DBInstance.DBClusterSnapshotIdentifier` | The reference resolved correctly, but the create failed terminally with `InvalidParameterValue: Invalid master password` — see below. |

On that last one: the reference itself was fine (`ACK.ReferencesResolved=True`, concrete field absent, `*Ref` present, against a synced ACK-managed `DBClusterSnapshot`). The failure looks like the controller not routing to a restore-from-cluster-snapshot call and instead attempting a plain `CreateDBInstance`, which requires a master password. The sibling `DBSnapshotIdentifier` on the same resource *does* route correctly and is kept in this PR, so the gap is specific to the cluster-snapshot path and exists independently of this change — worth a separate look by the controller owners. The AWS model also restricts that field to Multi-AZ DB cluster snapshots ("Can't be the identifier of an Aurora DB cluster snapshot").

The pre-existing `from:` block on `DBClusterSnapshotIdentifier` is retained — only its `references` block was removed, so that field behaves exactly as it did before this PR.

### What was checked mechanically

- Workspace refreshed (runtime, code-generator, controller) before generating; regenerated with `ack-workspace build rds` against a clean code-generator at the `v0.62.1` tag, matching the stamp on `main`.
- A `*Ref` companion is emitted on the spec for all 8 fields, and the companions for the 4 removed fields are gone.
- `resolveReferenceFor<Field>` is emitted for all 8 and absent for the 4 removed, confirmed by diffing the *set* of resolver names against `main` (regeneration reorders the file, so a naive line diff over-reports).
- `vpcSubnetIDs` relaxed out of the `DBProxy` CRD `required` list.
- `service_name` omitted for same-service targets, set for cross-service.
- `go build ./cmd/controller` passes.
- No new `go.mod` dependency (iam and ec2 were already present), so `ATTRIBUTION.md` is unchanged. The `instanceprofiles` RBAC rule that the removed `InstanceProfile` reference required is dropped again.

### Commit layout

`main` carries the code-generator `v0.62.1` regeneration (from the auto-generated release PR), and this branch is merged up to date with it, so the **Files changed** diff is limited to the reference change itself plus the recorded ack-generate stamp.